### PR TITLE
Fill intended use, DPIA, and pilot protocol drafts

### DIFF
--- a/docs/dpia-checklist.md
+++ b/docs/dpia-checklist.md
@@ -1,105 +1,117 @@
-# DPIA Checklist (Template)
+# DPIA Checklist (Working Draft v1)
 
 Use this checklist before any pilot or production processing of `video/audio/depth` uroflowmetry data.
 
 ## 1. Processing Overview
 
-- Project / feature name:
-- Controller entity:
-- Processor(s):
-- DPO / privacy contact:
-- Assessment date:
-- Assessment owner:
+- Project / feature name: `Mobile Uroflow Concept - Fusion MVP`
+- Controller entity: `TBD legal entity`
+- Processor(s): `none by default (on-device mode)`
+- DPO / privacy contact: `TBD`
+- Assessment date: `2026-02-23`
+- Assessment owner: `Privacy Lead + Product Lead`
 
 ## 2. Scope of Processing
 
-- [ ] Data sources documented (app capture, manual inputs, clinician portal)
-- [ ] Processing purposes documented
-- [ ] Processing locations documented (on-device, cloud regions, backups)
-- [ ] Data lifecycle mapped (collection -> storage -> sharing -> deletion)
+- [x] Data sources documented (app capture, calibration metadata, optional clinician review)
+- [x] Processing purposes documented
+- [x] Processing locations documented (on-device by default; cloud optional)
+- [x] Data lifecycle mapped (collection -> storage -> sharing -> deletion)
+
+Processing purpose (v1):
+- estimate uroflowmetry metrics from calibrated capture
+- provide quality validation and repeat/reject guidance
+- support pilot-level method comparison against reference uroflowmeter
 
 ## 3. Data Categories and Sensitivity
 
-- [ ] Health data identified (uroflow metrics, derived clinical indicators)
-- [ ] Raw media identified (video/audio/depth)
-- [ ] Metadata identified (device IDs, timestamps, calibration profile)
-- [ ] Any special-category data beyond health identified
+- [x] Health data identified (uroflow metrics, derived clinical indicators)
+- [x] Raw media identified (video/audio/depth)
+- [x] Metadata identified (timestamps, calibration profile, device characteristics)
+- [x] Special-category handling acknowledged (health-data treatment by default)
 
 ## 4. Lawful Basis and Art. 9 Basis (GDPR)
 
-- [ ] Art. 6 lawful basis selected and justified
-- [ ] Art. 9 condition selected and justified for health data
-- [ ] Consent flow documented where required
-- [ ] Withdrawal/revocation process documented
+- [ ] Art. 6 lawful basis selected and justified by legal counsel
+- [ ] Art. 9 condition selected and justified by legal counsel
+- [x] Consent flow required for raw media retention/export
+- [x] Withdrawal/revocation process required in UX and backend
+
+Working assumption for pilot planning only:
+- explicit informed consent is mandatory before capture and any export of raw media.
 
 ## 5. Necessity and Proportionality
 
-- [ ] Data minimization implemented (derivatives-only default)
-- [ ] Purpose limitation implemented
-- [ ] Storage limitation/retention periods defined
-- [ ] Access controls least-privilege by role
-- [ ] User transparency notices complete and understandable
+- [x] Data minimization implemented (derivatives-only default)
+- [x] Purpose limitation implemented in design docs
+- [x] Storage limitation/retention periods defined (draft)
+- [ ] Access controls least-privilege by role implemented and tested
+- [ ] User transparency notices reviewed by legal/privacy
 
 ## 6. Risk Assessment
 
-For each risk, document severity, likelihood, and residual risk after controls:
-
 | Risk | Affected Data | Likelihood | Severity | Existing Controls | Residual Risk | Owner |
 |---|---|---|---|---|---|---|
-| Unauthorized access to raw media | video/audio/depth |  |  | encryption + RBAC |  |  |
-| Re-identification from context | video/metadata |  |  | ROI-only capture + de-identification |  |  |
-| Excessive retention | all |  |  | TTL + auto-delete jobs |  |  |
-| Insecure transfer to cloud | media/metrics |  |  | TLS + signed URLs + short expiry |  |  |
+| Unauthorized access to raw media | video/audio/depth | Medium | High | encryption + derivatives-only default + role-bound export | Medium | Security Lead |
+| Re-identification from scene context | video/metadata | Medium | High | ROI-only capture guidance + de-identification + manual review policy | Medium | Privacy Lead |
+| Excessive retention | all | Medium | High | TTL + auto-delete jobs + deletion audit trail | Low-Medium | Data Platform |
+| Insecure transfer to cloud | media/metrics | Low-Medium | High | TLS + signed URLs + short expiry + no-default-upload | Low-Medium | Backend Lead |
+| Misuse of metrics as diagnosis | metrics/report | Medium | Medium-High | non-claims in UI/report + clinician-review framing | Medium | Product + Clinical |
 
 ## 7. Technical and Organizational Measures
 
-- [ ] Encryption at rest and in transit
-- [ ] Key management documented
-- [ ] Audit logging enabled and monitored
-- [ ] Incident response runbook updated
+- [x] Encryption at rest and in transit required
+- [x] Key management required
+- [x] Audit logging required for access/export/delete events
+- [ ] Incident response runbook linked to project playbook
 - [ ] Vendor due diligence completed (if processors used)
-- [ ] Data export controls and approval workflow defined
+- [x] Data export controls and approval workflow required
 
 ## 8. Data Subject Rights
 
-- [ ] Access request process
-- [ ] Rectification process
-- [ ] Erasure process
-- [ ] Restriction/objection process
-- [ ] Portability export process
-- [ ] SLA targets for rights requests
+- [ ] Access request process documented
+- [ ] Rectification process documented
+- [ ] Erasure process documented
+- [ ] Restriction/objection process documented
+- [ ] Portability export process documented
+- [ ] SLA targets approved by legal/privacy
 
 ## 9. International Transfers
 
-- [ ] Transfer map completed
-- [ ] Transfer mechanism documented (if outside jurisdiction)
-- [ ] Supplemental safeguards assessed
+- [x] Transfer map completed for current design (`none by default`)
+- [ ] Transfer mechanism documented (if cloud region is outside jurisdiction)
+- [ ] Supplemental safeguards assessed (if transfer is introduced)
 
-## 10. Retention and Deletion Policy
+## 10. Retention and Deletion Policy (Draft)
 
-- Raw media retention:
-- Derived metrics retention:
-- Logs retention:
-- Backup retention:
-- Hard delete SLA:
+- Raw media retention: `disabled by default`; if explicit consent enabled -> `max 30 days`
+- Derived metrics retention: `24 months` (pilot analytics and reproducibility)
+- Logs retention: `180 days`
+- Backup retention: `35 days rolling`
+- Hard delete SLA after request/expiry: `<=7 days`
 
-- [ ] Automatic deletion verified in test
-- [ ] Deletion evidence/audit trail available
+- [ ] Automatic deletion verified in integration test
+- [ ] Deletion evidence/audit trail verified in pilot dry-run
 
 ## 11. Residual Risk and Decision
 
-- Residual risk summary:
+- Residual risk summary: medium residual privacy risk remains until legal basis, rights handling, and deletion tests are fully validated.
 - [ ] Proceed
-- [ ] Proceed with conditions
+- [x] Proceed with conditions
 - [ ] Block until controls implemented
 
-Decision owner:
-Date:
+Conditions before pilot data collection:
+1. Legal confirmation of Art. 6 and Art. 9 basis.
+2. Approved consent and privacy notice text.
+3. Verified deletion and access-control tests.
+
+Decision owner: `[name]`
+Date: `[YYYY-MM-DD]`
 
 ## 12. Reassessment Triggers
 
-- [ ] New data category introduced
-- [ ] New processor / new region
-- [ ] New AI model with material behavior change
-- [ ] Security incident involving health data
-- [ ] Regulatory update affecting lawful basis or controls
+- [x] New data category introduced
+- [x] New processor / new region
+- [x] New AI model with material behavior change
+- [x] Security incident involving health data
+- [x] Regulatory update affecting lawful basis or controls

--- a/docs/intended-use-draft.md
+++ b/docs/intended-use-draft.md
@@ -1,59 +1,81 @@
-# Intended Use Draft (Template)
+# Intended Use (Working Draft v1)
 
 ## 1. Document Control
 
-- Version: `0.1-draft`
-- Owner: `Product + Clinical Lead`
-- Last updated: `YYYY-MM-DD`
+- Version: `1.0-draft`
+- Owner: `Product Lead + Clinical Lead`
+- Last updated: `2026-02-23`
 - Related concept docs:
   - `docs/stage-1-product-definition.md`
   - `docs/stage-2-fusion-development.md`
+  - `docs/architecture.md`
 
 ## 2. Product Description
 
 - Product name (working): `Mobile Uroflow Concept`
 - Product type: software-based uroflowmetry support solution (smartphone app + analytics pipeline)
-- Core sensing approach: `video + depth + audio` fusion with volume-based estimation `h(t) -> V(t) -> Q(t)`
+- Core sensing approach: `RGB video + depth (LiDAR/ToF) + audio` fusion with volume-based estimation `h(t) -> V(t) -> Q(t)`
+- Intended stage: investigational R&D and pilot validation
 
 ## 3. Intended Purpose
 
-Software is intended to estimate and report uroflowmetry parameters from smartphone recordings of a calibrated receiving container under controlled capture conditions.
+The software is intended to estimate and report uroflowmetry-derived parameters from synchronized smartphone recordings of a calibrated receiving container under controlled capture conditions.
 
 ## 4. Intended Users
 
-- Primary users: `[patients / clinicians / both]`
-- Operator profile: `[lay user with onboarding / trained clinical user]`
-- Clinical oversight model: `[self-use with clinician review / clinic-only]`
+- Primary users: `both (patients and clinicians)`
+- Operator profile: `lay user with in-app onboarding` and `trained clinical user`
+- Clinical oversight model: `self-capture with clinician review` or `clinic-supervised capture`
 
 ## 5. Intended Use Environment
 
-- Environment: `[home bathroom / outpatient clinic / mixed]`
-- Required setup: fixed phone position, calibrated container, sufficient lighting, ROI alignment
+- Environment: `mixed (home bathroom + outpatient clinic)`
+- Required setup:
+  - fixed smartphone position (tripod/holder)
+  - calibrated transparent receiving container + fiducial marker
+  - sufficient lighting and ROI alignment
+  - stable field of view without subject-identifying content
 
 ## 6. Target Population
 
-- Included population: `[define age, sex, symptoms group]`
-- Exclusions: `[catheterized patients, inability to void independently, etc.]`
-- Pediatric use: `[yes/no + constraints]`
+- Included population:
+  - adults (`>=18 years`)
+  - men and women able to void spontaneously
+  - symptomatic LUTS/BPH/OAB monitoring cohorts (pilot scope)
+- Exclusions:
+  - catheterized voiding
+  - inability to follow capture protocol
+  - inability to provide informed consent
+- Pediatric use: `no (out of scope for v1 pilot)`
 
 ## 7. Device Inputs and Outputs
 
 Inputs:
-- RGB video
-- LiDAR/ToF depth map (when available)
+- RGB video stream
+- LiDAR/ToF depth map and confidence map (when available)
 - Audio signal
-- Calibration metadata (container profile, fiducial marker)
+- Calibration metadata (container profile `V(h)`, fiducial marker)
 
 Outputs:
 - Time series: `V(t)`, `Q(t)`
-- Scalar metrics: `Qmax`, `Qavg`, `Vvoid`, `Flow time`, `Voiding time`, `Time to Qmax`, `Hesitancy` (if protocol supports)
-- Quality flags and measurement validity status
+- Scalar metrics:
+  - `Qmax`, `Qavg`, `Vvoid`
+  - `Flow time`, `Voiding time`, `Time to Qmax`
+  - `Hesitancy` (only when protocol start marker is present)
+- Quality flags:
+  - calibration quality
+  - depth confidence
+  - glare/lighting issues
+  - incomplete capture
+  - `Vvoid < 150 ml` flag
+- Measurement status: `valid / repeat / reject`
 
 ## 8. Clinical Claims (Draft)
 
 Candidate claims (subject to validation and regulatory strategy):
 - Reports uroflowmetry-derived parameters from calibrated recordings.
-- Flags low-quality recordings and suboptimal voided volume conditions.
+- Detects and flags low-quality recordings and suboptimal voided volume conditions.
+- Provides trend-ready structured output (`V(t)`, `Q(t)`, scalar metrics, quality metadata).
 
 ## 9. Non-Claims / Limitations (Mandatory)
 
@@ -61,32 +83,37 @@ Candidate claims (subject to validation and regulatory strategy):
 - Does not measure post-void residual (PVR) without external modality.
 - Does not provide standalone diagnosis.
 - Does not replace clinician judgment.
+- Not validated for pediatric use.
 
 ## 10. Performance Targets (Draft)
 
-- Supported flow range: `0-50 ml/s` (target alignment with ICS-style ranges)
+- Supported flow range: `0-50 ml/s`
 - Supported voided volume range: `0-1000 ml`
-- Minimum interpretable voided volume rule: `>150 ml` (otherwise mark as repeat/review)
-- Output latency target: `[e.g. <10 s after capture end]`
+- Minimum interpretable voided volume rule: `>150 ml` (otherwise mark as `repeat/review`)
+- Supported capture rates:
+  - RGB: `>=30 fps` (preferred 60 fps)
+  - Depth: frame-synchronous with confidence gating
+  - Audio: timestamp-synchronized with capture session
+- Report generation latency target: `<10 s` after capture end on supported device profile
 
 ## 11. Key Risks and Risk Controls (High-Level)
 
 - Geometry drift / poor alignment -> calibration verification + pre-check UI
-- Low depth confidence / visual artifacts -> confidence gating + fallback logic + QC flag
-- Incomplete capture of stream into container -> invalid measurement flag + repeat guidance
+- Low depth confidence / visual artifacts -> confidence gating + RGB fallback + QC flag
+- Incomplete stream capture into container -> invalid measurement flag + repeat guidance
 - Privacy risk from raw media -> derivatives-only default + explicit consent for raw export
 
 ## 12. Regulatory Positioning (Working Assumption)
 
-- US: likely falls under urine flow/volume measuring system pathway when medical claims are made.
-- EU: software medical device evaluation likely under MDR Rule 11 logic depending on final claims.
+- US: likely aligns with urine flow/volume measuring system pathway when medical claims are made.
+- EU: software medical device evaluation likely under MDR Rule 11 logic depending on final claims and clinical impact.
 
 ## 13. Open Decisions
 
-1. Home-use vs clinic-use primary indication
-2. Lay-use instructions and training burden
-3. Final claim language for first regulatory submission
-4. Country launch sequence and regulatory priority
+1. Home-first or clinic-first launch sequence
+2. Final wording of medical claims for first submission
+3. Country-by-country regulatory priority
+4. Whether to include stream-angle/spray features in v1 product UI or keep QC-only
 
 ## 14. Approval
 

--- a/docs/pilot-protocol-v1.md
+++ b/docs/pilot-protocol-v1.md
@@ -1,13 +1,13 @@
-# Pilot Protocol v1 (Template)
+# Pilot Protocol v1 (Working Draft)
 
 ## 1. Protocol Metadata
 
 - Protocol ID: `UF-PILOT-001`
-- Version: `0.1-draft`
-- Date: `YYYY-MM-DD`
-- Sponsor / institution:
-- Principal investigator:
-- Clinical site(s):
+- Version: `1.0-draft`
+- Date: `2026-02-23`
+- Sponsor / institution: `Mobile Uroflow Concept R&D`
+- Principal investigator: `TBD`
+- Clinical site(s): `TBD (1 clinic + optional home supervised arm)`
 
 ## 2. Objective
 
@@ -16,41 +16,44 @@ Primary objective:
 
 Secondary objectives:
 - Evaluate repeatability and measurement quality flags.
-- Assess robustness across capture conditions.
+- Assess robustness across capture conditions (lighting, depth confidence, container alignment).
 
 ## 3. Study Design
 
 - Type: prospective paired-comparison pilot
-- Reference method: certified clinical uroflowmeter
+- Reference method: certified clinical uroflowmeter (gravimetric preferred)
 - Test method: smartphone fusion pipeline (`RGB + depth + audio`)
 - Unit of analysis: paired measurement (test + reference)
+- Study mode: observational, non-interventional measurement comparison
 
 ## 4. Population
 
-Inclusion criteria (draft):
-- Adults able to void spontaneously
+Inclusion criteria:
+- Adults (`>=18 years`) able to void spontaneously
 - Able to provide informed consent
+- Able to follow capture instructions
 
-Exclusion criteria (draft):
-- Inability to follow protocol
-- Conditions that invalidate safe participation (per investigator)
+Exclusion criteria:
+- Catheterized voiding
+- Inability to complete protocol capture safely
+- Missing consent or withdrawal of consent
 
 ## 5. Sample Size (Pilot)
 
 - Target participants: `20-30`
-- Target paired measurements: `[set target, e.g. >=60]`
-- Repeat measurements per participant: `[e.g. 2-3 when feasible]`
+- Target paired measurements: `>=90`
+- Repeat measurements per participant: `2-4 when feasible`
 
 Note: this pilot is for variance estimation, workflow validation, and failure-mode discovery; not definitive clinical performance claims.
 
 ## 6. Measurement Workflow
 
-1. Verify setup and calibration (fiducial + container profile).
-2. Start synchronized capture and reference recording.
+1. Verify setup and calibration (fiducial + container profile + camera stability).
+2. Start synchronized smartphone capture (`RGB/depth/audio`) and reference recording.
 3. Record voiding event and derive `V(t), Q(t)`.
 4. Collect reference outputs from clinical uroflowmeter.
 5. Attach quality flags and protocol deviations.
-6. Repeat if `Vvoid < 150 ml` or measurement is flagged invalid.
+6. Repeat measurement if `Vvoid < 150 ml` or status is `repeat/reject`.
 
 ## 7. Endpoints
 
@@ -60,14 +63,14 @@ Primary endpoints:
 Secondary endpoints:
 - Agreement for timing metrics (`Flow time`, `Voiding time`, `TQmax`).
 - Repeatability metrics within participant.
-- Invalid/failed capture rate and reasons.
+- Invalid/failed capture rate and root-cause categories.
 
-## 8. Statistical Analysis Plan (Draft)
+## 8. Statistical Analysis Plan
 
 - Continuous agreement: Bland-Altman (bias, limits of agreement)
-- Error metrics: MAE, RMSE
-- Reliability: ICC for repeatability where applicable
-- Subgroup analyses (if sample allows): sex, age band, `Vvoid` strata
+- Error metrics: MAE, RMSE for `Qmax`, `Qavg`, `Vvoid`
+- Reliability: ICC for repeated measurements (where available)
+- Subgroup analyses (sample permitting): sex, age band, `Vvoid` strata (`<150`, `150-300`, `>300 ml`)
 
 ## 9. Data Quality and QC Rules
 
@@ -80,23 +83,23 @@ Mandatory QC fields per measurement:
 
 Decision logic:
 - `valid` -> include in primary analysis
-- `repeat` -> acceptable with repeat capture
+- `repeat` -> include only repeated valid measurement in primary analysis
 - `reject` -> exclude from primary analysis; include in failure analysis
 
 ## 10. Safety, Ethics, and Privacy
 
 - Informed consent required before data capture
 - Derivatives-only storage default; raw media only with explicit consent
-- De-identification and access controls enforced
-- Incident reporting path defined
+- De-identification and role-based access controls required
+- Incident reporting path and escalation owner defined before first participant
 
 ## 11. Operational Roles
 
-- Clinical operator:
-- Technical operator:
-- Data manager:
-- Statistician:
-- Privacy officer:
+- Clinical operator: `site uroflow nurse/technician`
+- Technical operator: `mobile app study engineer`
+- Data manager: `study data manager`
+- Statistician: `biostatistics lead`
+- Privacy officer: `DPO/privacy lead`
 
 ## 12. Deliverables
 
@@ -105,13 +108,15 @@ Decision logic:
 - Final pilot report with go/no-go recommendation
 - Updated risk register and protocol v2 proposal
 
-## 13. Go/No-Go Criteria (Draft)
+## 13. Go/No-Go Criteria (Draft Targets)
 
-Define thresholds before study start:
-- Maximum acceptable bias per primary metric
-- Maximum acceptable failed-capture rate
-- Minimum repeatability threshold (ICC target)
-- Minimum percentage of valid captures
+Targets to be met on primary analysis set:
+- `Qmax MAE <= 3.0 ml/s`
+- `Qavg MAE <= 2.0 ml/s`
+- `Vvoid MAE <= 25 ml` or `<=10%` relative error (whichever is larger)
+- Valid-capture rate `>=85%`
+- Failed/reject capture rate `<=15%`
+- ICC (`Qmax`, repeated measures) `>=0.75`
 
 Outcome:
 - [ ] Go to pivotal planning


### PR DESCRIPTION
## Summary
- replace template placeholders with v2-based working draft content
- define concrete intended use scope, claims/non-claims, and target population
- define DPIA draft controls, retention windows, and pre-pilot conditions
- define pilot protocol targets, workflow, and go/no-go metrics

## Validation
- pytest -q (5 passed)
