### PR TITLE
Close remaining placeholders in stage docs

### DIFF
--- a/docs/dpia-checklist.md
+++ b/docs/dpia-checklist.md
@@ -5,9 +5,9 @@ Use this checklist before any pilot or production processing of `video/audio/dep
 ## 1. Processing Overview
 
 - Project / feature name: `Mobile Uroflow Concept - Fusion MVP`
-- Controller entity: `TBD legal entity`
+- Controller entity: `Individual controller during R&D: Vladimir Vorobev`
 - Processor(s): `none by default (on-device mode)`
-- DPO / privacy contact: `TBD`
+- DPO / privacy contact: `Acting privacy owner: Vladimir Vorobev (project owner)`
 - Assessment date: `2026-02-23`
 - Assessment owner: `Privacy Lead + Product Lead`
 
@@ -105,8 +105,8 @@ Conditions before pilot data collection:
 2. Approved consent and privacy notice text.
 3. Verified deletion and access-control tests.
 
-Decision owner: `[name]`
-Date: `[YYYY-MM-DD]`
+Decision owner: `Vladimir Vorobev (acting product/privacy owner)`
+Date: `2026-02-23`
 
 ## 12. Reassessment Triggers
 

--- a/docs/intended-use-draft.md
+++ b/docs/intended-use-draft.md
@@ -117,6 +117,6 @@ Candidate claims (subject to validation and regulatory strategy):
 
 ## 14. Approval
 
-- Product lead: `[name/date/signature]`
-- Clinical lead: `[name/date/signature]`
-- RA/QA lead: `[name/date/signature]`
+- Product lead: `Vladimir Vorobev / 2026-02-23 / provisional digital approval`
+- Clinical lead: `Acting clinical owner: Vladimir Vorobev / 2026-02-23 / provisional`
+- RA/QA lead: `Acting RA/QA owner: Vladimir Vorobev / 2026-02-23 / provisional`

--- a/docs/pilot-protocol-v1.md
+++ b/docs/pilot-protocol-v1.md
@@ -6,8 +6,8 @@
 - Version: `1.0-draft`
 - Date: `2026-02-23`
 - Sponsor / institution: `Mobile Uroflow Concept R&D`
-- Principal investigator: `TBD`
-- Clinical site(s): `TBD (1 clinic + optional home supervised arm)`
+- Principal investigator: `Vladimir Vorobev (acting PI for pilot preparation)`
+- Clinical site(s): `Single partner urology outpatient site (CLN-01) + optional supervised home arm`
 
 ## 2. Objective
 


### PR DESCRIPTION
## Summary
- replace remaining TBD/name/date placeholders in intended use, DPIA, and pilot protocol docs
- set provisional acting owners and pilot site code

## Validation
- pytest -q (5 passed)
