### PR TITLE
Finalize stage docs to v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ uroflow-mobile analyze-video /path/to/mobile_recording.mp4 \
 - `docs/` — архитектура, ограничения, roadmap
 - `docs/stage-1-product-definition.md` — формализация первого этапа концепции
 - `docs/stage-2-fusion-development.md` — развитие концепции v2 (video+audio+LiDAR/ToF)
-- `docs/intended-use-draft.md` — шаблон Intended Use (черновик)
-- `docs/dpia-checklist.md` — чеклист DPIA для данных видео/аудио/depth
-- `docs/pilot-protocol-v1.md` — шаблон pilot-протокола сравнения с эталоном
+- `docs/intended-use-v1.md` — документ Intended Use v1.0
+- `docs/dpia-checklist.md` — DPIA checklist v1.0 для данных видео/аудио/depth
+- `docs/pilot-protocol-v1.md` — pilot-протокол v1.0 сравнения с эталоном
 - `src/uroflow_mobile/` — доменные модели и расчёт метрик
 - `tests/` — базовые тесты расчёта метрик
 - `examples/` — демо-скрипты

--- a/docs/dpia-checklist.md
+++ b/docs/dpia-checklist.md
@@ -1,4 +1,4 @@
-# DPIA Checklist (Working Draft v1)
+# DPIA Checklist (v1.0 Baseline)
 
 Use this checklist before any pilot or production processing of `video/audio/depth` uroflowmetry data.
 
@@ -7,9 +7,9 @@ Use this checklist before any pilot or production processing of `video/audio/dep
 - Project / feature name: `Mobile Uroflow Concept - Fusion MVP`
 - Controller entity: `Individual controller during R&D: Vladimir Vorobev`
 - Processor(s): `none by default (on-device mode)`
-- DPO / privacy contact: `Acting privacy owner: Vladimir Vorobev (project owner)`
+- DPO / privacy contact: `Privacy contact: Vladimir Vorobev`
 - Assessment date: `2026-02-23`
-- Assessment owner: `Privacy Lead + Product Lead`
+- Assessment owner: `Vladimir Vorobev`
 
 ## 2. Scope of Processing
 
@@ -44,7 +44,7 @@ Working assumption for pilot planning only:
 
 - [x] Data minimization implemented (derivatives-only default)
 - [x] Purpose limitation implemented in design docs
-- [x] Storage limitation/retention periods defined (draft)
+- [x] Storage limitation/retention periods defined
 - [ ] Access controls least-privilege by role implemented and tested
 - [ ] User transparency notices reviewed by legal/privacy
 
@@ -82,7 +82,7 @@ Working assumption for pilot planning only:
 - [ ] Transfer mechanism documented (if cloud region is outside jurisdiction)
 - [ ] Supplemental safeguards assessed (if transfer is introduced)
 
-## 10. Retention and Deletion Policy (Draft)
+## 10. Retention and Deletion Policy (v1)
 
 - Raw media retention: `disabled by default`; if explicit consent enabled -> `max 30 days`
 - Derived metrics retention: `24 months` (pilot analytics and reproducibility)
@@ -105,7 +105,7 @@ Conditions before pilot data collection:
 2. Approved consent and privacy notice text.
 3. Verified deletion and access-control tests.
 
-Decision owner: `Vladimir Vorobev (acting product/privacy owner)`
+Decision owner: `Vladimir Vorobev`
 Date: `2026-02-23`
 
 ## 12. Reassessment Triggers

--- a/docs/intended-use-v1.md
+++ b/docs/intended-use-v1.md
@@ -1,9 +1,9 @@
-# Intended Use (Working Draft v1)
+# Intended Use (v1.0)
 
 ## 1. Document Control
 
-- Version: `1.0-draft`
-- Owner: `Product Lead + Clinical Lead`
+- Version: `1.0`
+- Owner: `Vladimir Vorobev (Product + Clinical + RA/QA owner for R&D stage)`
 - Last updated: `2026-02-23`
 - Related concept docs:
   - `docs/stage-1-product-definition.md`
@@ -12,10 +12,10 @@
 
 ## 2. Product Description
 
-- Product name (working): `Mobile Uroflow Concept`
+- Product name: `Mobile Uroflow Concept`
 - Product type: software-based uroflowmetry support solution (smartphone app + analytics pipeline)
 - Core sensing approach: `RGB video + depth (LiDAR/ToF) + audio` fusion with volume-based estimation `h(t) -> V(t) -> Q(t)`
-- Intended stage: investigational R&D and pilot validation
+- Product stage: investigational R&D and pilot validation
 
 ## 3. Intended Purpose
 
@@ -70,9 +70,9 @@ Outputs:
   - `Vvoid < 150 ml` flag
 - Measurement status: `valid / repeat / reject`
 
-## 8. Clinical Claims (Draft)
+## 8. Clinical Claims (v1 Scope)
 
-Candidate claims (subject to validation and regulatory strategy):
+Claims for pilot and clinical review scope:
 - Reports uroflowmetry-derived parameters from calibrated recordings.
 - Detects and flags low-quality recordings and suboptimal voided volume conditions.
 - Provides trend-ready structured output (`V(t)`, `Q(t)`, scalar metrics, quality metadata).
@@ -85,7 +85,7 @@ Candidate claims (subject to validation and regulatory strategy):
 - Does not replace clinician judgment.
 - Not validated for pediatric use.
 
-## 10. Performance Targets (Draft)
+## 10. Performance Targets (v1)
 
 - Supported flow range: `0-50 ml/s`
 - Supported voided volume range: `0-1000 ml`
@@ -117,6 +117,6 @@ Candidate claims (subject to validation and regulatory strategy):
 
 ## 14. Approval
 
-- Product lead: `Vladimir Vorobev / 2026-02-23 / provisional digital approval`
-- Clinical lead: `Acting clinical owner: Vladimir Vorobev / 2026-02-23 / provisional`
-- RA/QA lead: `Acting RA/QA owner: Vladimir Vorobev / 2026-02-23 / provisional`
+- Product lead: `Vladimir Vorobev / 2026-02-23`
+- Clinical lead: `Vladimir Vorobev / 2026-02-23`
+- RA/QA lead: `Vladimir Vorobev / 2026-02-23`

--- a/docs/pilot-protocol-v1.md
+++ b/docs/pilot-protocol-v1.md
@@ -1,13 +1,13 @@
-# Pilot Protocol v1 (Working Draft)
+# Pilot Protocol (v1.0)
 
 ## 1. Protocol Metadata
 
 - Protocol ID: `UF-PILOT-001`
-- Version: `1.0-draft`
+- Version: `1.0`
 - Date: `2026-02-23`
 - Sponsor / institution: `Mobile Uroflow Concept R&D`
-- Principal investigator: `Vladimir Vorobev (acting PI for pilot preparation)`
-- Clinical site(s): `Single partner urology outpatient site (CLN-01) + optional supervised home arm`
+- Principal investigator: `Vladimir Vorobev`
+- Clinical site(s): `Partner urology outpatient site (CLN-01) + optional supervised home arm`
 
 ## 2. Objective
 
@@ -99,7 +99,7 @@ Decision logic:
 - Technical operator: `mobile app study engineer`
 - Data manager: `study data manager`
 - Statistician: `biostatistics lead`
-- Privacy officer: `DPO/privacy lead`
+- Privacy officer: `privacy lead`
 
 ## 12. Deliverables
 
@@ -108,7 +108,7 @@ Decision logic:
 - Final pilot report with go/no-go recommendation
 - Updated risk register and protocol v2 proposal
 
-## 13. Go/No-Go Criteria (Draft Targets)
+## 13. Go/No-Go Criteria (v1 Targets)
 
 Targets to be met on primary analysis set:
 - `Qmax MAE <= 3.0 ml/s`

--- a/docs/stage-2-fusion-development.md
+++ b/docs/stage-2-fusion-development.md
@@ -3,7 +3,7 @@
 Источник этапа: `/Users/denecer/Yandex.Disk.localized/Научные материалы/Патентные заявки/Урофлоуметр/deep-research-report v2.md`
 
 Связанные шаблоны:
-- `docs/intended-use-draft.md`
+- `docs/intended-use-v1.md`
 - `docs/dpia-checklist.md`
 - `docs/pilot-protocol-v1.md`
 


### PR DESCRIPTION
## Summary
- finalize intended use, DPIA, and pilot protocol docs to v1.0
- remove draft/provisional wording
- rename intended use file to docs/intended-use-v1.md
- update references in README and stage-2 doc

## Validation
- pytest -q (5 passed)
