### PR TITLE
ci: upgrade github actions for node24

### DIFF
--- a/.github/workflows/capture-coverage-report.yml
+++ b/.github/workflows/capture-coverage-report.yml
@@ -116,10 +116,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -417,7 +417,7 @@ jobs:
           PY
 
       - name: Upload coverage report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: capture-coverage-report-${{ github.run_id }}
           path: ${{ steps.generate.outputs.report_dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -82,10 +82,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -343,7 +343,7 @@ jobs:
 
       - name: Upload pilot automation artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pilot-automation-smoke-v2.8
           path: /tmp/pilot_automation_smoke
@@ -355,10 +355,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -425,7 +425,7 @@ jobs:
 
       - name: Upload G1 holdout artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-gates-g1-holdout-smoke
           path: /tmp/gates_g1_holdout

--- a/.github/workflows/clinical-hub-contract.yml
+++ b/.github/workflows/clinical-hub-contract.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -83,7 +83,7 @@ jobs:
             --schema-version ios_capture_v1
 
       - name: Upload release manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mobile-release-manifest
           path: /tmp/mobile-release-manifest.json
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check EXPO_TOKEN availability
         id: expo
@@ -119,7 +119,7 @@ jobs:
 
       - name: Set up Node.js
         if: ${{ steps.expo.outputs.available == 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload EAS build result artifact
         if: ${{ steps.expo.outputs.available == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mobile-eas-build-result-${{ github.run_id }}
           path: /tmp/eas-build-result.json

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## Summary
- upgrade official GitHub actions to Node 24-compatible major versions
- update checkout/setup-python/setup-node/upload-artifact across all workflows
- remove the current Node 20 deprecation risk before GitHub forces Node 24 on June 2, 2026

## Updated versions
- `actions/checkout`: `v4` -> `v6`
- `actions/setup-python`: `v5` -> `v6`
- `actions/setup-node`: `v4` -> `v6`
- `actions/upload-artifact`: `v4` -> `v7`

## Validation
- local YAML parse passed for every file in `.github/workflows`
