### PR TITLE
Extract mobile pending sync hook

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
-  AppState,
   Platform,
   Pressable,
   SafeAreaView,
@@ -28,11 +27,10 @@ import {
 } from "./src/capture/runtimeCaptureSession";
 import { estimateRoiSignalFromBase64 } from "./src/capture/roiSignalEstimator";
 import { LabeledInput } from "./src/components/LabeledInput";
+import { usePendingSyncQueue } from "./src/hooks/usePendingSyncQueue";
 import {
   loadAppSettings,
-  loadPendingSubmissions,
   saveAppSettings,
-  savePendingSubmissions,
 } from "./src/storage/appStorage";
 import type {
   AppSettings,
@@ -41,8 +39,6 @@ import type {
   CapturePackagePayload,
   ComparisonSummaryResponse,
   PairedPayload,
-  PendingEndpoint,
-  PendingSubmission,
   QualityStatus,
   RequestHeaderContext,
   RoiFrameAnalysisState,
@@ -52,14 +48,12 @@ import {
   COVERAGE_GOAL_RATIO,
   DEFAULT_REQUEST_TIMEOUT_MS,
   buildHeaderContextFromValues,
-  createPendingId,
   createSessionId,
   createSyncId,
   extractCreatedRecordId,
   formatNullable,
   normalizeActorRoleInput,
   parseNumber,
-  resolvePendingHeaderContext,
   runtimeCaptureMatchesSession,
 } from "./src/utils/appHelpers";
 
@@ -105,9 +99,6 @@ export default function App() {
   const [notes, setNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [lastResponse, setLastResponse] = useState<string>("");
-  const [pendingQueue, setPendingQueue] = useState<PendingSubmission[]>([]);
-  const [syncingPending, setSyncingPending] = useState(false);
-  const [syncStatusMessage, setSyncStatusMessage] = useState("");
   const [summaryQualityStatus, setSummaryQualityStatus] = useState<SummaryQualityStatus>("valid");
   const [summarySyncId, setSummarySyncId] = useState("");
   const [summaryLoading, setSummaryLoading] = useState(false);
@@ -136,8 +127,6 @@ export default function App() {
   const [runtimeCaptureContractPayload, setRuntimeCaptureContractPayload] = useState<
     Record<string, unknown> | null
   >(null);
-  const syncInFlightRef = useRef(false);
-  const autoSyncIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const captureRuntimeRef = useRef<RuntimeCaptureSession | null>(null);
   const cameraPreviewRef = useRef<CameraView | null>(null);
   const roiFrameIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -151,6 +140,26 @@ export default function App() {
     setRoiFrameValid(false);
     setRoiFrameCount(0);
   }
+
+  const requestHeaderContext = useMemo<RequestHeaderContext>(
+    () => buildHeaderContextFromValues(apiKey, actorRole, siteId, operatorId),
+    [actorRole, apiKey, operatorId, siteId],
+  );
+
+  const {
+    pendingQueue,
+    syncingPending,
+    syncStatusMessage,
+    enqueuePendingJob,
+    syncPendingSubmissions,
+    clearPendingSubmissions,
+  } = usePendingSyncQueue({
+    apiBaseUrl,
+    requestTimeoutMs,
+    requestHeaderContext,
+    settingsHydrated,
+    onLastResponse: setLastResponse,
+  });
 
   const payload = useMemo<PairedPayload>(() => {
     return {
@@ -250,11 +259,7 @@ export default function App() {
 
   useEffect(() => {
     void (async () => {
-      const [queue, settings] = await Promise.all([
-        loadPendingSubmissions(),
-        loadAppSettings(),
-      ]);
-      setPendingQueue(queue);
+      const settings = await loadAppSettings();
       if (settings) {
         setApiBaseUrl(settings.api_base_url);
         setApiKey(settings.api_key);
@@ -507,20 +512,8 @@ export default function App() {
     }
   }
 
-  async function persistPendingQueue(queue: PendingSubmission[]): Promise<void> {
-    await savePendingSubmissions(queue);
-    setPendingQueue(queue);
-  }
-
-  async function enqueuePendingSubmission(item: PendingSubmission): Promise<void> {
-    const queue =
-      pendingQueue.length > 0 ? [...pendingQueue] : await loadPendingSubmissions();
-    queue.push(item);
-    await persistPendingQueue(queue);
-  }
-
   function createCurrentRequestHeaderContext(): RequestHeaderContext {
-    return buildHeaderContextFromValues(apiKey, actorRole, siteId, operatorId);
+    return requestHeaderContext;
   }
 
   function buildCapturePackagePayloadFromPaired(
@@ -554,168 +547,6 @@ export default function App() {
       paired_measurement_id: pairedMeasurementId,
       notes,
     };
-  }
-
-
-  async function enqueuePendingJob(
-    endpoint: PendingEndpoint,
-    endpointPayload: PairedPayload | CapturePackagePayload,
-    headerContext: RequestHeaderContext,
-    lastError: string | null,
-    lastStatusCode: number | null,
-  ): Promise<void> {
-    const pendingItem: PendingSubmission = {
-      id: createPendingId(),
-      created_at: new Date().toISOString(),
-      endpoint,
-      payload: endpointPayload,
-      request_headers: headerContext,
-      attempt_count: 0,
-      last_attempt_at: null,
-      last_error: lastError,
-      last_status_code: lastStatusCode,
-    };
-    await enqueuePendingSubmission(pendingItem);
-  }
-
-  async function syncPendingSubmissions(showAlert = true): Promise<void> {
-    if (syncInFlightRef.current) {
-      return;
-    }
-    syncInFlightRef.current = true;
-    setSyncingPending(true);
-    setSyncStatusMessage("");
-    try {
-      const queue = await loadPendingSubmissions();
-      if (queue.length === 0) {
-        setPendingQueue([]);
-        setSyncStatusMessage("Pending queue is empty.");
-        return;
-      }
-
-      const remaining: PendingSubmission[] = [];
-      let syncedPaired = 0;
-      let syncedCapture = 0;
-      let droppedNonRetryable = 0;
-
-      for (const item of queue) {
-        const headerContext = resolvePendingHeaderContext(item, createCurrentRequestHeaderContext());
-        const result = await attemptSubmitEndpoint({
-          apiBaseUrl,
-          requestTimeoutMs,
-          endpoint: item.endpoint,
-          endpointPayload: item.payload,
-          headerContext,
-        });
-        const attemptedItem: PendingSubmission = {
-          ...item,
-          request_headers: headerContext,
-          attempt_count: item.attempt_count + 1,
-          last_attempt_at: new Date().toISOString(),
-          last_status_code: result.statusCode,
-          last_error: result.ok ? null : result.body,
-        };
-        if (result.ok) {
-          if (item.endpoint === "capture_packages") {
-            syncedCapture += 1;
-          } else {
-            syncedPaired += 1;
-          }
-          continue;
-        }
-        if (result.retryable) {
-          remaining.push(attemptedItem);
-          continue;
-        }
-        droppedNonRetryable += 1;
-      }
-
-      await persistPendingQueue(remaining);
-
-      const statusMessage =
-        `Sync completed. Synced paired: ${syncedPaired}, synced capture: ${syncedCapture}, ` +
-        `remaining retryable: ${remaining.length}, ` +
-        `dropped non-retryable: ${droppedNonRetryable}.`;
-      setSyncStatusMessage(statusMessage);
-      setLastResponse(statusMessage);
-      if (showAlert) {
-        Alert.alert("Sync completed", statusMessage);
-      }
-    } finally {
-      syncInFlightRef.current = false;
-      setSyncingPending(false);
-    }
-  }
-
-  useEffect(() => {
-    if (!settingsHydrated || pendingQueue.length === 0) {
-      if (autoSyncIntervalRef.current != null) {
-        clearInterval(autoSyncIntervalRef.current);
-        autoSyncIntervalRef.current = null;
-      }
-      return;
-    }
-
-    if (autoSyncIntervalRef.current == null) {
-      autoSyncIntervalRef.current = setInterval(() => {
-        void syncPendingSubmissions(false);
-      }, 25000);
-    }
-
-    void syncPendingSubmissions(false);
-
-    return () => {
-      if (autoSyncIntervalRef.current != null) {
-        clearInterval(autoSyncIntervalRef.current);
-        autoSyncIntervalRef.current = null;
-      }
-    };
-  }, [
-    actorRole,
-    apiBaseUrl,
-    apiKey,
-    operatorId,
-    pendingQueue.length,
-    requestTimeoutMs,
-    settingsHydrated,
-    siteId,
-  ]);
-
-  useEffect(() => {
-    const subscription = AppState.addEventListener("change", (state) => {
-      if (state === "active" && pendingQueue.length > 0) {
-        void syncPendingSubmissions(false);
-      }
-    });
-    return () => {
-      subscription.remove();
-    };
-  }, [
-    actorRole,
-    apiBaseUrl,
-    apiKey,
-    operatorId,
-    pendingQueue.length,
-    requestTimeoutMs,
-    siteId,
-  ]);
-
-  async function clearPendingSubmissions(): Promise<void> {
-    Alert.alert(
-      "Clear pending queue",
-      "Remove all pending submissions from local storage?",
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Clear",
-          style: "destructive",
-          onPress: () => {
-            void persistPendingQueue([]);
-            setSyncStatusMessage("Pending queue cleared.");
-          },
-        },
-      ],
-    );
   }
 
   async function testApiConnection(): Promise<void> {

--- a/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
+++ b/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
@@ -1,0 +1,214 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Alert, AppState } from "react-native";
+
+import { attemptSubmitEndpoint } from "../api/clinicalHub";
+import {
+  loadPendingSubmissions,
+  savePendingSubmissions,
+} from "../storage/appStorage";
+import type {
+  EndpointPayload,
+  PendingEndpoint,
+  PendingSubmission,
+  RequestHeaderContext,
+} from "../types";
+import { createPendingId, resolvePendingHeaderContext } from "../utils/appHelpers";
+
+type UsePendingSyncQueueOptions = {
+  apiBaseUrl: string;
+  requestTimeoutMs: string;
+  requestHeaderContext: RequestHeaderContext;
+  settingsHydrated: boolean;
+  onLastResponse: (message: string) => void;
+};
+
+export function usePendingSyncQueue({
+  apiBaseUrl,
+  requestTimeoutMs,
+  requestHeaderContext,
+  settingsHydrated,
+  onLastResponse,
+}: UsePendingSyncQueueOptions) {
+  const [pendingQueue, setPendingQueue] = useState<PendingSubmission[]>([]);
+  const [syncingPending, setSyncingPending] = useState(false);
+  const [syncStatusMessage, setSyncStatusMessage] = useState("");
+  const syncInFlightRef = useRef(false);
+  const autoSyncIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const persistPendingQueue = useCallback(async (queue: PendingSubmission[]): Promise<void> => {
+    await savePendingSubmissions(queue);
+    setPendingQueue(queue);
+  }, []);
+
+  const enqueuePendingJob = useCallback(
+    async (
+      endpoint: PendingEndpoint,
+      endpointPayload: EndpointPayload,
+      headerContext: RequestHeaderContext,
+      lastError: string | null,
+      lastStatusCode: number | null,
+    ): Promise<void> => {
+      const queue = await loadPendingSubmissions();
+      const pendingItem: PendingSubmission = {
+        id: createPendingId(),
+        created_at: new Date().toISOString(),
+        endpoint,
+        payload: endpointPayload,
+        request_headers: headerContext,
+        attempt_count: 0,
+        last_attempt_at: null,
+        last_error: lastError,
+        last_status_code: lastStatusCode,
+      };
+      await persistPendingQueue([...queue, pendingItem]);
+    },
+    [persistPendingQueue],
+  );
+
+  const syncPendingSubmissions = useCallback(
+    async (showAlert = true): Promise<void> => {
+      if (syncInFlightRef.current) {
+        return;
+      }
+      syncInFlightRef.current = true;
+      setSyncingPending(true);
+      setSyncStatusMessage("");
+      try {
+        const queue = await loadPendingSubmissions();
+        if (queue.length === 0) {
+          setPendingQueue([]);
+          setSyncStatusMessage("Pending queue is empty.");
+          return;
+        }
+
+        const remaining: PendingSubmission[] = [];
+        let syncedPaired = 0;
+        let syncedCapture = 0;
+        let droppedNonRetryable = 0;
+
+        for (const item of queue) {
+          const headerContext = resolvePendingHeaderContext(item, requestHeaderContext);
+          const result = await attemptSubmitEndpoint({
+            apiBaseUrl,
+            requestTimeoutMs,
+            endpoint: item.endpoint,
+            endpointPayload: item.payload,
+            headerContext,
+          });
+          const attemptedItem: PendingSubmission = {
+            ...item,
+            request_headers: headerContext,
+            attempt_count: item.attempt_count + 1,
+            last_attempt_at: new Date().toISOString(),
+            last_status_code: result.statusCode,
+            last_error: result.ok ? null : result.body,
+          };
+          if (result.ok) {
+            if (item.endpoint === "capture_packages") {
+              syncedCapture += 1;
+            } else {
+              syncedPaired += 1;
+            }
+            continue;
+          }
+          if (result.retryable) {
+            remaining.push(attemptedItem);
+            continue;
+          }
+          droppedNonRetryable += 1;
+        }
+
+        await persistPendingQueue(remaining);
+
+        const statusMessage =
+          `Sync completed. Synced paired: ${syncedPaired}, synced capture: ${syncedCapture}, ` +
+          `remaining retryable: ${remaining.length}, ` +
+          `dropped non-retryable: ${droppedNonRetryable}.`;
+        setSyncStatusMessage(statusMessage);
+        onLastResponse(statusMessage);
+        if (showAlert) {
+          Alert.alert("Sync completed", statusMessage);
+        }
+      } finally {
+        syncInFlightRef.current = false;
+        setSyncingPending(false);
+      }
+    },
+    [
+      apiBaseUrl,
+      onLastResponse,
+      persistPendingQueue,
+      requestHeaderContext,
+      requestTimeoutMs,
+    ],
+  );
+
+  const clearPendingSubmissions = useCallback(async (): Promise<void> => {
+    Alert.alert(
+      "Clear pending queue",
+      "Remove all pending submissions from local storage?",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Clear",
+          style: "destructive",
+          onPress: () => {
+            void persistPendingQueue([]);
+            setSyncStatusMessage("Pending queue cleared.");
+          },
+        },
+      ],
+    );
+  }, [persistPendingQueue]);
+
+  useEffect(() => {
+    void (async () => {
+      setPendingQueue(await loadPendingSubmissions());
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!settingsHydrated || pendingQueue.length === 0) {
+      if (autoSyncIntervalRef.current != null) {
+        clearInterval(autoSyncIntervalRef.current);
+        autoSyncIntervalRef.current = null;
+      }
+      return;
+    }
+
+    if (autoSyncIntervalRef.current == null) {
+      autoSyncIntervalRef.current = setInterval(() => {
+        void syncPendingSubmissions(false);
+      }, 25000);
+    }
+
+    void syncPendingSubmissions(false);
+
+    return () => {
+      if (autoSyncIntervalRef.current != null) {
+        clearInterval(autoSyncIntervalRef.current);
+        autoSyncIntervalRef.current = null;
+      }
+    };
+  }, [pendingQueue.length, settingsHydrated, syncPendingSubmissions]);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "active" && pendingQueue.length > 0) {
+        void syncPendingSubmissions(false);
+      }
+    });
+    return () => {
+      subscription.remove();
+    };
+  }, [pendingQueue.length, syncPendingSubmissions]);
+
+  return {
+    pendingQueue,
+    syncingPending,
+    syncStatusMessage,
+    enqueuePendingJob,
+    syncPendingSubmissions,
+    clearPendingSubmissions,
+  };
+}


### PR DESCRIPTION
## Summary
- move pending queue state, persistence, auto-sync, app-active retry, and clear dialog into `usePendingSyncQueue`
- keep `App.tsx` focused on form/runtime capture and submit orchestration
- reuse the current request header context through the hook so queued items still preserve stored headers with current-value fallback

## Validation
- `npm run typecheck`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q`