### PR TITLE
Strengthen mobile release validation

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
-      - name: Typecheck
-        run: npm run typecheck
+      - name: Validate Expo project
+        run: npm run validate:ci
 
       - name: Build release manifest
         env:
@@ -74,7 +74,7 @@ jobs:
           elif [[ "$profile" == "production" ]]; then
             channel="production"
           fi
-          python ../../scripts/build_mobile_release_manifest.py \
+          python3 ../../scripts/build_mobile_release_manifest.py \
             --app-json app.json \
             --output /tmp/mobile-release-manifest.json \
             --profile "$profile" \
@@ -131,7 +131,7 @@ jobs:
 
       - name: Install EAS CLI
         if: ${{ steps.expo.outputs.available == 'true' }}
-        run: npm install -g eas-cli
+        run: npm install -g eas-cli@20.0.0
 
       - name: Trigger EAS build
         if: ${{ steps.expo.outputs.available == 'true' }}
@@ -175,7 +175,7 @@ jobs:
           WORKFLOW_WAIT_FOR_BUILD: ${{ github.event.inputs.wait_for_build || 'false' }}
         run: |
           set -euo pipefail
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import os
           from pathlib import Path

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -40,5 +40,5 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
-      - name: TypeScript typecheck
-        run: npm run typecheck
+      - name: Validate Expo project
+        run: npm run validate:ci

--- a/README.md
+++ b/README.md
@@ -414,8 +414,12 @@ uroflow-mobile evaluate-gates examples/gates/gate_metrics.json \
 ```bash
 cd apps/field-mobile
 npm ci
+npm run validate:ci
 npm run start
 ```
+
+`npm run validate:ci` mirrors Mobile CI: TypeScript, Expo Doctor, production
+dependency audit, and Expo export bundle builds for iOS and Android.
 
 Если на macOS обычный `npm run start` упирается в `EMFILE`, для реального запуска через Expo Go используйте стабильный путь:
 

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -50,11 +50,15 @@ npm run start:device
 
 This mode keeps Metro up for Expo Go on a physical phone over LAN, publishes the laptop LAN IP into the Expo manifest, and disables live reload (`CI=1`) to avoid file-watcher exhaustion.
 
-Optional local check:
+Optional local checks:
 
 ```bash
 npm run typecheck
+npm run validate:ci
 ```
+
+`validate:ci` mirrors Mobile CI: TypeScript, Expo Doctor, production dependency audit,
+and Expo export bundle builds for both iOS and Android.
 
 3. Open on iPhone/Android via Expo Go (QR code), or run native:
 
@@ -104,7 +108,8 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 - `Test API` calls `/api/v1/auth-context` to show effective auth/role/site resolution.
 
 CI:
-- `.github/workflows/mobile-ci.yml` runs TypeScript typecheck for `apps/field-mobile/**` changes.
+- `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
+- `validate:ci` covers TypeScript, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/package-lock.json
+++ b/apps/field-mobile/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@types/react": "~19.2.16",
+        "expo-doctor": "1.19.8",
         "typescript": "~6.0.3"
       },
       "engines": {
@@ -2884,6 +2885,19 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-doctor": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/expo-doctor/-/expo-doctor-1.19.8.tgz",
+      "integrity": "sha512-ZHpQM+BfJe1DNaA+/ObtLYazC2x78tIV3kkfoSGR46Tj1EvzOFh1p9gFHsILI9TOyXPEcgxCkFw9AVvf8C4c1g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "expo-doctor": "bin/expo-doctor.js"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/apps/field-mobile/package.json
+++ b/apps/field-mobile/package.json
@@ -13,6 +13,11 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "typecheck": "tsc --noEmit",
+    "doctor": "CI=1 expo-doctor",
+    "audit:prod": "npm audit --omit=dev",
+    "export:ios": "CI=1 expo export --platform ios --clear --output-dir /tmp/uroflow-field-mobile-export-ios",
+    "export:android": "CI=1 expo export --platform android --clear --output-dir /tmp/uroflow-field-mobile-export-android",
+    "validate:ci": "npm run typecheck && npm run doctor && npm run audit:prod && npm run export:ios && npm run export:android",
     "build:preview": "eas build --platform all --profile preview",
     "build:production": "eas build --platform all --profile production"
   },
@@ -31,6 +36,7 @@
   },
   "devDependencies": {
     "@types/react": "~19.2.16",
+    "expo-doctor": "1.19.8",
     "typescript": "~6.0.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- add a deterministic mobile validation script that runs TypeScript, Expo Doctor, production dependency audit, and iOS/Android Expo export bundle builds
- make Mobile CI and Mobile Build preflight use the stronger validation gate instead of typecheck only
- pin expo-doctor locally and pin the workflow EAS CLI install to 20.0.0
- switch workflow Python calls from python to python3 and document the new local validation path

## Validation
- npm ci --no-audit --no-fund
- npm run validate:ci
- npm audit
- python3 scripts/build_mobile_release_manifest.py --app-json apps/field-mobile/app.json --output /tmp/mobile-release-manifest.json --profile preview --channel preview --model-id fusion-v0.1 --schema-version ios_capture_v1
- .venv/bin/ruff check .
- .venv/bin/pytest -q
- ruby YAML parse for .github/workflows/mobile-ci.yml and .github/workflows/mobile-build.yml

Note: actionlint is not installed in the local environment; GitHub Actions will validate workflow semantics.
