### PR TITLE
Add mobile release readiness report

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -63,6 +63,52 @@ jobs:
       - name: Validate Expo project
         run: npm run validate:ci
 
+      - name: Build release readiness report
+        env:
+          CLINICAL_HUB_API_KEY: ${{ secrets.CLINICAL_HUB_API_KEY }}
+          CLINICAL_HUB_URL: ${{ secrets.CLINICAL_HUB_URL }}
+          EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          python3 ../../scripts/check_mobile_release_readiness.py \
+            --app-json app.json \
+            --eas-json eas.json \
+            --package-json package.json \
+            --package-lock package-lock.json \
+            --output /tmp/mobile-release-readiness.json
+
+      - name: Publish release readiness summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads(Path("/tmp/mobile-release-readiness.json").read_text(encoding="utf-8"))
+          missing = [
+              item["id"]
+              for item in payload.get("external_items", [])
+              if item.get("status") == "missing"
+          ]
+          manual = [
+              item["id"]
+              for item in payload.get("manual_external_items", [])
+              if item.get("status") == "manual_required"
+          ]
+          lines = [
+              "## Mobile Release Readiness",
+              f"- Status: `{payload.get('status')}`",
+              f"- Local checks: `{payload.get('local_checks_status')}`",
+              f"- External readiness: `{payload.get('external_readiness_status')}`",
+              f"- Missing external items: `{', '.join(missing) if missing else 'none'}`",
+              f"- Manual external items: `{', '.join(manual) if manual else 'none'}`",
+          ]
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("\n".join(lines) + "\n")
+          PY
+
       - name: Build release manifest
         env:
           WORKFLOW_BUILD_PROFILE: ${{ github.event.inputs.build_profile || 'preview' }}
@@ -87,6 +133,12 @@ jobs:
         with:
           name: mobile-release-manifest
           path: /tmp/mobile-release-manifest.json
+
+      - name: Upload release readiness report
+        uses: actions/upload-artifact@v7
+        with:
+          name: mobile-release-readiness
+          path: /tmp/mobile-release-readiness.json
 
   eas-build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -420,6 +420,8 @@ npm run start
 
 `npm run validate:ci` mirrors Mobile CI: TypeScript, Expo Doctor, production
 dependency audit, and Expo export bundle builds for iOS and Android.
+`scripts/check_mobile_release_readiness.py` builds a JSON readiness report that
+separates local release checks from external Expo/Apple/Google/Clinical Hub blockers.
 
 Если на macOS обычный `npm run start` упирается в `EMFILE`, для реального запуска через Expo Go используйте стабильный путь:
 

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -116,8 +116,9 @@ CI:
   - `wait_for_build` (`true` / `false`)
 - `mobile-build` uploads:
   - `mobile-release-manifest` (version + git SHA + model/schema traceability)
+  - `mobile-release-readiness` (local readiness checks + explicit external credential blockers)
   - `mobile-eas-build-result-<run_id>` (raw EAS JSON response for build IDs/URLs)
-- Workflow summary includes direct EAS build links for operator/release use.
+- Workflow summary includes release readiness status and direct EAS build links for operator/release use.
 
 ## Installable Build (EAS)
 

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -8,7 +8,11 @@ Scope: pilot installable builds for Uroflow Field Mobile
 1. App code merged to target branch.
 2. `apps/field-mobile/eas.json` profiles updated.
 3. GitHub secret `EXPO_TOKEN` configured.
-4. Expo project credentials configured for iOS and Android signing.
+4. `EAS_PROJECT_ID` configured as a GitHub repo variable or `expo.extra.eas.projectId` set in `app.json`.
+5. Expo project credentials configured for iOS and Android signing.
+6. Clinical Hub secrets configured when live API smoke/report push is part of the release:
+   - `CLINICAL_HUB_URL`
+   - `CLINICAL_HUB_API_KEY`
 
 ## 2) Trigger preview build
 
@@ -19,9 +23,12 @@ From GitHub Actions:
    - `build_platform` (`all`/`ios`/`android`),
    - `wait_for_build` (`false` for fast trigger, `true` for full wait mode).
 3. Verify `preflight` passes.
-4. Verify `eas-build` starts.
-5. Open workflow summary (`Mobile EAS Build`) and copy build links.
-6. Download artifact `mobile-eas-build-result-<run_id>` for traceability JSON.
+4. Open workflow summary (`Mobile Release Readiness`) and confirm:
+   - `Local checks` is `pass`,
+   - missing external items are understood and either configured or accepted as blockers for this run.
+5. Verify `eas-build` starts.
+6. Open workflow summary (`Mobile EAS Build`) and copy build links.
+7. Download artifact `mobile-eas-build-result-<run_id>` for traceability JSON.
 
 Local fallback:
 
@@ -38,14 +45,30 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - model_id and capture schema version.
 - selected build profile/channel.
 
+Workflow also generates artifact `mobile-release-readiness` containing:
+- local mobile readiness checks (`app.json`, `eas.json`, package scripts, lockfile, pinned tooling),
+- external credential state without secret values,
+- manual release requirements for Apple Developer and Google Play accounts.
+
 Manifest script:
 
 ```bash
-python scripts/build_mobile_release_manifest.py \
+python3 scripts/build_mobile_release_manifest.py \
   --app-json apps/field-mobile/app.json \
   --output /tmp/mobile-release-manifest.json \
   --profile preview \
   --channel preview
+```
+
+Readiness script:
+
+```bash
+python3 scripts/check_mobile_release_readiness.py \
+  --app-json apps/field-mobile/app.json \
+  --eas-json apps/field-mobile/eas.json \
+  --package-json apps/field-mobile/package.json \
+  --package-lock apps/field-mobile/package-lock.json \
+  --output /tmp/mobile-release-readiness.json
 ```
 
 ## 4) Distribution channels
@@ -70,7 +93,8 @@ Android:
 ## 6) Evidence to archive per build
 
 1. Mobile release manifest JSON.
-2. Build links (iOS + Android).
-3. Smoke test log with device model and OS version.
-4. Clinical Hub sample export (paired + capture package rows).
-5. Go/No-Go note for pilot usage.
+2. Mobile release readiness JSON.
+3. Build links (iOS + Android).
+4. Smoke test log with device model and OS version.
+5. Clinical Hub sample export (paired + capture package rows).
+6. Go/No-Go note for pilot usage.

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _has_plugin(plugins: list[Any], plugin_name: str) -> bool:
+    for plugin in plugins:
+        if plugin == plugin_name:
+            return True
+        if isinstance(plugin, list) and plugin and plugin[0] == plugin_name:
+            return True
+    return False
+
+
+def _get_plugin_options(plugins: list[Any], plugin_name: str) -> dict[str, Any]:
+    for plugin in plugins:
+        if isinstance(plugin, list) and len(plugin) > 1 and plugin[0] == plugin_name:
+            return plugin[1] if isinstance(plugin[1], dict) else {}
+    return {}
+
+
+def _check(
+    checks: list[dict[str, Any]],
+    check_id: str,
+    passed: bool,
+    evidence: str,
+    *,
+    severity: str = "error",
+) -> None:
+    checks.append(
+        {
+            "id": check_id,
+            "status": "pass" if passed else "fail",
+            "severity": severity,
+            "evidence": evidence,
+        }
+    )
+
+
+def build_readiness_report(
+    *,
+    app_json: Path,
+    eas_json: Path,
+    package_json: Path,
+    package_lock: Path,
+    env: dict[str, str],
+) -> dict[str, Any]:
+    app_payload = _load_json(app_json)
+    eas_payload = _load_json(eas_json)
+    package_payload = _load_json(package_json)
+    lock_payload = _load_json(package_lock)
+
+    expo = app_payload.get("expo", {})
+    plugins = expo.get("plugins", [])
+    ios = expo.get("ios", {})
+    android = expo.get("android", {})
+    scripts = package_payload.get("scripts", {})
+    root_lock = lock_payload.get("packages", {}).get("", {})
+    eas_build = eas_payload.get("build", {})
+
+    checks: list[dict[str, Any]] = []
+
+    platforms = expo.get("platforms", [])
+    _check(
+        checks,
+        "platforms_ios_android",
+        "ios" in platforms and "android" in platforms,
+        f"platforms={platforms!r}",
+    )
+    _check(checks, "expo_name", bool(expo.get("name")), f"name={expo.get('name')!r}")
+    _check(checks, "expo_slug", bool(expo.get("slug")), f"slug={expo.get('slug')!r}")
+    _check(checks, "expo_version", bool(expo.get("version")), f"version={expo.get('version')!r}")
+    _check(
+        checks,
+        "ios_bundle_identifier",
+        bool(ios.get("bundleIdentifier")),
+        f"bundleIdentifier={ios.get('bundleIdentifier')!r}",
+    )
+    _check(
+        checks,
+        "ios_build_number",
+        bool(ios.get("buildNumber")),
+        f"buildNumber={ios.get('buildNumber')!r}",
+    )
+    _check(
+        checks,
+        "android_package",
+        bool(android.get("package")),
+        f"package={android.get('package')!r}",
+    )
+    _check(
+        checks,
+        "android_version_code",
+        isinstance(android.get("versionCode"), int) and android.get("versionCode", 0) > 0,
+        f"versionCode={android.get('versionCode')!r}",
+    )
+    _check(
+        checks,
+        "camera_plugin",
+        _has_plugin(plugins, "expo-camera"),
+        "expo-camera plugin configured",
+    )
+    _check(
+        checks,
+        "audio_plugin",
+        _has_plugin(plugins, "expo-audio"),
+        "expo-audio plugin configured",
+    )
+
+    audio_options = _get_plugin_options(plugins, "expo-audio")
+    _check(
+        checks,
+        "foreground_audio_disabled",
+        audio_options.get("enableBackgroundPlayback") is False
+        and audio_options.get("enableBackgroundRecording") is False,
+        f"expo-audio options={audio_options!r}",
+    )
+    _check(
+        checks,
+        "android_runtime_permissions_declared",
+        {"CAMERA", "RECORD_AUDIO"}.issubset(set(android.get("permissions", []))),
+        f"permissions={android.get('permissions', [])!r}",
+    )
+
+    for profile in ("development", "preview", "production"):
+        _check(
+            checks,
+            f"eas_profile_{profile}",
+            profile in eas_build,
+            f"eas build profiles={list(eas_build)}",
+        )
+    _check(
+        checks,
+        "preview_android_apk",
+        eas_build.get("preview", {}).get("android", {}).get("buildType") == "apk",
+        f"preview.android={eas_build.get('preview', {}).get('android')!r}",
+        severity="warning",
+    )
+    _check(
+        checks,
+        "validate_ci_script",
+        "validate:ci" in scripts,
+        "package script validate:ci is present",
+    )
+    _check(
+        checks,
+        "build_scripts",
+        "build:preview" in scripts and "build:production" in scripts,
+        "package build scripts are present",
+    )
+    _check(
+        checks,
+        "package_lock_matches_root",
+        root_lock.get("name") == package_payload.get("name"),
+        f"lock root={root_lock.get('name')!r}, package={package_payload.get('name')!r}",
+    )
+    _check(
+        checks,
+        "expo_doctor_pinned",
+        package_payload.get("devDependencies", {}).get("expo-doctor") == "1.19.8"
+        and root_lock.get("devDependencies", {}).get("expo-doctor") == "1.19.8",
+        "expo-doctor devDependency is pinned in package.json and package-lock.json",
+    )
+
+    extra = expo.get("extra", {})
+    eas_project_id = (
+        extra.get("eas", {}).get("projectId") if isinstance(extra.get("eas"), dict) else None
+    )
+    external_items = [
+        {
+            "id": "expo_token",
+            "status": "present" if bool(env.get("EXPO_TOKEN")) else "missing",
+            "required_for": "Authenticated EAS build trigger from GitHub Actions.",
+            "evidence": "EXPO_TOKEN environment variable is set"
+            if env.get("EXPO_TOKEN")
+            else "EXPO_TOKEN environment variable is not set",
+        },
+        {
+            "id": "eas_project_identity",
+            "status": "present" if bool(eas_project_id or env.get("EAS_PROJECT_ID")) else "missing",
+            "required_for": "Deterministic non-interactive EAS project identity.",
+            "evidence": "expo.extra.eas.projectId or EAS_PROJECT_ID is set"
+            if eas_project_id or env.get("EAS_PROJECT_ID")
+            else "Neither expo.extra.eas.projectId nor EAS_PROJECT_ID is set",
+        },
+        {
+            "id": "clinical_hub_live_api",
+            "status": "present"
+            if bool(env.get("CLINICAL_HUB_URL") and env.get("CLINICAL_HUB_API_KEY"))
+            else "missing",
+            "required_for": "Live Clinical Hub smoke tests and CI report push.",
+            "evidence": "CLINICAL_HUB_URL and CLINICAL_HUB_API_KEY are set"
+            if env.get("CLINICAL_HUB_URL") and env.get("CLINICAL_HUB_API_KEY")
+            else "CLINICAL_HUB_URL and/or CLINICAL_HUB_API_KEY are not set",
+        },
+    ]
+    manual_external_items = [
+        {
+            "id": "apple_developer_account",
+            "status": "manual_required",
+            "required_for": (
+                "Signed iOS build, TestFlight/App Store distribution, "
+                "and certificate/profile management."
+            ),
+        },
+        {
+            "id": "google_play_account",
+            "status": "manual_required",
+            "required_for": (
+                "Android production signing, Play Console upload, and store distribution."
+            ),
+        },
+    ]
+
+    local_failures = [
+        item for item in checks if item["status"] == "fail" and item["severity"] == "error"
+    ]
+    external_missing = [item for item in external_items if item["status"] == "missing"]
+    if local_failures:
+        status = "not_ready"
+    elif external_missing:
+        status = "ready_except_external_credentials"
+    else:
+        status = "ready_for_authenticated_eas_preflight"
+
+    return {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "local_checks_status": "pass" if not local_failures else "fail",
+        "external_readiness_status": "pass" if not external_missing else "blocked",
+        "app": {
+            "name": expo.get("name"),
+            "slug": expo.get("slug"),
+            "version": expo.get("version"),
+            "ios_bundle_identifier": ios.get("bundleIdentifier"),
+            "android_package": android.get("package"),
+        },
+        "local_checks": checks,
+        "external_items": external_items,
+        "manual_external_items": manual_external_items,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a mobile release readiness report with explicit external blockers."
+    )
+    parser.add_argument("--app-json", type=Path, required=True)
+    parser.add_argument("--eas-json", type=Path, required=True)
+    parser.add_argument("--package-json", type=Path, required=True)
+    parser.add_argument("--package-lock", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--strict-external",
+        action="store_true",
+        help="Return a non-zero exit code when external credentials are missing.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = build_readiness_report(
+        app_json=args.app_json,
+        eas_json=args.eas_json,
+        package_json=args.package_json,
+        package_lock=args.package_lock,
+        env=dict(os.environ),
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"written {args.output}")
+    print(f"status: {report['status']}")
+
+    if report["local_checks_status"] != "pass":
+        return 1
+    if args.strict_external and report["external_readiness_status"] != "pass":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path("scripts/check_mobile_release_readiness.py")
+APP_JSON = Path("apps/field-mobile/app.json")
+EAS_JSON = Path("apps/field-mobile/eas.json")
+PACKAGE_JSON = Path("apps/field-mobile/package.json")
+PACKAGE_LOCK = Path("apps/field-mobile/package-lock.json")
+
+
+def _run_readiness(output: Path, env: dict[str, str]) -> dict:
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--app-json",
+            str(APP_JSON),
+            "--eas-json",
+            str(EAS_JSON),
+            "--package-json",
+            str(PACKAGE_JSON),
+            "--package-lock",
+            str(PACKAGE_LOCK),
+            "--output",
+            str(output),
+        ],
+        check=True,
+        env=env,
+    )
+    return json.loads(output.read_text(encoding="utf-8"))
+
+
+def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> None:
+    payload = _run_readiness(
+        tmp_path / "readiness.json",
+        env={"PATH": os.environ.get("PATH", "")},
+    )
+
+    assert payload["status"] == "ready_except_external_credentials"
+    assert payload["local_checks_status"] == "pass"
+    assert payload["external_readiness_status"] == "blocked"
+    assert {item["id"] for item in payload["external_items"] if item["status"] == "missing"} == {
+        "clinical_hub_live_api",
+        "eas_project_identity",
+        "expo_token",
+    }
+    assert all(item["status"] == "pass" for item in payload["local_checks"])
+
+
+def test_mobile_release_readiness_passes_authenticated_preflight_env(tmp_path: Path) -> None:
+    payload = _run_readiness(
+        tmp_path / "readiness.json",
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "CLINICAL_HUB_API_KEY": "test-key",
+            "CLINICAL_HUB_URL": "https://clinical.example.test",
+            "EAS_PROJECT_ID": "00000000-0000-0000-0000-000000000000",
+            "EXPO_TOKEN": "test-token",
+        },
+    )
+
+    assert payload["status"] == "ready_for_authenticated_eas_preflight"
+    assert payload["local_checks_status"] == "pass"
+    assert payload["external_readiness_status"] == "pass"
+    assert all(item["status"] == "present" for item in payload["external_items"])
+    assert {item["status"] for item in payload["manual_external_items"]} == {"manual_required"}


### PR DESCRIPTION
## Summary
- add a machine-readable mobile release readiness report that separates local readiness from external credential blockers
- include readiness generation, summary, and artifact upload in Mobile Build preflight
- document EXPO_TOKEN, EAS_PROJECT_ID, Clinical Hub, Apple Developer, and Google Play external release requirements
- add tests for missing-credential and authenticated-preflight readiness states

## Validation
- .venv/bin/ruff check .
- .venv/bin/pytest -q (94 passed)
- npm ci --no-audit --no-fund
- npm run validate:ci
- npm audit
- python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-release-readiness.json
- ruby YAML parse for .github/workflows/mobile-build.yml and .github/workflows/mobile-ci.yml
