### PR TITLE
[codex] Add mobile readiness next actions

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -97,6 +97,11 @@ jobs:
               for item in payload.get("manual_external_items", [])
               if item.get("status") == "manual_required"
           ]
+          next_actions = [
+              item["id"]
+              for item in payload.get("next_actions", [])
+              if item.get("id")
+          ]
           lines = [
               "## Mobile Release Readiness",
               f"- Status: `{payload.get('status')}`",
@@ -104,6 +109,7 @@ jobs:
               f"- External readiness: `{payload.get('external_readiness_status')}`",
               f"- Missing external items: `{', '.join(missing) if missing else 'none'}`",
               f"- Manual external items: `{', '.join(manual) if manual else 'none'}`",
+              f"- Next actions: `{', '.join(next_actions) if next_actions else 'none'}`",
           ]
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
               handle.write("\n".join(lines) + "\n")

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -48,7 +48,8 @@ Workflow generates artifact `mobile-release-manifest` containing:
 Workflow also generates artifact `mobile-release-readiness` containing:
 - local mobile readiness checks (`app.json`, `eas.json`, package scripts, lockfile, pinned tooling),
 - external credential state without secret values,
-- manual release requirements for Apple Developer and Google Play accounts.
+- manual release requirements for Apple Developer and Google Play accounts,
+- machine-readable `next_actions` for configuring missing GitHub secrets/variables and manual store-account handoff.
 
 Manifest script:
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -47,6 +47,110 @@ def _check(
     )
 
 
+def _build_next_actions(
+    external_items: list[dict[str, Any]],
+    manual_external_items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    external_action_map = {
+        "expo_token": {
+            "id": "configure_expo_token",
+            "blocked_item": "expo_token",
+            "status": "required",
+            "owner": "release_engineer",
+            "action": "Create an Expo access token and add it as GitHub Actions secret EXPO_TOKEN.",
+            "verification": (
+                "Re-run Mobile Build; external_items.expo_token status should become present."
+            ),
+            "secret_names": ["EXPO_TOKEN"],
+            "variable_names": [],
+            "file_paths": [],
+            "doc": "docs/mobile-release-runbook-v0.1.md",
+        },
+        "eas_project_identity": {
+            "id": "configure_eas_project_identity",
+            "blocked_item": "eas_project_identity",
+            "status": "required",
+            "owner": "release_engineer",
+            "action": (
+                "Set GitHub repository variable EAS_PROJECT_ID or commit expo.extra.eas.projectId "
+                "in apps/field-mobile/app.json."
+            ),
+            "verification": (
+                "Re-run Mobile Build; external_items.eas_project_identity status should become "
+                "present."
+            ),
+            "secret_names": [],
+            "variable_names": ["EAS_PROJECT_ID"],
+            "file_paths": ["apps/field-mobile/app.json"],
+            "doc": "docs/mobile-release-runbook-v0.1.md",
+        },
+        "clinical_hub_live_api": {
+            "id": "configure_clinical_hub_live_api",
+            "blocked_item": "clinical_hub_live_api",
+            "status": "required",
+            "owner": "clinical_hub_admin",
+            "action": (
+                "Add GitHub Actions secrets CLINICAL_HUB_URL and CLINICAL_HUB_API_KEY for live "
+                "Clinical Hub smoke tests and report push."
+            ),
+            "verification": (
+                "Re-run Mobile Build; external_items.clinical_hub_live_api status should become "
+                "present."
+            ),
+            "secret_names": ["CLINICAL_HUB_URL", "CLINICAL_HUB_API_KEY"],
+            "variable_names": [],
+            "file_paths": [],
+            "doc": "docs/mobile-release-runbook-v0.1.md",
+        },
+    }
+    manual_action_map = {
+        "apple_developer_account": {
+            "id": "provision_apple_developer_account",
+            "blocked_item": "apple_developer_account",
+            "status": "manual_required",
+            "owner": "account_admin",
+            "action": (
+                "Provision Apple Developer access, signing certificates/profiles, and TestFlight "
+                "distribution permissions."
+            ),
+            "verification": (
+                "Trigger a signed iOS EAS build and confirm TestFlight upload readiness."
+            ),
+            "secret_names": [],
+            "variable_names": [],
+            "file_paths": [],
+            "doc": "docs/mobile-release-runbook-v0.1.md",
+        },
+        "google_play_account": {
+            "id": "provision_google_play_account",
+            "blocked_item": "google_play_account",
+            "status": "manual_required",
+            "owner": "account_admin",
+            "action": (
+                "Provision Google Play Console access, Android signing, and internal testing track "
+                "permissions."
+            ),
+            "verification": (
+                "Trigger a signed Android EAS build and confirm Play Internal Testing upload "
+                "readiness."
+            ),
+            "secret_names": [],
+            "variable_names": [],
+            "file_paths": [],
+            "doc": "docs/mobile-release-runbook-v0.1.md",
+        },
+    }
+
+    next_actions: list[dict[str, Any]] = []
+    for item in external_items:
+        if item["status"] == "missing" and item["id"] in external_action_map:
+            next_actions.append(external_action_map[item["id"]])
+    for item in manual_external_items:
+        if item["status"] == "manual_required" and item["id"] in manual_action_map:
+            next_actions.append(manual_action_map[item["id"]])
+    return next_actions
+
+
 def build_readiness_report(
     *,
     app_json: Path,
@@ -233,6 +337,8 @@ def build_readiness_report(
     else:
         status = "ready_for_authenticated_eas_preflight"
 
+    next_actions = _build_next_actions(external_items, manual_external_items)
+
     return {
         "generated_at_utc": datetime.now(timezone.utc).isoformat(),
         "status": status,
@@ -248,6 +354,7 @@ def build_readiness_report(
         "local_checks": checks,
         "external_items": external_items,
         "manual_external_items": manual_external_items,
+        "next_actions": next_actions,
     }
 
 

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -50,6 +50,18 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "expo_token",
     }
     assert all(item["status"] == "pass" for item in payload["local_checks"])
+    assert {item["id"] for item in payload["next_actions"]} == {
+        "configure_clinical_hub_live_api",
+        "configure_eas_project_identity",
+        "configure_expo_token",
+        "provision_apple_developer_account",
+        "provision_google_play_account",
+    }
+    expo_action = next(
+        item for item in payload["next_actions"] if item["id"] == "configure_expo_token"
+    )
+    assert expo_action["secret_names"] == ["EXPO_TOKEN"]
+    assert expo_action["verification"]
 
 
 def test_mobile_release_readiness_passes_authenticated_preflight_env(tmp_path: Path) -> None:
@@ -69,3 +81,7 @@ def test_mobile_release_readiness_passes_authenticated_preflight_env(tmp_path: P
     assert payload["external_readiness_status"] == "pass"
     assert all(item["status"] == "present" for item in payload["external_items"])
     assert {item["status"] for item in payload["manual_external_items"]} == {"manual_required"}
+    assert {item["id"] for item in payload["next_actions"]} == {
+        "provision_apple_developer_account",
+        "provision_google_play_account",
+    }


### PR DESCRIPTION
## Summary

- Add machine-readable `next_actions` to the mobile release readiness report for missing Expo/EAS/Clinical Hub credentials and manual Apple/Google store-account handoff.
- Surface the next action IDs in the `Mobile Build` workflow summary without exposing secret values.
- Document the new readiness artifact field in the mobile release runbook.

## Validation

- `.venv/bin/pytest -q tests/test_mobile_release_readiness_script.py tests/test_mobile_release_manifest_script.py`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q`
- `npm run validate:ci` in `apps/field-mobile`
