### PR TITLE
[codex] Extract mobile measurement form section

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   Platform,
-  Pressable,
   SafeAreaView,
   ScrollView,
   Text,
@@ -25,7 +24,7 @@ import {
 } from "./src/capture/runtimeCaptureSession";
 import { estimateRoiSignalFromBase64 } from "./src/capture/roiSignalEstimator";
 import { ApiConnectionSection } from "./src/components/ApiConnectionSection";
-import { LabeledInput } from "./src/components/LabeledInput";
+import { MeasurementFormSection } from "./src/components/MeasurementFormSection";
 import { ResponseAndSummarySection } from "./src/components/ResponseAndSummarySection";
 import { RuntimeCaptureSection } from "./src/components/RuntimeCaptureSection";
 import { styles } from "./src/styles/appStyles";
@@ -861,48 +860,64 @@ export default function App() {
           onToggleRoiLock={() => setRoiLocked((current) => !current)}
         />
 
-        <Text style={styles.sectionTitle}>Session</Text>
-        <LabeledInput label="Session ID" value={sessionId} onChangeText={setSessionId} />
-        <LabeledInput label="Sync ID" value={syncId} onChangeText={setSyncId} />
-        <LabeledInput label="Site ID" value={siteId} onChangeText={setSiteId} />
-        <LabeledInput label="Subject ID" value={subjectId} onChangeText={setSubjectId} />
-        <LabeledInput label="Operator ID" value={operatorId} onChangeText={setOperatorId} />
-        <LabeledInput label="Attempt Number" value={attemptNumber} onChangeText={setAttemptNumber} keyboardType="number-pad" />
-        <LabeledInput label="Measured At (ISO)" value={measuredAt} onChangeText={setMeasuredAt} />
-        <LabeledInput
-          label="Platform (ios/android)"
-          value={platform}
-          onChangeText={setPlatform}
+        <MeasurementFormSection
+          appFlowTime={appFlowTime}
+          appModelId={appModelId}
+          appQavg={appQavg}
+          appQmax={appQmax}
+          appQualityScore={appQualityScore}
+          appQualityStatus={appQualityStatus}
+          appTqmax={appTqmax}
+          appVersion={appVersion}
+          appVvoid={appVvoid}
+          attemptNumber={attemptNumber}
+          captureMode={captureMode}
+          deviceModel={deviceModel}
+          measuredAt={measuredAt}
+          notes={notes}
+          operatorId={operatorId}
+          platform={platform}
+          refDeviceModel={refDeviceModel}
+          refDeviceSerial={refDeviceSerial}
+          refFlowTime={refFlowTime}
+          refQavg={refQavg}
+          refQmax={refQmax}
+          refTqmax={refTqmax}
+          refVvoid={refVvoid}
+          sessionId={sessionId}
+          siteId={siteId}
+          subjectId={subjectId}
+          submitting={submitting}
+          syncId={syncId}
+          onAppFlowTimeChange={setAppFlowTime}
+          onAppModelIdChange={setAppModelId}
+          onAppQavgChange={setAppQavg}
+          onAppQmaxChange={setAppQmax}
+          onAppQualityScoreChange={setAppQualityScore}
+          onAppQualityStatusChange={setAppQualityStatus}
+          onAppTqmaxChange={setAppTqmax}
+          onAppVersionChange={setAppVersion}
+          onAppVvoidChange={setAppVvoid}
+          onAttemptNumberChange={setAttemptNumber}
+          onCaptureModeChange={setCaptureMode}
+          onDeviceModelChange={setDeviceModel}
+          onMeasuredAtChange={setMeasuredAt}
+          onNotesChange={setNotes}
+          onOperatorIdChange={setOperatorId}
+          onPlatformChange={setPlatform}
+          onRefDeviceModelChange={setRefDeviceModel}
+          onRefDeviceSerialChange={setRefDeviceSerial}
+          onRefFlowTimeChange={setRefFlowTime}
+          onRefQavgChange={setRefQavg}
+          onRefQmaxChange={setRefQmax}
+          onRefTqmaxChange={setRefTqmax}
+          onRefVvoidChange={setRefVvoid}
+          onSessionIdChange={setSessionId}
+          onSiteIdChange={setSiteId}
+          onSubjectIdChange={setSubjectId}
+          onSubmit={submitPayload}
+          onSyncIdChange={setSyncId}
         />
-        <LabeledInput label="Device Model" value={deviceModel} onChangeText={setDeviceModel} />
-        <LabeledInput label="App Version" value={appVersion} onChangeText={setAppVersion} />
-        <LabeledInput label="Capture Mode" value={captureMode} onChangeText={setCaptureMode} />
-
-        <Text style={styles.sectionTitle}>App Measurement</Text>
-        <LabeledInput label="Qmax (ml/s)" value={appQmax} onChangeText={setAppQmax} keyboardType="decimal-pad" />
-        <LabeledInput label="Qavg (ml/s)" value={appQavg} onChangeText={setAppQavg} keyboardType="decimal-pad" />
-        <LabeledInput label="Vvoid (ml)" value={appVvoid} onChangeText={setAppVvoid} keyboardType="decimal-pad" />
-        <LabeledInput label="Flow Time (s)" value={appFlowTime} onChangeText={setAppFlowTime} keyboardType="decimal-pad" />
-        <LabeledInput label="TQmax (s)" value={appTqmax} onChangeText={setAppTqmax} keyboardType="decimal-pad" />
-        <LabeledInput label="Quality Status" value={appQualityStatus} onChangeText={(value) => setAppQualityStatus((value as QualityStatus) || "valid")} />
-        <LabeledInput label="Quality Score (0-100)" value={appQualityScore} onChangeText={setAppQualityScore} keyboardType="decimal-pad" />
-        <LabeledInput label="Model ID" value={appModelId} onChangeText={setAppModelId} />
-
-        <Text style={styles.sectionTitle}>Reference Uroflowmeter</Text>
-        <LabeledInput label="Qmax (ml/s)" value={refQmax} onChangeText={setRefQmax} keyboardType="decimal-pad" />
-        <LabeledInput label="Qavg (ml/s)" value={refQavg} onChangeText={setRefQavg} keyboardType="decimal-pad" />
-        <LabeledInput label="Vvoid (ml)" value={refVvoid} onChangeText={setRefVvoid} keyboardType="decimal-pad" />
-        <LabeledInput label="Flow Time (s)" value={refFlowTime} onChangeText={setRefFlowTime} keyboardType="decimal-pad" />
-        <LabeledInput label="TQmax (s)" value={refTqmax} onChangeText={setRefTqmax} keyboardType="decimal-pad" />
-        <LabeledInput label="Reference Device Model" value={refDeviceModel} onChangeText={setRefDeviceModel} />
-        <LabeledInput label="Reference Device Serial" value={refDeviceSerial} onChangeText={setRefDeviceSerial} />
-
-        <Text style={styles.sectionTitle}>Notes</Text>
-        <LabeledInput label="Notes" value={notes} onChangeText={setNotes} multiline />
-
-        <Pressable style={[styles.submitButton, submitting && styles.submitButtonDisabled]} onPress={submitPayload} disabled={submitting}>
-          <Text style={styles.submitButtonText}>{submitting ? "Submitting..." : "Submit Paired Measurement"}</Text>
-        </Pressable>
 
         <ResponseAndSummarySection
           coverageError={coverageError}

--- a/apps/field-mobile/src/components/MeasurementFormSection.tsx
+++ b/apps/field-mobile/src/components/MeasurementFormSection.tsx
@@ -1,0 +1,245 @@
+import React from "react";
+import { Pressable, Text } from "react-native";
+
+import type { QualityStatus } from "../types";
+import { styles } from "../styles/appStyles";
+import { LabeledInput } from "./LabeledInput";
+
+type MeasurementFormSectionProps = {
+  appFlowTime: string;
+  appModelId: string;
+  appQavg: string;
+  appQmax: string;
+  appQualityScore: string;
+  appQualityStatus: QualityStatus;
+  appTqmax: string;
+  appVersion: string;
+  appVvoid: string;
+  attemptNumber: string;
+  captureMode: string;
+  deviceModel: string;
+  measuredAt: string;
+  notes: string;
+  operatorId: string;
+  platform: string;
+  refDeviceModel: string;
+  refDeviceSerial: string;
+  refFlowTime: string;
+  refQavg: string;
+  refQmax: string;
+  refTqmax: string;
+  refVvoid: string;
+  sessionId: string;
+  siteId: string;
+  subjectId: string;
+  submitting: boolean;
+  syncId: string;
+  onAppFlowTimeChange: (value: string) => void;
+  onAppModelIdChange: (value: string) => void;
+  onAppQavgChange: (value: string) => void;
+  onAppQmaxChange: (value: string) => void;
+  onAppQualityScoreChange: (value: string) => void;
+  onAppQualityStatusChange: (value: QualityStatus) => void;
+  onAppTqmaxChange: (value: string) => void;
+  onAppVersionChange: (value: string) => void;
+  onAppVvoidChange: (value: string) => void;
+  onAttemptNumberChange: (value: string) => void;
+  onCaptureModeChange: (value: string) => void;
+  onDeviceModelChange: (value: string) => void;
+  onMeasuredAtChange: (value: string) => void;
+  onNotesChange: (value: string) => void;
+  onOperatorIdChange: (value: string) => void;
+  onPlatformChange: (value: string) => void;
+  onRefDeviceModelChange: (value: string) => void;
+  onRefDeviceSerialChange: (value: string) => void;
+  onRefFlowTimeChange: (value: string) => void;
+  onRefQavgChange: (value: string) => void;
+  onRefQmaxChange: (value: string) => void;
+  onRefTqmaxChange: (value: string) => void;
+  onRefVvoidChange: (value: string) => void;
+  onSessionIdChange: (value: string) => void;
+  onSiteIdChange: (value: string) => void;
+  onSubjectIdChange: (value: string) => void;
+  onSubmit: () => Promise<void>;
+  onSyncIdChange: (value: string) => void;
+};
+
+export function MeasurementFormSection({
+  appFlowTime,
+  appModelId,
+  appQavg,
+  appQmax,
+  appQualityScore,
+  appQualityStatus,
+  appTqmax,
+  appVersion,
+  appVvoid,
+  attemptNumber,
+  captureMode,
+  deviceModel,
+  measuredAt,
+  notes,
+  operatorId,
+  platform,
+  refDeviceModel,
+  refDeviceSerial,
+  refFlowTime,
+  refQavg,
+  refQmax,
+  refTqmax,
+  refVvoid,
+  sessionId,
+  siteId,
+  subjectId,
+  submitting,
+  syncId,
+  onAppFlowTimeChange,
+  onAppModelIdChange,
+  onAppQavgChange,
+  onAppQmaxChange,
+  onAppQualityScoreChange,
+  onAppQualityStatusChange,
+  onAppTqmaxChange,
+  onAppVersionChange,
+  onAppVvoidChange,
+  onAttemptNumberChange,
+  onCaptureModeChange,
+  onDeviceModelChange,
+  onMeasuredAtChange,
+  onNotesChange,
+  onOperatorIdChange,
+  onPlatformChange,
+  onRefDeviceModelChange,
+  onRefDeviceSerialChange,
+  onRefFlowTimeChange,
+  onRefQavgChange,
+  onRefQmaxChange,
+  onRefTqmaxChange,
+  onRefVvoidChange,
+  onSessionIdChange,
+  onSiteIdChange,
+  onSubjectIdChange,
+  onSubmit,
+  onSyncIdChange,
+}: MeasurementFormSectionProps) {
+  return (
+    <>
+      <Text style={styles.sectionTitle}>Session</Text>
+      <LabeledInput label="Session ID" value={sessionId} onChangeText={onSessionIdChange} />
+      <LabeledInput label="Sync ID" value={syncId} onChangeText={onSyncIdChange} />
+      <LabeledInput label="Site ID" value={siteId} onChangeText={onSiteIdChange} />
+      <LabeledInput label="Subject ID" value={subjectId} onChangeText={onSubjectIdChange} />
+      <LabeledInput label="Operator ID" value={operatorId} onChangeText={onOperatorIdChange} />
+      <LabeledInput
+        label="Attempt Number"
+        value={attemptNumber}
+        onChangeText={onAttemptNumberChange}
+        keyboardType="number-pad"
+      />
+      <LabeledInput label="Measured At (ISO)" value={measuredAt} onChangeText={onMeasuredAtChange} />
+      <LabeledInput label="Platform (ios/android)" value={platform} onChangeText={onPlatformChange} />
+      <LabeledInput label="Device Model" value={deviceModel} onChangeText={onDeviceModelChange} />
+      <LabeledInput label="App Version" value={appVersion} onChangeText={onAppVersionChange} />
+      <LabeledInput label="Capture Mode" value={captureMode} onChangeText={onCaptureModeChange} />
+
+      <Text style={styles.sectionTitle}>App Measurement</Text>
+      <LabeledInput
+        label="Qmax (ml/s)"
+        value={appQmax}
+        onChangeText={onAppQmaxChange}
+        keyboardType="decimal-pad"
+      />
+      <LabeledInput
+        label="Qavg (ml/s)"
+        value={appQavg}
+        onChangeText={onAppQavgChange}
+        keyboardType="decimal-pad"
+      />
+      <LabeledInput
+        label="Vvoid (ml)"
+        value={appVvoid}
+        onChangeText={onAppVvoidChange}
+        keyboardType="decimal-pad"
+      />
+      <LabeledInput
+        label="Flow Time (s)"
+        value={appFlowTime}
+        onChangeText={onAppFlowTimeChange}
+        keyboardType="decimal-pad"
+      />
+      <LabeledInput
+        label="TQmax (s)"
+        value={appTqmax}
+        onChangeText={onAppTqmaxChange}
+        keyboardType="decimal-pad"
+      />
+      <LabeledInput
+        label="Quality Status"
+        value={appQualityStatus}
+        onChangeText={(value) => onAppQualityStatusChange((value as QualityStatus) || "valid")}
+      />
+      <LabeledInput
+        label="Quality Score (0-100)"
+        value={appQualityScore}
+        onChangeText={onAppQualityScoreChange}
+        keyboardType="decimal-pad"
+      />
+      <LabeledInput label="Model ID" value={appModelId} onChangeText={onAppModelIdChange} />
+
+      <Text style={styles.sectionTitle}>Reference Uroflowmeter</Text>
+      <LabeledInput
+        label="Qmax (ml/s)"
+        value={refQmax}
+        onChangeText={onRefQmaxChange}
+        keyboardType="decimal-pad"
+      />
+      <LabeledInput
+        label="Qavg (ml/s)"
+        value={refQavg}
+        onChangeText={onRefQavgChange}
+        keyboardType="decimal-pad"
+      />
+      <LabeledInput
+        label="Vvoid (ml)"
+        value={refVvoid}
+        onChangeText={onRefVvoidChange}
+        keyboardType="decimal-pad"
+      />
+      <LabeledInput
+        label="Flow Time (s)"
+        value={refFlowTime}
+        onChangeText={onRefFlowTimeChange}
+        keyboardType="decimal-pad"
+      />
+      <LabeledInput
+        label="TQmax (s)"
+        value={refTqmax}
+        onChangeText={onRefTqmaxChange}
+        keyboardType="decimal-pad"
+      />
+      <LabeledInput
+        label="Reference Device Model"
+        value={refDeviceModel}
+        onChangeText={onRefDeviceModelChange}
+      />
+      <LabeledInput
+        label="Reference Device Serial"
+        value={refDeviceSerial}
+        onChangeText={onRefDeviceSerialChange}
+      />
+
+      <Text style={styles.sectionTitle}>Notes</Text>
+      <LabeledInput label="Notes" value={notes} onChangeText={onNotesChange} multiline />
+
+      <Pressable
+        style={[styles.submitButton, submitting && styles.submitButtonDisabled]}
+        onPress={() => void onSubmit()}
+        disabled={submitting}
+      >
+        <Text style={styles.submitButtonText}>
+          {submitting ? "Submitting..." : "Submit Paired Measurement"}
+        </Text>
+      </Pressable>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract the mobile paired-measurement form UI into `MeasurementFormSection`.
- Keep measurement state, payload assembly, and submit/offline queue behavior in `App.tsx` unchanged.
- Continue decomposing the mobile root component so release-readiness and field UX work can be made with lower blast radius.

## Validation

- `npm run typecheck` in `apps/field-mobile`
- `npm run validate:ci` in `apps/field-mobile`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q`
