### PR TITLE
[codex] Gate mobile EAS build on readiness

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -41,6 +41,9 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      authenticated_eas_status: ${{ steps.readiness.outputs.authenticated_eas_status }}
+      authenticated_eas_blockers: ${{ steps.readiness.outputs.authenticated_eas_blockers }}
 
     defaults:
       run:
@@ -77,6 +80,25 @@ jobs:
             --package-lock package-lock.json \
             --output /tmp/mobile-release-readiness.json
 
+      - name: Export release readiness outputs
+        id: readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads(Path("/tmp/mobile-release-readiness.json").read_text(encoding="utf-8"))
+          blockers = payload.get("authenticated_eas_blockers", [])
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
+              handle.write(
+                  f"authenticated_eas_status={payload.get('authenticated_eas_status', 'blocked')}\n"
+              )
+              handle.write(f"authenticated_eas_blockers={','.join(blockers)}\n")
+          PY
+
       - name: Publish release readiness summary
         shell: bash
         run: |
@@ -102,13 +124,16 @@ jobs:
               for item in payload.get("next_actions", [])
               if item.get("id")
           ]
+          authenticated_eas_status = payload.get("authenticated_eas_status")
+          eas_trigger_status = "enabled" if authenticated_eas_status == "pass" else "blocked"
           lines = [
               "## Mobile Release Readiness",
               f"- Status: `{payload.get('status')}`",
               f"- Local checks: `{payload.get('local_checks_status')}`",
               f"- External readiness: `{payload.get('external_readiness_status')}`",
-              f"- Authenticated EAS readiness: `{payload.get('authenticated_eas_status')}`",
+              f"- Authenticated EAS readiness: `{authenticated_eas_status}`",
               f"- Authenticated EAS blockers: `{', '.join(payload.get('authenticated_eas_blockers', [])) if payload.get('authenticated_eas_blockers') else 'none'}`",
+              f"- Authenticated EAS build trigger: `{eas_trigger_status}`",
               f"- Clinical Hub live API: `{payload.get('clinical_hub_live_api_status')}`",
               f"- Missing external items: `{', '.join(missing) if missing else 'none'}`",
               f"- Manual external items: `{', '.join(manual) if manual else 'none'}`",
@@ -153,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     needs: preflight
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && needs.preflight.outputs.authenticated_eas_status == 'pass' }}
 
     defaults:
       run:
@@ -163,23 +188,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Check EXPO_TOKEN availability
-        id: expo
-        shell: bash
-        env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${EXPO_TOKEN:-}" ]]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "EXPO_TOKEN is not configured; EAS build steps will be skipped."
-          else
-            echo "available=true" >> "$GITHUB_OUTPUT"
-            echo "EXPO_TOKEN is configured."
-          fi
-
       - name: Set up Node.js
-        if: ${{ steps.expo.outputs.available == 'true' }}
         uses: actions/setup-node@v6
         with:
           node-version: "22.13.x"
@@ -187,15 +196,12 @@ jobs:
           cache-dependency-path: apps/field-mobile/package-lock.json
 
       - name: Install dependencies
-        if: ${{ steps.expo.outputs.available == 'true' }}
         run: npm ci --no-audit --no-fund
 
       - name: Install EAS CLI
-        if: ${{ steps.expo.outputs.available == 'true' }}
         run: npm install -g eas-cli@20.0.0
 
       - name: Trigger EAS build
-        if: ${{ steps.expo.outputs.available == 'true' }}
         id: eas
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
@@ -219,7 +225,6 @@ jobs:
           echo "result_json=/tmp/eas-build-result.json" >> "$GITHUB_OUTPUT"
 
       - name: Upload EAS build result artifact
-        if: ${{ steps.expo.outputs.available == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: mobile-eas-build-result-${{ github.run_id }}
@@ -227,7 +232,6 @@ jobs:
           if-no-files-found: error
 
       - name: Publish EAS build summary
-        if: ${{ steps.expo.outputs.available == 'true' }}
         shell: bash
         env:
           RESULT_JSON: ${{ steps.eas.outputs.result_json }}

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -143,6 +143,10 @@ release handoff checklist:
 Do not commit secret values. Keep live Clinical Hub keys in GitHub Actions secrets and device-local
 app settings only.
 
+On manual `Mobile Build` dispatch, the `eas-build` job runs only when `authenticated_eas_status`
+is `pass`. If it is `blocked`, the run still uploads readiness/manifest artifacts and skips the EAS
+trigger by design.
+
 ## Installable Build (EAS)
 
 EAS profiles are configured in `apps/field-mobile/eas.json`:

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -29,7 +29,7 @@ From GitHub Actions:
    - `Clinical Hub live API` is `present` before live API smoke/report push is expected,
    - missing external items are understood and either configured or accepted as blockers for this run.
    - `Next actions` maps the remaining external blockers to concrete setup tasks.
-5. Verify `eas-build` starts.
+5. Verify `eas-build` starts. If `Authenticated EAS readiness` is `blocked`, `eas-build` is skipped by design and the readiness artifact is the handoff output.
 6. Open workflow summary (`Mobile EAS Build`) and copy build links.
 7. Download artifact `mobile-eas-build-result-<run_id>` for traceability JSON.
 


### PR DESCRIPTION
## Summary

- Export `authenticated_eas_status` from the Mobile Build preflight job.
- Gate the `eas-build` job on authenticated EAS readiness, so manual dispatches skip EAS when `EXPO_TOKEN` or EAS project identity is missing.
- Document the preflight-only behavior when authenticated EAS readiness is blocked.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/mobile-build.yml`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q`
- `npm run validate:ci` in `apps/field-mobile`
