### PR TITLE
[codex] Harden mobile pending queue sync

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -16,6 +16,8 @@ Cross-platform mobile client (Expo React Native) for collecting paired measureme
 - Retry policy: non-retryable API errors are not re-queued
 - Pending items store request header context (`x-api-key`, `x-site-id`, `x-actor-role`, `x-operator-id`)
 - Sync reuses stored header context per item (prevents wrong-site replay after settings change)
+- Pending queue preview shows error categories, not raw server response bodies
+- Sync runs in bounded batches of 10 queued jobs to avoid long foreground stalls on large offline queues
 - Auto-sync retries queued jobs every ~25s while queue is non-empty and when app becomes active
 - Queue controls: `Test API`, `Sync Queue`, `Clear Queue`
 - Persisted local settings (`API URL`, `site/operator`, timeout, summary filter)

--- a/apps/field-mobile/src/components/PendingQueuePreview.tsx
+++ b/apps/field-mobile/src/components/PendingQueuePreview.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Text, View } from "react-native";
 
 import type { PendingSubmission } from "../types";
+import { summarizePendingError } from "../utils/appHelpers";
 import { styles } from "../styles/appStyles";
 
 type PendingQueuePreviewProps = {
@@ -14,16 +15,20 @@ export function PendingQueuePreview({ pendingQueue }: PendingQueuePreviewProps) 
       <View style={styles.pendingRow}>
         <Text style={styles.pendingText}>Pending submissions: {pendingQueue.length}</Text>
       </View>
-      {pendingQueue.slice(0, 3).map((item) => (
-        <Text key={item.id} style={styles.pendingItemText}>
-          {item.id}: endpoint={item.endpoint}, attempts={item.attempt_count}
-          {item.payload.session.sync_id ? `, sync=${item.payload.session.sync_id}` : ""}
-          {item.request_headers.site_id ? `, site=${item.request_headers.site_id}` : ""}
-          {item.request_headers.actor_role ? `, role=${item.request_headers.actor_role}` : ""}
-          {item.last_status_code != null ? `, last_status=${item.last_status_code}` : ""}
-          {item.last_error ? `, last_error=${item.last_error.slice(0, 80)}` : ""}
-        </Text>
-      ))}
+      {pendingQueue.slice(0, 3).map((item) => {
+        const errorSummary = summarizePendingError(item.last_error);
+        return (
+          <Text key={item.id} style={styles.pendingItemText}>
+            {item.id}: endpoint={item.endpoint}, attempts={item.attempt_count}
+            {item.payload.session.sync_id ? `, sync=${item.payload.session.sync_id}` : ""}
+            {item.request_headers.site_id ? `, site=${item.request_headers.site_id}` : ""}
+            {item.request_headers.actor_role ? `, role=${item.request_headers.actor_role}` : ""}
+            {item.last_attempt_at ? `, last_attempt=${item.last_attempt_at}` : ""}
+            {item.last_status_code != null ? `, last_status=${item.last_status_code}` : ""}
+            {errorSummary ? `, last_error=${errorSummary}` : ""}
+          </Text>
+        );
+      })}
       {pendingQueue.length > 3 ? (
         <Text style={styles.pendingItemText}>
           ...and {pendingQueue.length - 3} more pending submissions

--- a/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
+++ b/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
@@ -14,6 +14,8 @@ import type {
 } from "../types";
 import { createPendingId, resolvePendingHeaderContext } from "../utils/appHelpers";
 
+const MAX_PENDING_SYNC_BATCH_SIZE = 10;
+
 type UsePendingSyncQueueOptions = {
   apiBaseUrl: string;
   requestTimeoutMs: string;
@@ -81,12 +83,14 @@ export function usePendingSyncQueue({
           return;
         }
 
-        const remaining: PendingSubmission[] = [];
+        const batch = queue.slice(0, MAX_PENDING_SYNC_BATCH_SIZE);
+        const deferred = queue.slice(MAX_PENDING_SYNC_BATCH_SIZE);
+        const retryableBatchItems: PendingSubmission[] = [];
         let syncedPaired = 0;
         let syncedCapture = 0;
         let droppedNonRetryable = 0;
 
-        for (const item of queue) {
+        for (const item of batch) {
           const headerContext = resolvePendingHeaderContext(item, requestHeaderContext);
           const result = await attemptSubmitEndpoint({
             apiBaseUrl,
@@ -112,18 +116,20 @@ export function usePendingSyncQueue({
             continue;
           }
           if (result.retryable) {
-            remaining.push(attemptedItem);
+            retryableBatchItems.push(attemptedItem);
             continue;
           }
           droppedNonRetryable += 1;
         }
 
+        const remaining = [...retryableBatchItems, ...deferred];
         await persistPendingQueue(remaining);
 
         const statusMessage =
-          `Sync completed. Synced paired: ${syncedPaired}, synced capture: ${syncedCapture}, ` +
-          `remaining retryable: ${remaining.length}, ` +
-          `dropped non-retryable: ${droppedNonRetryable}.`;
+          `Sync batch completed (${batch.length}/${queue.length}). ` +
+          `Synced paired: ${syncedPaired}, synced capture: ${syncedCapture}, ` +
+          `remaining queued: ${remaining.length}, ` +
+          `deferred: ${deferred.length}, dropped non-retryable: ${droppedNonRetryable}.`;
         setSyncStatusMessage(statusMessage);
         onLastResponse(statusMessage);
         if (showAlert) {

--- a/apps/field-mobile/src/utils/appHelpers.ts
+++ b/apps/field-mobile/src/utils/appHelpers.ts
@@ -64,6 +64,36 @@ export function classifyRetryable(statusCode: number | null): boolean {
   return statusCode === 408 || statusCode === 425 || statusCode === 429;
 }
 
+export function summarizePendingError(error: string | null): string | null {
+  if (!error) {
+    return null;
+  }
+  const normalized = error.toLowerCase();
+  if (
+    normalized.includes("abort") ||
+    normalized.includes("network") ||
+    normalized.includes("timed out") ||
+    normalized.includes("failed to fetch")
+  ) {
+    return "network_or_timeout";
+  }
+  if (
+    normalized.includes("unauthorized") ||
+    normalized.includes("forbidden") ||
+    normalized.includes("api key")
+  ) {
+    return "auth_or_permission";
+  }
+  if (
+    normalized.includes("validation") ||
+    normalized.includes("field required") ||
+    normalized.includes("unprocessable")
+  ) {
+    return "validation";
+  }
+  return "server_or_client_response";
+}
+
 export function normalizeActorRoleInput(rawValue: string | null | undefined): string {
   const normalized = (rawValue ?? "").trim().toLowerCase();
   if (ALLOWED_ACTOR_ROLES.includes(normalized as (typeof ALLOWED_ACTOR_ROLES)[number])) {


### PR DESCRIPTION
## Summary
- sync pending submissions in bounded batches of 10 to avoid long foreground stalls on large offline queues
- show categorized pending errors in the queue preview instead of raw server response bodies
- document bounded queue sync and sanitized pending error preview in the mobile README

## Validation
- npm run validate:ci