### PR TITLE
[codex] Use stable mobile retry request ids

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -48,6 +48,7 @@ import type {
 import {
   DEFAULT_REQUEST_TIMEOUT_MS,
   buildHeaderContextFromValues,
+  createRequestId,
   createSessionId,
   createSyncId,
   extractCreatedRecordId,
@@ -609,12 +610,16 @@ export default function App() {
 
     try {
       const requestHeaderContext = createCurrentRequestHeaderContext();
+      const pairedRequestHeaderContext: RequestHeaderContext = {
+        ...requestHeaderContext,
+        request_id: createRequestId(),
+      };
       const result = await attemptSubmitEndpoint({
         apiBaseUrl,
         requestTimeoutMs,
         endpoint: "paired_measurements",
         endpointPayload: payload,
-        headerContext: requestHeaderContext,
+        headerContext: pairedRequestHeaderContext,
       });
       if (result.ok) {
         const pairedMeasurementId = extractCreatedRecordId(result.body);
@@ -622,19 +627,23 @@ export default function App() {
           payload,
           pairedMeasurementId,
         );
+        const captureRequestHeaderContext: RequestHeaderContext = {
+          ...requestHeaderContext,
+          request_id: createRequestId(),
+        };
         const captureResult = await attemptSubmitEndpoint({
           apiBaseUrl,
           requestTimeoutMs,
           endpoint: "capture_packages",
           endpointPayload: capturePayload,
-          headerContext: requestHeaderContext,
+          headerContext: captureRequestHeaderContext,
         });
         if (!captureResult.ok) {
           if (captureResult.retryable) {
             await enqueuePendingJob(
               "capture_packages",
               capturePayload,
-              requestHeaderContext,
+              captureRequestHeaderContext,
               captureResult.body,
               captureResult.statusCode,
             );
@@ -681,17 +690,21 @@ export default function App() {
       }
 
       const capturePayloadWithoutPair = buildCapturePackagePayloadFromPaired(payload, null);
+      const captureRetryHeaderContext: RequestHeaderContext = {
+        ...requestHeaderContext,
+        request_id: createRequestId(),
+      };
       await enqueuePendingJob(
         "paired_measurements",
         payload,
-        requestHeaderContext,
+        pairedRequestHeaderContext,
         result.body,
         result.statusCode,
       );
       await enqueuePendingJob(
         "capture_packages",
         capturePayloadWithoutPair,
-        requestHeaderContext,
+        captureRetryHeaderContext,
         "queued_with_paired_retry",
         null,
       );

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -15,6 +15,7 @@ Cross-platform mobile client (Expo React Native) for collecting paired measureme
 - Offline pending queue stores both endpoint jobs: `paired-measurements` and `capture-packages`
 - Retry policy: non-retryable API errors are not re-queued
 - Pending items store request header context (`x-api-key`, `x-site-id`, `x-actor-role`, `x-operator-id`)
+- Pending retries reuse a stable `x-request-id` per endpoint job to reduce duplicate risk after timeout/retry
 - Sync reuses stored header context per item (prevents wrong-site replay after settings change)
 - Pending queue preview shows error categories, not raw server response bodies
 - Sync runs in bounded batches of 10 queued jobs to avoid long foreground stalls on large offline queues

--- a/apps/field-mobile/src/api/clinicalHub.ts
+++ b/apps/field-mobile/src/api/clinicalHub.ts
@@ -4,7 +4,7 @@ import type {
   RequestHeaderContext,
   SubmitAttemptResult,
 } from "../types";
-import { clampTimeoutMs, classifyRetryable, createPendingId } from "../utils/appHelpers";
+import { clampTimeoutMs, classifyRetryable, createRequestId } from "../utils/appHelpers";
 
 export function buildBaseUrl(apiBaseUrl: string): string {
   return apiBaseUrl.replace(/\/$/, "");
@@ -37,7 +37,7 @@ export function buildRequestHeaders(
   if (headerContext.actor_role) {
     headers["x-actor-role"] = headerContext.actor_role;
   }
-  headers["x-request-id"] = createPendingId();
+  headers["x-request-id"] = headerContext.request_id?.trim() || createRequestId();
   return headers;
 }
 

--- a/apps/field-mobile/src/components/PendingQueuePreview.tsx
+++ b/apps/field-mobile/src/components/PendingQueuePreview.tsx
@@ -21,6 +21,7 @@ export function PendingQueuePreview({ pendingQueue }: PendingQueuePreviewProps) 
           <Text key={item.id} style={styles.pendingItemText}>
             {item.id}: endpoint={item.endpoint}, attempts={item.attempt_count}
             {item.payload.session.sync_id ? `, sync=${item.payload.session.sync_id}` : ""}
+            {item.request_headers.request_id ? `, request=${item.request_headers.request_id}` : ""}
             {item.request_headers.site_id ? `, site=${item.request_headers.site_id}` : ""}
             {item.request_headers.actor_role ? `, role=${item.request_headers.actor_role}` : ""}
             {item.last_attempt_at ? `, last_attempt=${item.last_attempt_at}` : ""}

--- a/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
+++ b/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
@@ -51,12 +51,16 @@ export function usePendingSyncQueue({
       lastStatusCode: number | null,
     ): Promise<void> => {
       const queue = await loadPendingSubmissions();
+      const pendingId = createPendingId();
       const pendingItem: PendingSubmission = {
-        id: createPendingId(),
+        id: pendingId,
         created_at: new Date().toISOString(),
         endpoint,
         payload: endpointPayload,
-        request_headers: headerContext,
+        request_headers: {
+          ...headerContext,
+          request_id: headerContext.request_id || pendingId,
+        },
         attempt_count: 0,
         last_attempt_at: null,
         last_error: lastError,

--- a/apps/field-mobile/src/storage/appStorage.ts
+++ b/apps/field-mobile/src/storage/appStorage.ts
@@ -33,6 +33,7 @@ function normalizeRequestHeaderContext(
     typeof candidate.operator_id === "string"
       ? candidate.operator_id
       : payload.session.operator_id ?? "",
+    typeof candidate.request_id === "string" ? candidate.request_id : "",
   );
 }
 

--- a/apps/field-mobile/src/types.ts
+++ b/apps/field-mobile/src/types.ts
@@ -121,6 +121,7 @@ export type RequestHeaderContext = {
   actor_role: string;
   site_id: string;
   operator_id: string;
+  request_id?: string;
 };
 
 export type RoiFrameAnalysisState = {

--- a/apps/field-mobile/src/utils/appHelpers.ts
+++ b/apps/field-mobile/src/utils/appHelpers.ts
@@ -54,6 +54,10 @@ export function createPendingId(): string {
   return `PENDING-${Date.now()}-${randomPart}`;
 }
 
+export function createRequestId(): string {
+  return createPendingId();
+}
+
 export function classifyRetryable(statusCode: number | null): boolean {
   if (statusCode == null) {
     return true;
@@ -107,12 +111,14 @@ export function buildHeaderContextFromValues(
   actorRole: string,
   siteId: string,
   operatorId: string,
+  requestId?: string,
 ): RequestHeaderContext {
   return {
     api_key: apiKey.trim(),
     actor_role: normalizeActorRoleInput(actorRole),
     site_id: siteId.trim(),
     operator_id: operatorId.trim(),
+    request_id: requestId?.trim() || undefined,
   };
 }
 
@@ -168,5 +174,6 @@ export function resolvePendingHeaderContext(
     actor_role: item.request_headers.actor_role || current.actor_role,
     site_id: item.request_headers.site_id || current.site_id,
     operator_id: item.request_headers.operator_id || current.operator_id,
+    request_id: item.request_headers.request_id || item.id || current.request_id,
   };
 }

--- a/docs/mobile-install-and-field-test-runbook-v0.1.md
+++ b/docs/mobile-install-and-field-test-runbook-v0.1.md
@@ -90,6 +90,7 @@ Per subject/attempt:
 5. Enter reference metrics (`Qmax/Qavg/Vvoid` and optional time metrics).
 6. Submit paired measurement.
 7. If network failed, ensure queue item exists and run `Sync Queue` later.
+8. For retry/audit troubleshooting, match the pending item `request_id` to Clinical Hub request logs.
 
 ## 6. Daily Export For Analysis
 


### PR DESCRIPTION
## Summary
- preserve a stable x-request-id per mobile endpoint job across queued retries
- give paired and capture submissions separate request ids, then reuse those ids if they enter the pending queue
- surface request_id in pending queue preview and document audit/retry matching

## Validation
- npm run validate:ci