### PR TITLE
[codex] Add mobile helper unit tests

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -60,8 +60,9 @@ npm run typecheck
 npm run validate:ci
 ```
 
-`validate:ci` mirrors Mobile CI: TypeScript, Expo Doctor, production dependency audit,
-and Expo export bundle builds for both iOS and Android.
+`validate:ci` mirrors Mobile CI: TypeScript, Node unit tests for mobile helper/API
+invariants, Expo Doctor, production dependency audit, and Expo export bundle builds for
+both iOS and Android.
 
 3. Open on iPhone/Android via Expo Go (QR code), or run native:
 
@@ -112,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, mobile helper/API unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/package.json
+++ b/apps/field-mobile/package.json
@@ -13,11 +13,12 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "typecheck": "tsc --noEmit",
+    "test:unit": "rm -rf /tmp/uroflow-field-mobile-unit && tsc --ignoreConfig src/utils/appHelpers.ts src/api/clinicalHub.ts --outDir /tmp/uroflow-field-mobile-unit --module Node16 --target ES2022 --moduleResolution node16 --lib ES2022,DOM --skipLibCheck --esModuleInterop && MOBILE_UNIT_BUILD_DIR=/tmp/uroflow-field-mobile-unit node --test tests/*.test.js",
     "doctor": "CI=1 expo-doctor",
     "audit:prod": "npm audit --omit=dev",
     "export:ios": "CI=1 expo export --platform ios --clear --output-dir /tmp/uroflow-field-mobile-export-ios",
     "export:android": "CI=1 expo export --platform android --clear --output-dir /tmp/uroflow-field-mobile-export-android",
-    "validate:ci": "npm run typecheck && npm run doctor && npm run audit:prod && npm run export:ios && npm run export:android",
+    "validate:ci": "npm run typecheck && npm run test:unit && npm run doctor && npm run audit:prod && npm run export:ios && npm run export:android",
     "build:preview": "eas build --platform all --profile preview",
     "build:production": "eas build --platform all --profile production"
   },

--- a/apps/field-mobile/tests/appHelpers.test.js
+++ b/apps/field-mobile/tests/appHelpers.test.js
@@ -1,0 +1,154 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const helpers = require(path.join(buildDir, "utils/appHelpers.js"));
+const clinicalHub = require(path.join(buildDir, "api/clinicalHub.js"));
+
+function buildPendingSubmission(overrides = {}) {
+  return {
+    id: "PENDING-STABLE-ID",
+    created_at: "2026-06-04T00:00:00.000Z",
+    endpoint: "paired_measurements",
+    payload: {
+      session: {
+        session_id: "SESSION-001",
+        sync_id: "SYNC-001",
+        site_id: "SITE-OLD",
+        subject_id: "SUBJ-001",
+        operator_id: "OP-OLD",
+        attempt_number: 1,
+        measured_at: "2026-06-04T00:00:00Z",
+        platform: "ios",
+        device_model: "iPhone",
+        app_version: "0.1.0",
+        capture_mode: "water_impact",
+      },
+    },
+    request_headers: {
+      api_key: "",
+      actor_role: "operator",
+      site_id: "SITE-QUEUED",
+      operator_id: "OP-QUEUED",
+      request_id: "REQ-QUEUED",
+    },
+    attempt_count: 0,
+    last_attempt_at: null,
+    last_error: null,
+    last_status_code: null,
+    ...overrides,
+  };
+}
+
+test("classifyRetryable separates transient and non-retryable statuses", () => {
+  assert.equal(helpers.classifyRetryable(null), true);
+  assert.equal(helpers.classifyRetryable(408), true);
+  assert.equal(helpers.classifyRetryable(425), true);
+  assert.equal(helpers.classifyRetryable(429), true);
+  assert.equal(helpers.classifyRetryable(500), true);
+  assert.equal(helpers.classifyRetryable(503), true);
+  assert.equal(helpers.classifyRetryable(400), false);
+  assert.equal(helpers.classifyRetryable(401), false);
+  assert.equal(helpers.classifyRetryable(422), false);
+});
+
+test("summarizePendingError redacts raw response bodies into safe categories", () => {
+  assert.equal(helpers.summarizePendingError(null), null);
+  assert.equal(helpers.summarizePendingError("AbortError: request timed out"), "network_or_timeout");
+  assert.equal(helpers.summarizePendingError("Unauthorized: bad API key"), "auth_or_permission");
+  assert.equal(helpers.summarizePendingError("Validation error: field required"), "validation");
+  assert.equal(helpers.summarizePendingError("HTTP 503 upstream unavailable"), "server_or_client_response");
+});
+
+test("buildHeaderContextFromValues normalizes operator context and preserves request id", () => {
+  assert.deepEqual(
+    helpers.buildHeaderContextFromValues(
+      "  secret-key  ",
+      " Investigator ",
+      " SITE-001 ",
+      " OP-01 ",
+      " REQ-001 ",
+    ),
+    {
+      api_key: "secret-key",
+      actor_role: "investigator",
+      site_id: "SITE-001",
+      operator_id: "OP-01",
+      request_id: "REQ-001",
+    },
+  );
+  assert.equal(
+    helpers.buildHeaderContextFromValues("", "unknown-role", "", "").actor_role,
+    "operator",
+  );
+});
+
+test("resolvePendingHeaderContext reuses queued request id and queued site context", () => {
+  const current = {
+    api_key: "current-key",
+    actor_role: "admin",
+    site_id: "SITE-CURRENT",
+    operator_id: "OP-CURRENT",
+    request_id: "REQ-CURRENT",
+  };
+  assert.deepEqual(helpers.resolvePendingHeaderContext(buildPendingSubmission(), current), {
+    api_key: "current-key",
+    actor_role: "operator",
+    site_id: "SITE-QUEUED",
+    operator_id: "OP-QUEUED",
+    request_id: "REQ-QUEUED",
+  });
+});
+
+test("resolvePendingHeaderContext falls back to pending id for migrated queue items", () => {
+  const item = buildPendingSubmission({
+    request_headers: {
+      api_key: "",
+      actor_role: "",
+      site_id: "",
+      operator_id: "",
+    },
+  });
+  const resolved = helpers.resolvePendingHeaderContext(item, {
+    api_key: "current-key",
+    actor_role: "data_manager",
+    site_id: "SITE-CURRENT",
+    operator_id: "OP-CURRENT",
+    request_id: "REQ-CURRENT",
+  });
+  assert.equal(resolved.request_id, "PENDING-STABLE-ID");
+  assert.equal(resolved.actor_role, "data_manager");
+  assert.equal(resolved.site_id, "SITE-CURRENT");
+});
+
+test("buildRequestHeaders uses stable request id when provided", () => {
+  const headers = clinicalHub.buildRequestHeaders(true, {
+    api_key: "secret-key",
+    actor_role: "operator",
+    site_id: "SITE-001",
+    operator_id: "OP-01",
+    request_id: "REQ-STABLE",
+  });
+  assert.equal(headers["Content-Type"], "application/json");
+  assert.equal(headers["x-api-key"], "secret-key");
+  assert.equal(headers["x-actor-role"], "operator");
+  assert.equal(headers["x-site-id"], "SITE-001");
+  assert.equal(headers["x-operator-id"], "OP-01");
+  assert.equal(headers["x-request-id"], "REQ-STABLE");
+});
+
+test("buildRequestHeaders creates a request id fallback without leaking empty headers", () => {
+  const headers = clinicalHub.buildRequestHeaders(false, {
+    api_key: "",
+    actor_role: "operator",
+    site_id: "",
+    operator_id: "",
+  });
+  assert.equal(headers["Content-Type"], undefined);
+  assert.equal(headers["x-api-key"], undefined);
+  assert.equal(headers["x-site-id"], undefined);
+  assert.equal(headers["x-operator-id"], undefined);
+  assert.equal(headers["x-actor-role"], "operator");
+  assert.match(headers["x-request-id"], /^PENDING-\d+-[a-z0-9]+$/);
+});


### PR DESCRIPTION
## Summary
- add Node unit tests for mobile helper/API invariants around retryability, pending error redaction, request header normalization, and stable x-request-id behavior
- wire the unit test step into apps/field-mobile validate:ci
- document that Mobile CI now covers helper/API unit tests in addition to typecheck, Expo Doctor, audit, and exports

## Validation
- npm run test:unit
- npm run validate:ci