### PR TITLE
[codex] Add mobile capture contract unit tests

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -60,9 +60,9 @@ npm run typecheck
 npm run validate:ci
 ```
 
-`validate:ci` mirrors Mobile CI: TypeScript, Node unit tests for mobile helper/API
-invariants, Expo Doctor, production dependency audit, and Expo export bundle builds for
-both iOS and Android.
+`validate:ci` mirrors Mobile CI: TypeScript, Node unit tests for mobile helper/API and
+capture-contract invariants, Expo Doctor, production dependency audit, and Expo export
+bundle builds for both iOS and Android.
 
 3. Open on iPhone/Android via Expo Go (QR code), or run native:
 
@@ -113,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, mobile helper/API unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, mobile helper/API + capture-contract unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/package.json
+++ b/apps/field-mobile/package.json
@@ -13,7 +13,7 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "typecheck": "tsc --noEmit",
-    "test:unit": "rm -rf /tmp/uroflow-field-mobile-unit && tsc --ignoreConfig src/utils/appHelpers.ts src/api/clinicalHub.ts --outDir /tmp/uroflow-field-mobile-unit --module Node16 --target ES2022 --moduleResolution node16 --lib ES2022,DOM --skipLibCheck --esModuleInterop && MOBILE_UNIT_BUILD_DIR=/tmp/uroflow-field-mobile-unit node --test tests/*.test.js",
+    "test:unit": "scripts/run-unit-tests.sh",
     "doctor": "CI=1 expo-doctor",
     "audit:prod": "npm audit --omit=dev",
     "export:ios": "CI=1 expo export --platform ios --clear --output-dir /tmp/uroflow-field-mobile-export-ios",

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+BUILD_DIR="${MOBILE_UNIT_BUILD_DIR:-/tmp/uroflow-field-mobile-unit}"
+
+rm -rf "$BUILD_DIR"
+tsc --ignoreConfig \
+  src/utils/appHelpers.ts \
+  src/api/clinicalHub.ts \
+  src/capture/buildCaptureContract.ts \
+  --outDir "$BUILD_DIR" \
+  --module Node16 \
+  --target ES2022 \
+  --moduleResolution node16 \
+  --lib ES2022,DOM \
+  --skipLibCheck \
+  --esModuleInterop
+
+MOBILE_UNIT_BUILD_DIR="$BUILD_DIR" node --test tests/*.test.js

--- a/apps/field-mobile/tests/captureContract.test.js
+++ b/apps/field-mobile/tests/captureContract.test.js
@@ -1,0 +1,157 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const capture = require(path.join(buildDir, "capture/buildCaptureContract.js"));
+
+test("buildCaptureContractPayload creates privacy-preserving scaffold payloads", () => {
+  const payload = capture.buildCaptureContractPayload({
+    sessionId: "SESSION-001",
+    syncId: "SYNC-001",
+    startedAtIso: "2026-06-04T01:02:03Z",
+    captureMode: "water_impact",
+    deviceModel: " iPhone 15 ",
+    iosVersion: "19.0",
+    appVersion: " 0.1.0 ",
+    qmaxMlS: 12.5,
+    qavgMlS: 8.1,
+    flowTimeS: 4,
+  });
+
+  assert.equal(payload.schema_version, "ios_capture_v1");
+  assert.equal(payload.session.session_id, "SESSION-001");
+  assert.equal(payload.session.sync_id, "SYNC-001");
+  assert.equal(payload.session.started_at, "2026-06-04T01:02:03.000Z");
+  assert.equal(payload.session.device.model, "iPhone 15");
+  assert.deepEqual(payload.session.privacy, {
+    store_raw_video: false,
+    store_raw_audio: false,
+    roi_only: true,
+  });
+  assert.equal(payload.session.calibration.ml_per_mm, 8);
+  assert.equal(payload.session.calibration.min_depth_confidence, 0.6);
+  assert.ok(payload.samples.length >= 8);
+  assert.equal(payload.samples.every((sample) => sample.roi_valid === true), true);
+  assert.equal(payload.samples.every((sample) => sample.t_s >= 0), true);
+});
+
+test("buildCaptureContractPayloadFromSamples creates fallback samples for empty runtime input", () => {
+  const payload = capture.buildCaptureContractPayloadFromSamples({
+    sessionId: "SESSION-EMPTY",
+    syncId: null,
+    startedAtIso: "2026-06-04T01:02:03Z",
+    captureMode: "water_impact",
+    deviceModel: "",
+    iosVersion: "android-16",
+    appVersion: "",
+    samples: [],
+    minDepthConfidence: 0.7,
+    cameraDistanceMm: 700,
+    sourceLabel: " runtime-audio-imu ",
+  });
+
+  assert.equal(payload.session.device.model, "unknown-device-runtime-audio-imu");
+  assert.equal(payload.session.app.version, "0.1.0");
+  assert.equal(payload.session.calibration.min_depth_confidence, 0.7);
+  assert.equal(payload.session.calibration.camera_distance_mm, 700);
+  assert.equal(payload.samples.length, 2);
+  assert.deepEqual(
+    payload.samples.map((sample) => sample.t_s),
+    [0, 0.5],
+  );
+  assert.equal(payload.analysis, undefined);
+});
+
+test("buildCaptureContractPayloadFromSamples duplicates one-sample runtime captures safely", () => {
+  const payload = capture.buildCaptureContractPayloadFromSamples({
+    sessionId: "SESSION-ONE",
+    syncId: "SYNC-ONE",
+    startedAtIso: "2026-06-04T01:02:03Z",
+    captureMode: "water_impact",
+    deviceModel: "Pixel",
+    iosVersion: "android-16",
+    appVersion: "0.1.0",
+    samples: [
+      {
+        t_s: 7,
+        depth_level_mm: 1.23456,
+        rgb_level_mm: 1.1,
+        depth_confidence: 0.91,
+        audio_rms_dbfs: -42,
+        motion_norm: 0.03,
+        roi_valid: true,
+      },
+    ],
+  });
+
+  assert.equal(payload.samples.length, 2);
+  assert.equal(payload.samples[0].t_s, 0);
+  assert.equal(payload.samples[1].t_s, 0.5);
+  assert.equal(payload.samples[1].depth_level_mm, 1.23456);
+});
+
+test("buildCaptureContractPayloadFromSamples sanitizes runtime analysis", () => {
+  const flowSeries = Array.from({ length: 130 }, (_, index) => ({
+    t_s: index / 10,
+    flow_ml_s: index === 3 ? -10 : index,
+  }));
+  flowSeries.push({ t_s: -1, flow_ml_s: 99 });
+  flowSeries.push({ t_s: Number.POSITIVE_INFINITY, flow_ml_s: 99 });
+
+  const payload = capture.buildCaptureContractPayloadFromSamples({
+    sessionId: "SESSION-ANALYSIS",
+    syncId: "SYNC-ANALYSIS",
+    startedAtIso: "2026-06-04T01:02:03Z",
+    captureMode: "water_impact",
+    deviceModel: "iPhone",
+    iosVersion: "19.0",
+    appVersion: "0.1.0",
+    samples: [
+      {
+        t_s: 0,
+        depth_level_mm: 0,
+        rgb_level_mm: 0,
+        depth_confidence: 0.9,
+        audio_rms_dbfs: -45,
+        motion_norm: 0.02,
+        roi_valid: true,
+      },
+      {
+        t_s: 0.5,
+        depth_level_mm: 0.2,
+        rgb_level_mm: 0.19,
+        depth_confidence: 0.8,
+        audio_rms_dbfs: -44,
+        motion_norm: 0.03,
+        roi_valid: true,
+      },
+    ],
+    analysis: {
+      runtime_flow_series: flowSeries,
+      runtime_quality: {
+        quality_score: -5,
+        quality_status: "repeat",
+        roi_valid_ratio: 2,
+        low_confidence_ratio: -1,
+      },
+    },
+  });
+
+  assert.ok(payload.analysis);
+  assert.ok(payload.analysis.runtime_flow_series.length <= 121);
+  assert.deepEqual(payload.analysis.runtime_flow_series.at(-1), {
+    t_s: 12.9,
+    flow_ml_s: 129,
+  });
+  assert.equal(
+    payload.analysis.runtime_flow_series.some((point) => point.t_s < 0),
+    false,
+  );
+  assert.deepEqual(payload.analysis.runtime_quality, {
+    quality_score: 0,
+    quality_status: "repeat",
+    roi_valid_ratio: 1,
+    low_confidence_ratio: 0,
+  });
+});


### PR DESCRIPTION
## Summary
- add capture contract unit tests for scaffold payload privacy/defaults, runtime sample fallback, one-sample duplication, and runtime analysis sanitization
- move mobile unit-test build command into scripts/run-unit-tests.sh so more pure TS modules can be covered without bloating package.json
- document that validate:ci now covers helper/API and capture-contract unit tests

## Validation
- npm run test:unit
- npm run validate:ci