### PR TITLE
[codex] Report mobile unit test readiness evidence

### DIFF
--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -49,7 +49,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - selected build profile/channel.
 
 Workflow also generates artifact `mobile-release-readiness` containing:
-- local mobile readiness checks (`app.json`, `eas.json`, package scripts, lockfile, pinned tooling),
+- local mobile readiness checks (`app.json`, `eas.json`, package scripts, lockfile, pinned tooling, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status,

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -171,6 +171,7 @@ def build_readiness_report(
     scripts = package_payload.get("scripts", {})
     root_lock = lock_payload.get("packages", {}).get("", {})
     eas_build = eas_payload.get("build", {})
+    mobile_root = package_json.parent
 
     checks: list[dict[str, Any]] = []
 
@@ -255,6 +256,41 @@ def build_readiness_report(
         "validate_ci_script",
         "validate:ci" in scripts,
         "package script validate:ci is present",
+    )
+    validate_ci_script = scripts.get("validate:ci", "")
+    test_unit_script = scripts.get("test:unit", "")
+    unit_runner_path = mobile_root / "scripts" / "run-unit-tests.sh"
+    helper_tests_path = mobile_root / "tests" / "appHelpers.test.js"
+    capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
+    _check(
+        checks,
+        "unit_test_script",
+        bool(test_unit_script),
+        "package script test:unit is present",
+    )
+    _check(
+        checks,
+        "validate_ci_runs_unit_tests",
+        "npm run test:unit" in validate_ci_script,
+        f"validate:ci={validate_ci_script!r}",
+    )
+    _check(
+        checks,
+        "unit_test_runner_script",
+        unit_runner_path.is_file(),
+        f"path={unit_runner_path}",
+    )
+    _check(
+        checks,
+        "mobile_helper_unit_tests_present",
+        helper_tests_path.is_file(),
+        f"path={helper_tests_path}",
+    )
+    _check(
+        checks,
+        "capture_contract_unit_tests_present",
+        capture_tests_path.is_file(),
+        f"path={capture_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -53,6 +53,14 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "expo_token",
     }
     assert all(item["status"] == "pass" for item in payload["local_checks"])
+    local_check_ids = {item["id"] for item in payload["local_checks"]}
+    assert {
+        "unit_test_script",
+        "validate_ci_runs_unit_tests",
+        "unit_test_runner_script",
+        "mobile_helper_unit_tests_present",
+        "capture_contract_unit_tests_present",
+    }.issubset(local_check_ids)
     assert {item["id"] for item in payload["next_actions"]} == {
         "configure_clinical_hub_live_api",
         "configure_eas_project_identity",


### PR DESCRIPTION
## Summary
- include mobile unit-test wiring in the release readiness local checks
- assert readiness JSON reports test:unit, validate:ci unit-test execution, runner script, helper tests, and capture-contract tests
- document unit-test coverage wiring in the mobile release runbook readiness artifact section

## Validation
- .venv/bin/pytest tests/test_mobile_release_readiness_script.py -q
- python3 scripts/check_mobile_release_readiness.py ... --output /tmp/mobile-release-readiness-unit-evidence.json
- .venv/bin/ruff check . && .venv/bin/pytest -q
- npm run validate:ci