### PR TITLE
[codex] Add mobile ROI signal unit tests

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -60,9 +60,9 @@ npm run typecheck
 npm run validate:ci
 ```
 
-`validate:ci` mirrors Mobile CI: TypeScript, Node unit tests for mobile helper/API and
-capture-contract invariants, Expo Doctor, production dependency audit, and Expo export
-bundle builds for both iOS and Android.
+`validate:ci` mirrors Mobile CI: TypeScript, Node unit tests for mobile helper/API,
+capture-contract, and ROI signal invariants, Expo Doctor, production dependency audit,
+and Expo export bundle builds for both iOS and Android.
 
 3. Open on iPhone/Android via Expo Go (QR code), or run native:
 
@@ -113,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, mobile helper/API + capture-contract unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, mobile helper/API + capture-contract + ROI signal unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -8,6 +8,7 @@ tsc --ignoreConfig \
   src/utils/appHelpers.ts \
   src/api/clinicalHub.ts \
   src/capture/buildCaptureContract.ts \
+  src/capture/roiSignalEstimator.ts \
   --outDir "$BUILD_DIR" \
   --module Node16 \
   --target ES2022 \

--- a/apps/field-mobile/tests/roiSignalEstimator.test.js
+++ b/apps/field-mobile/tests/roiSignalEstimator.test.js
@@ -1,0 +1,63 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const roi = require(path.join(buildDir, "capture/roiSignalEstimator.js"));
+
+const texturedFrame =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".repeat(16);
+
+test("estimateRoiSignalFromBase64 rejects low-texture frames", () => {
+  const signal = roi.estimateRoiSignalFromBase64({
+    frameBase64: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    prevHash: null,
+    prevLength: null,
+  });
+
+  assert.equal(signal.frameLength, 32);
+  assert.equal(signal.motionProxy, 0);
+  assert.equal(signal.textureProxy, 0);
+  assert.equal(signal.roiValid, false);
+});
+
+test("estimateRoiSignalFromBase64 accepts textured stable frames", () => {
+  const signal = roi.estimateRoiSignalFromBase64({
+    frameBase64: texturedFrame,
+    prevHash: null,
+    prevLength: null,
+  });
+
+  assert.ok(signal.textureProxy > 0.18);
+  assert.equal(signal.motionProxy, 0);
+  assert.equal(signal.roiValid, true);
+});
+
+test("estimateRoiSignalFromBase64 is deterministic for the same frame", () => {
+  const first = roi.estimateRoiSignalFromBase64({
+    frameBase64: texturedFrame,
+    prevHash: null,
+    prevLength: null,
+  });
+  const second = roi.estimateRoiSignalFromBase64({
+    frameBase64: texturedFrame,
+    prevHash: first.frameHash,
+    prevLength: first.frameLength,
+  });
+
+  assert.equal(second.frameHash, first.frameHash);
+  assert.equal(second.frameLength, first.frameLength);
+  assert.equal(second.motionProxy, 0);
+  assert.equal(second.roiValid, true);
+});
+
+test("estimateRoiSignalFromBase64 rejects high-motion frame transitions", () => {
+  const signal = roi.estimateRoiSignalFromBase64({
+    frameBase64: texturedFrame,
+    prevHash: 0,
+    prevLength: 1,
+  });
+
+  assert.equal(signal.motionProxy, 1);
+  assert.equal(signal.roiValid, false);
+});

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -262,6 +262,7 @@ def build_readiness_report(
     unit_runner_path = mobile_root / "scripts" / "run-unit-tests.sh"
     helper_tests_path = mobile_root / "tests" / "appHelpers.test.js"
     capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
+    roi_signal_tests_path = mobile_root / "tests" / "roiSignalEstimator.test.js"
     _check(
         checks,
         "unit_test_script",
@@ -291,6 +292,12 @@ def build_readiness_report(
         "capture_contract_unit_tests_present",
         capture_tests_path.is_file(),
         f"path={capture_tests_path}",
+    )
+    _check(
+        checks,
+        "roi_signal_unit_tests_present",
+        roi_signal_tests_path.is_file(),
+        f"path={roi_signal_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -60,6 +60,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "unit_test_runner_script",
         "mobile_helper_unit_tests_present",
         "capture_contract_unit_tests_present",
+        "roi_signal_unit_tests_present",
     }.issubset(local_check_ids)
     assert {item["id"] for item in payload["next_actions"]} == {
         "configure_clinical_hub_live_api",


### PR DESCRIPTION
## Summary
- add Node unit tests for ROI signal estimator validity, texture, determinism, and high-motion rejection
- include roiSignalEstimator.ts in the mobile unit-test compilation path
- report ROI signal unit-test presence in mobile release readiness local checks

## Validation
- npm run test:unit
- .venv/bin/pytest tests/test_mobile_release_readiness_script.py -q
- python3 scripts/check_mobile_release_readiness.py ... --output /tmp/mobile-release-readiness-roi-tests.json
- .venv/bin/ruff check . && .venv/bin/pytest -q
- npm run validate:ci