### PR TITLE
[codex] Extract mobile runtime metrics for unit testing

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -61,8 +61,8 @@ npm run validate:ci
 ```
 
 `validate:ci` mirrors Mobile CI: TypeScript, Node unit tests for mobile helper/API,
-capture-contract, and ROI signal invariants, Expo Doctor, production dependency audit,
-and Expo export bundle builds for both iOS and Android.
+capture-contract, ROI signal, and runtime metric/quality invariants, Expo Doctor,
+production dependency audit, and Expo export bundle builds for both iOS and Android.
 
 3. Open on iPhone/Android via Expo Go (QR code), or run native:
 
@@ -113,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, mobile helper/API + capture-contract + ROI signal unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, mobile helper/API + capture-contract + ROI signal + runtime metric unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -8,6 +8,7 @@ tsc --ignoreConfig \
   src/utils/appHelpers.ts \
   src/api/clinicalHub.ts \
   src/capture/buildCaptureContract.ts \
+  src/capture/runtimeMetrics.ts \
   src/capture/roiSignalEstimator.ts \
   --outDir "$BUILD_DIR" \
   --module Node16 \

--- a/apps/field-mobile/src/capture/runtimeCaptureSession.ts
+++ b/apps/field-mobile/src/capture/runtimeCaptureSession.ts
@@ -11,29 +11,24 @@ import { Accelerometer } from "expo-sensors";
 import { Camera } from "expo-camera";
 import * as Device from "expo-device";
 import type { CaptureContractSample } from "./buildCaptureContract";
+import {
+  calculateAverageMotionNorm,
+  clamp,
+  deriveRuntimeCaptureMetrics,
+  round4,
+  scoreRuntimeCaptureQuality,
+  type RuntimeCaptureDerivedMetrics,
+  type RuntimeCapturePermissions,
+  type RuntimeCaptureQuality,
+  type RuntimeFlowPoint,
+} from "./runtimeMetrics";
 
-export type RuntimeCapturePermissions = {
-  microphoneGranted: boolean;
-  cameraGranted: boolean;
-  motionGranted: boolean;
-};
-
-export type RuntimeCaptureDerivedMetrics = {
-  qmaxMlS: number;
-  qavgMlS: number;
-  vvoidMl: number;
-  flowTimeS: number;
-  tqmaxS: number;
-  eventStartTs: number | null;
-  eventEndTs: number | null;
-};
-
-export type RuntimeCaptureQuality = {
-  qualityScore: number;
-  qualityStatus: "valid" | "repeat" | "reject";
-  roiValidRatio: number;
-  lowConfidenceRatio: number;
-};
+export type {
+  RuntimeCaptureDerivedMetrics,
+  RuntimeCapturePermissions,
+  RuntimeCaptureQuality,
+  RuntimeFlowPoint,
+} from "./runtimeMetrics";
 
 export type RuntimeCaptureStopResult = {
   startedAtIso: string;
@@ -57,36 +52,9 @@ export type RuntimeCameraSignal = {
   roiValidByFrame?: boolean;
 };
 
-export type RuntimeFlowPoint = {
-  t_s: number;
-  flow_ml_s: number;
-};
-
 type AccelerometerWithPermissions = typeof Accelerometer & {
   requestPermissionsAsync?: () => Promise<{ granted: boolean }>;
 };
-
-function clamp(value: number, minValue: number, maxValue: number): number {
-  return Math.max(minValue, Math.min(maxValue, value));
-}
-
-function round4(value: number): number {
-  return Math.round(value * 10000) / 10000;
-}
-
-function integrateTrapezoid(series: RuntimeFlowPoint[]): number {
-  if (series.length < 2) {
-    return 0;
-  }
-  let sum = 0;
-  for (let index = 1; index < series.length; index += 1) {
-    const prev = series[index - 1];
-    const curr = series[index];
-    const dt = Math.max(0, curr.t_s - prev.t_s);
-    sum += ((prev.flow_ml_s + curr.flow_ml_s) * 0.5) * dt;
-  }
-  return sum;
-}
 
 export class RuntimeCaptureSession {
   private recording: AudioRecorder | null = null;
@@ -238,12 +206,16 @@ export class RuntimeCaptureSession {
       this.flowSeries = this.samples.map((sample) => ({ t_s: sample.t_s, flow_ml_s: 0 }));
     }
 
-    const avgMotionNorm =
-      this.samples.reduce((sum, item) => sum + item.motion_norm, 0) /
-      Math.max(1, this.samples.length);
-
-    const derived = this.computeDerivedMetrics();
-    const quality = this.computeQuality(avgMotionNorm);
+    const avgMotionNorm = calculateAverageMotionNorm(this.samples);
+    const derived = deriveRuntimeCaptureMetrics({
+      samples: this.samples,
+      flowSeries: this.flowSeries,
+      permissions: this.permissions,
+    });
+    const quality = scoreRuntimeCaptureQuality({
+      samples: this.samples,
+      averageMotionNorm: avgMotionNorm,
+    });
 
     return {
       startedAtIso: this.startedAtIso || new Date().toISOString(),
@@ -257,131 +229,6 @@ export class RuntimeCaptureSession {
       flowSeries: [...this.flowSeries],
       derived,
       quality,
-    };
-  }
-
-  private computeDerivedMetrics(): RuntimeCaptureDerivedMetrics {
-    if (this.flowSeries.length === 0) {
-      return {
-        qmaxMlS: 0,
-        qavgMlS: 0,
-        vvoidMl: 0,
-        flowTimeS: 0,
-        tqmaxS: 0,
-        eventStartTs: null,
-        eventEndTs: null,
-      };
-    }
-
-    const startThreshold = 1.0;
-    const stopThreshold = 0.8;
-    const sampleCount = Math.max(1, this.samples.length);
-    const roiValidRatio =
-      this.samples.filter((sample) => sample.roi_valid).length / sampleCount;
-    const enforceRoiForEventBounds = this.permissions.cameraGranted && roiValidRatio >= 0.25;
-
-    let startIndex = -1;
-    for (let i = 0; i < this.flowSeries.length; i += 1) {
-      const roiGate = !enforceRoiForEventBounds || this.samples[i]?.roi_valid;
-      if (this.flowSeries[i].flow_ml_s >= startThreshold && roiGate) {
-        startIndex = i;
-        break;
-      }
-    }
-    if (startIndex < 0) {
-      for (let i = 0; i < this.flowSeries.length; i += 1) {
-        if (this.flowSeries[i].flow_ml_s >= startThreshold) {
-          startIndex = i;
-          break;
-        }
-      }
-    }
-
-    let endIndex = -1;
-    for (let i = this.flowSeries.length - 1; i >= 0; i -= 1) {
-      const roiGate = !enforceRoiForEventBounds || this.samples[i]?.roi_valid;
-      if (this.flowSeries[i].flow_ml_s >= stopThreshold && roiGate) {
-        endIndex = i;
-        break;
-      }
-    }
-    if (endIndex < 0) {
-      for (let i = this.flowSeries.length - 1; i >= 0; i -= 1) {
-        if (this.flowSeries[i].flow_ml_s >= stopThreshold) {
-          endIndex = i;
-          break;
-        }
-      }
-    }
-
-    const eventStartTs = startIndex >= 0 ? this.flowSeries[startIndex].t_s : null;
-    const eventEndTs =
-      endIndex >= 0 && startIndex >= 0 && endIndex >= startIndex
-        ? this.flowSeries[endIndex].t_s
-        : null;
-
-    const qmax = this.flowSeries.reduce(
-      (acc, point) => Math.max(acc, point.flow_ml_s),
-      0,
-    );
-
-    const vvoid = integrateTrapezoid(this.flowSeries);
-
-    let flowTimeS = 0;
-    let qavg = 0;
-    let tqmax = 0;
-
-    if (eventStartTs != null && eventEndTs != null && eventEndTs >= eventStartTs) {
-      flowTimeS = eventEndTs - eventStartTs;
-      const activeSeries = this.flowSeries.filter(
-        (point) => point.t_s >= eventStartTs && point.t_s <= eventEndTs,
-      );
-      if (activeSeries.length > 0) {
-        qavg = activeSeries.reduce((sum, point) => sum + point.flow_ml_s, 0) / activeSeries.length;
-        const qmaxPoint = activeSeries.reduce((best, point) =>
-          point.flow_ml_s > best.flow_ml_s ? point : best,
-        activeSeries[0]);
-        tqmax = Math.max(0, qmaxPoint.t_s - eventStartTs);
-      }
-    }
-
-    return {
-      qmaxMlS: round4(qmax),
-      qavgMlS: round4(qavg),
-      vvoidMl: round4(vvoid),
-      flowTimeS: round4(flowTimeS),
-      tqmaxS: round4(tqmax),
-      eventStartTs,
-      eventEndTs,
-    };
-  }
-
-  private computeQuality(averageMotionNorm: number): RuntimeCaptureQuality {
-    const sampleCount = Math.max(1, this.samples.length);
-    const roiValidCount = this.samples.filter((sample) => sample.roi_valid).length;
-    const lowConfidenceCount = this.samples.filter((sample) => sample.depth_confidence < 0.6).length;
-
-    const roiValidRatio = roiValidCount / sampleCount;
-    const lowConfidenceRatio = lowConfidenceCount / sampleCount;
-
-    let score = 100;
-    score -= clamp(averageMotionNorm * 80, 0, 60);
-    score -= clamp((1 - roiValidRatio) * 70, 0, 50);
-    score -= clamp(lowConfidenceRatio * 40, 0, 25);
-    score = clamp(score, 0, 100);
-
-    let qualityStatus: RuntimeCaptureQuality["qualityStatus"] = "valid";
-    if (score < 50 || roiValidRatio < 0.55) {
-      qualityStatus = "reject";
-    } else if (score < 75 || roiValidRatio < 0.8 || lowConfidenceRatio > 0.35) {
-      qualityStatus = "repeat";
-    }
-
-    return {
-      qualityScore: round4(score),
-      qualityStatus,
-      roiValidRatio: round4(roiValidRatio),
-      lowConfidenceRatio: round4(lowConfidenceRatio),
     };
   }
 

--- a/apps/field-mobile/src/capture/runtimeMetrics.ts
+++ b/apps/field-mobile/src/capture/runtimeMetrics.ts
@@ -1,0 +1,188 @@
+import type { CaptureContractSample } from "./buildCaptureContract";
+
+export type RuntimeCapturePermissions = {
+  microphoneGranted: boolean;
+  cameraGranted: boolean;
+  motionGranted: boolean;
+};
+
+export type RuntimeCaptureDerivedMetrics = {
+  qmaxMlS: number;
+  qavgMlS: number;
+  vvoidMl: number;
+  flowTimeS: number;
+  tqmaxS: number;
+  eventStartTs: number | null;
+  eventEndTs: number | null;
+};
+
+export type RuntimeCaptureQuality = {
+  qualityScore: number;
+  qualityStatus: "valid" | "repeat" | "reject";
+  roiValidRatio: number;
+  lowConfidenceRatio: number;
+};
+
+export type RuntimeFlowPoint = {
+  t_s: number;
+  flow_ml_s: number;
+};
+
+export function clamp(value: number, minValue: number, maxValue: number): number {
+  return Math.max(minValue, Math.min(maxValue, value));
+}
+
+export function round4(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+export function calculateAverageMotionNorm(samples: CaptureContractSample[]): number {
+  return (
+    samples.reduce((sum, item) => sum + item.motion_norm, 0) / Math.max(1, samples.length)
+  );
+}
+
+export function integrateRuntimeFlowSeries(series: RuntimeFlowPoint[]): number {
+  if (series.length < 2) {
+    return 0;
+  }
+  let sum = 0;
+  for (let index = 1; index < series.length; index += 1) {
+    const prev = series[index - 1];
+    const curr = series[index];
+    const dt = Math.max(0, curr.t_s - prev.t_s);
+    sum += ((prev.flow_ml_s + curr.flow_ml_s) * 0.5) * dt;
+  }
+  return sum;
+}
+
+export function deriveRuntimeCaptureMetrics(input: {
+  samples: CaptureContractSample[];
+  flowSeries: RuntimeFlowPoint[];
+  permissions: Pick<RuntimeCapturePermissions, "cameraGranted">;
+}): RuntimeCaptureDerivedMetrics {
+  if (input.flowSeries.length === 0) {
+    return {
+      qmaxMlS: 0,
+      qavgMlS: 0,
+      vvoidMl: 0,
+      flowTimeS: 0,
+      tqmaxS: 0,
+      eventStartTs: null,
+      eventEndTs: null,
+    };
+  }
+
+  const startThreshold = 1.0;
+  const stopThreshold = 0.8;
+  const sampleCount = Math.max(1, input.samples.length);
+  const roiValidRatio =
+    input.samples.filter((sample) => sample.roi_valid).length / sampleCount;
+  const enforceRoiForEventBounds = input.permissions.cameraGranted && roiValidRatio >= 0.25;
+
+  let startIndex = -1;
+  for (let i = 0; i < input.flowSeries.length; i += 1) {
+    const roiGate = !enforceRoiForEventBounds || input.samples[i]?.roi_valid;
+    if (input.flowSeries[i].flow_ml_s >= startThreshold && roiGate) {
+      startIndex = i;
+      break;
+    }
+  }
+  if (startIndex < 0) {
+    for (let i = 0; i < input.flowSeries.length; i += 1) {
+      if (input.flowSeries[i].flow_ml_s >= startThreshold) {
+        startIndex = i;
+        break;
+      }
+    }
+  }
+
+  let endIndex = -1;
+  for (let i = input.flowSeries.length - 1; i >= 0; i -= 1) {
+    const roiGate = !enforceRoiForEventBounds || input.samples[i]?.roi_valid;
+    if (input.flowSeries[i].flow_ml_s >= stopThreshold && roiGate) {
+      endIndex = i;
+      break;
+    }
+  }
+  if (endIndex < 0) {
+    for (let i = input.flowSeries.length - 1; i >= 0; i -= 1) {
+      if (input.flowSeries[i].flow_ml_s >= stopThreshold) {
+        endIndex = i;
+        break;
+      }
+    }
+  }
+
+  const eventStartTs = startIndex >= 0 ? input.flowSeries[startIndex].t_s : null;
+  const eventEndTs =
+    endIndex >= 0 && startIndex >= 0 && endIndex >= startIndex
+      ? input.flowSeries[endIndex].t_s
+      : null;
+
+  const qmax = input.flowSeries.reduce(
+    (acc, point) => Math.max(acc, point.flow_ml_s),
+    0,
+  );
+  const vvoid = integrateRuntimeFlowSeries(input.flowSeries);
+
+  let flowTimeS = 0;
+  let qavg = 0;
+  let tqmax = 0;
+
+  if (eventStartTs != null && eventEndTs != null && eventEndTs >= eventStartTs) {
+    flowTimeS = eventEndTs - eventStartTs;
+    const activeSeries = input.flowSeries.filter(
+      (point) => point.t_s >= eventStartTs && point.t_s <= eventEndTs,
+    );
+    if (activeSeries.length > 0) {
+      qavg = activeSeries.reduce((sum, point) => sum + point.flow_ml_s, 0) / activeSeries.length;
+      const qmaxPoint = activeSeries.reduce((best, point) =>
+        point.flow_ml_s > best.flow_ml_s ? point : best,
+      activeSeries[0]);
+      tqmax = Math.max(0, qmaxPoint.t_s - eventStartTs);
+    }
+  }
+
+  return {
+    qmaxMlS: round4(qmax),
+    qavgMlS: round4(qavg),
+    vvoidMl: round4(vvoid),
+    flowTimeS: round4(flowTimeS),
+    tqmaxS: round4(tqmax),
+    eventStartTs,
+    eventEndTs,
+  };
+}
+
+export function scoreRuntimeCaptureQuality(input: {
+  samples: CaptureContractSample[];
+  averageMotionNorm: number;
+}): RuntimeCaptureQuality {
+  const sampleCount = Math.max(1, input.samples.length);
+  const roiValidCount = input.samples.filter((sample) => sample.roi_valid).length;
+  const lowConfidenceCount = input.samples.filter((sample) => sample.depth_confidence < 0.6).length;
+
+  const roiValidRatio = roiValidCount / sampleCount;
+  const lowConfidenceRatio = lowConfidenceCount / sampleCount;
+
+  let score = 100;
+  score -= clamp(input.averageMotionNorm * 80, 0, 60);
+  score -= clamp((1 - roiValidRatio) * 70, 0, 50);
+  score -= clamp(lowConfidenceRatio * 40, 0, 25);
+  score = clamp(score, 0, 100);
+
+  let qualityStatus: RuntimeCaptureQuality["qualityStatus"] = "valid";
+  if (score < 50 || roiValidRatio < 0.55) {
+    qualityStatus = "reject";
+  } else if (score < 75 || roiValidRatio < 0.8 || lowConfidenceRatio > 0.35) {
+    qualityStatus = "repeat";
+  }
+
+  return {
+    qualityScore: round4(score),
+    qualityStatus,
+    roiValidRatio: round4(roiValidRatio),
+    lowConfidenceRatio: round4(lowConfidenceRatio),
+  };
+}

--- a/apps/field-mobile/tests/runtimeMetrics.test.js
+++ b/apps/field-mobile/tests/runtimeMetrics.test.js
@@ -1,0 +1,151 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const runtime = require(path.join(buildDir, "capture/runtimeMetrics.js"));
+
+function sample(overrides = {}) {
+  return {
+    t_s: 0,
+    depth_level_mm: 0,
+    rgb_level_mm: 0,
+    depth_confidence: 0.9,
+    audio_rms_dbfs: -45,
+    motion_norm: 0.05,
+    roi_valid: true,
+    ...overrides,
+  };
+}
+
+test("deriveRuntimeCaptureMetrics computes event bounds and flow metrics", () => {
+  const metrics = runtime.deriveRuntimeCaptureMetrics({
+    permissions: { cameraGranted: true },
+    samples: [
+      sample({ t_s: 0 }),
+      sample({ t_s: 1 }),
+      sample({ t_s: 2 }),
+      sample({ t_s: 3 }),
+      sample({ t_s: 4 }),
+    ],
+    flowSeries: [
+      { t_s: 0, flow_ml_s: 0.5 },
+      { t_s: 1, flow_ml_s: 2 },
+      { t_s: 2, flow_ml_s: 4 },
+      { t_s: 3, flow_ml_s: 1 },
+      { t_s: 4, flow_ml_s: 0.4 },
+    ],
+  });
+
+  assert.deepEqual(metrics, {
+    qmaxMlS: 4,
+    qavgMlS: 2.3333,
+    vvoidMl: 7.45,
+    flowTimeS: 2,
+    tqmaxS: 1,
+    eventStartTs: 1,
+    eventEndTs: 3,
+  });
+});
+
+test("deriveRuntimeCaptureMetrics uses ROI gates when enough valid ROI samples exist", () => {
+  const metrics = runtime.deriveRuntimeCaptureMetrics({
+    permissions: { cameraGranted: true },
+    samples: [
+      sample({ t_s: 0, roi_valid: false }),
+      sample({ t_s: 1, roi_valid: true }),
+      sample({ t_s: 2, roi_valid: true }),
+      sample({ t_s: 3, roi_valid: true }),
+    ],
+    flowSeries: [
+      { t_s: 0, flow_ml_s: 5 },
+      { t_s: 1, flow_ml_s: 1.5 },
+      { t_s: 2, flow_ml_s: 0.9 },
+      { t_s: 3, flow_ml_s: 0.2 },
+    ],
+  });
+
+  assert.equal(metrics.eventStartTs, 1);
+  assert.equal(metrics.eventEndTs, 2);
+  assert.equal(metrics.tqmaxS, 0);
+});
+
+test("deriveRuntimeCaptureMetrics falls back to flow-only bounds when ROI is unavailable", () => {
+  const metrics = runtime.deriveRuntimeCaptureMetrics({
+    permissions: { cameraGranted: true },
+    samples: [
+      sample({ t_s: 0, roi_valid: false }),
+      sample({ t_s: 1, roi_valid: false }),
+      sample({ t_s: 2, roi_valid: false }),
+    ],
+    flowSeries: [
+      { t_s: 0, flow_ml_s: 2 },
+      { t_s: 1, flow_ml_s: 1 },
+      { t_s: 2, flow_ml_s: 0.1 },
+    ],
+  });
+
+  assert.equal(metrics.eventStartTs, 0);
+  assert.equal(metrics.eventEndTs, 1);
+});
+
+test("scoreRuntimeCaptureQuality classifies valid, repeat, and reject captures", () => {
+  assert.equal(
+    runtime.scoreRuntimeCaptureQuality({
+      averageMotionNorm: 0.1,
+      samples: [sample(), sample(), sample(), sample()],
+    }).qualityStatus,
+    "valid",
+  );
+
+  const repeat = runtime.scoreRuntimeCaptureQuality({
+    averageMotionNorm: 0.05,
+    samples: [
+      sample(),
+      sample(),
+      sample(),
+      sample({ roi_valid: false }),
+    ],
+  });
+  assert.equal(repeat.qualityStatus, "repeat");
+  assert.equal(repeat.roiValidRatio, 0.75);
+
+  const reject = runtime.scoreRuntimeCaptureQuality({
+    averageMotionNorm: 0.05,
+    samples: [
+      sample(),
+      sample({ roi_valid: false }),
+      sample({ roi_valid: false }),
+      sample({ roi_valid: false }),
+    ],
+  });
+  assert.equal(reject.qualityStatus, "reject");
+  assert.equal(reject.roiValidRatio, 0.25);
+});
+
+test("scoreRuntimeCaptureQuality repeats high low-confidence captures", () => {
+  const quality = runtime.scoreRuntimeCaptureQuality({
+    averageMotionNorm: 0.05,
+    samples: [
+      sample(),
+      sample(),
+      sample({ depth_confidence: 0.4 }),
+      sample({ depth_confidence: 0.4 }),
+      sample(),
+    ],
+  });
+
+  assert.equal(quality.qualityStatus, "repeat");
+  assert.equal(quality.lowConfidenceRatio, 0.4);
+});
+
+test("calculateAverageMotionNorm handles empty samples", () => {
+  assert.equal(runtime.calculateAverageMotionNorm([]), 0);
+  assert.equal(
+    runtime.calculateAverageMotionNorm([
+      sample({ motion_norm: 0.1 }),
+      sample({ motion_norm: 0.3 }),
+    ]),
+    0.2,
+  );
+});

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -263,6 +263,7 @@ def build_readiness_report(
     helper_tests_path = mobile_root / "tests" / "appHelpers.test.js"
     capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
     roi_signal_tests_path = mobile_root / "tests" / "roiSignalEstimator.test.js"
+    runtime_metrics_tests_path = mobile_root / "tests" / "runtimeMetrics.test.js"
     _check(
         checks,
         "unit_test_script",
@@ -298,6 +299,12 @@ def build_readiness_report(
         "roi_signal_unit_tests_present",
         roi_signal_tests_path.is_file(),
         f"path={roi_signal_tests_path}",
+    )
+    _check(
+        checks,
+        "runtime_metrics_unit_tests_present",
+        runtime_metrics_tests_path.is_file(),
+        f"path={runtime_metrics_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -61,6 +61,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "mobile_helper_unit_tests_present",
         "capture_contract_unit_tests_present",
         "roi_signal_unit_tests_present",
+        "runtime_metrics_unit_tests_present",
     }.issubset(local_check_ids)
     assert {item["id"] for item in payload["next_actions"]} == {
         "configure_clinical_hub_live_api",


### PR DESCRIPTION
## Summary
- move runtime derived metrics and quality scoring into a pure runtimeMetrics module
- keep RuntimeCaptureSession public type exports stable while delegating Qmax/Qavg/Vvoid/event/quality calculations to the pure module
- add Node unit tests for event bounds, ROI-gated fallback behavior, volume integration, quality thresholds, and average motion handling
- report runtime metrics unit-test presence in mobile release readiness checks

## Validation
- npm run test:unit
- .venv/bin/pytest tests/test_mobile_release_readiness_script.py -q
- python3 scripts/check_mobile_release_readiness.py ... --output /tmp/mobile-release-readiness-runtime-metrics.json
- .venv/bin/ruff check . && .venv/bin/pytest -q
- npm run validate:ci