### PR TITLE
[codex] Sanitize mobile runtime capture samples

### DIFF
--- a/apps/field-mobile/src/capture/buildCaptureContract.ts
+++ b/apps/field-mobile/src/capture/buildCaptureContract.ts
@@ -129,6 +129,41 @@ function sanitizeRuntimeFlowSeries(
   return reduced;
 }
 
+function sanitizeNullableLevel(value: number | null): number | null {
+  if (value == null || !Number.isFinite(value)) {
+    return null;
+  }
+  return round4(Math.max(0, value));
+}
+
+function sanitizeSample(sample: CaptureContractSample): CaptureContractSample | null {
+  if (!Number.isFinite(sample.t_s) || sample.t_s < 0) {
+    return null;
+  }
+  return {
+    t_s: round4(sample.t_s),
+    depth_level_mm: sanitizeNullableLevel(sample.depth_level_mm),
+    rgb_level_mm: sanitizeNullableLevel(sample.rgb_level_mm),
+    depth_confidence: Number.isFinite(sample.depth_confidence)
+      ? round4(clamp(sample.depth_confidence, 0, 1))
+      : 0,
+    audio_rms_dbfs: Number.isFinite(sample.audio_rms_dbfs)
+      ? round4(clamp(sample.audio_rms_dbfs, -120, 0))
+      : -120,
+    motion_norm: Number.isFinite(sample.motion_norm)
+      ? round4(clamp(sample.motion_norm, 0, 1))
+      : 1,
+    roi_valid: sample.roi_valid === true,
+  };
+}
+
+function sanitizeRuntimeSamples(samples: CaptureContractSample[]): CaptureContractSample[] {
+  return samples
+    .map((sample) => sanitizeSample(sample))
+    .filter((sample): sample is CaptureContractSample => sample != null)
+    .sort((a, b) => a.t_s - b.t_s);
+}
+
 function sanitizeAnalysis(
   analysis: CaptureContractAnalysis | undefined,
 ): CaptureContractAnalysis | undefined {
@@ -248,7 +283,7 @@ export function buildCaptureContractPayloadFromSamples(
   const model = input.deviceModel?.trim() || "unknown-device";
   const appVersion = input.appVersion?.trim() || "0.1.0";
   const source = input.sourceLabel?.trim();
-  let safeSamples: CaptureContractSample[] = input.samples;
+  let safeSamples: CaptureContractSample[] = sanitizeRuntimeSamples(input.samples);
   if (safeSamples.length === 0) {
     safeSamples = [
       {

--- a/apps/field-mobile/tests/captureContract.test.js
+++ b/apps/field-mobile/tests/captureContract.test.js
@@ -88,7 +88,69 @@ test("buildCaptureContractPayloadFromSamples duplicates one-sample runtime captu
   assert.equal(payload.samples.length, 2);
   assert.equal(payload.samples[0].t_s, 0);
   assert.equal(payload.samples[1].t_s, 0.5);
-  assert.equal(payload.samples[1].depth_level_mm, 1.23456);
+  assert.equal(payload.samples[1].depth_level_mm, 1.2346);
+});
+
+test("buildCaptureContractPayloadFromSamples sanitizes malformed runtime samples", () => {
+  const payload = capture.buildCaptureContractPayloadFromSamples({
+    sessionId: "SESSION-SANITIZE",
+    syncId: "SYNC-SANITIZE",
+    startedAtIso: "2026-06-04T01:02:03Z",
+    captureMode: "water_impact",
+    deviceModel: "iPhone",
+    iosVersion: "19.0",
+    appVersion: "0.1.0",
+    samples: [
+      {
+        t_s: 2.123456,
+        depth_level_mm: -1,
+        rgb_level_mm: Number.POSITIVE_INFINITY,
+        depth_confidence: 2,
+        audio_rms_dbfs: 6,
+        motion_norm: 2,
+        roi_valid: "yes",
+      },
+      {
+        t_s: -1,
+        depth_level_mm: 99,
+        rgb_level_mm: 99,
+        depth_confidence: 0.9,
+        audio_rms_dbfs: -30,
+        motion_norm: 0.1,
+        roi_valid: true,
+      },
+      {
+        t_s: 0.5,
+        depth_level_mm: Number.NaN,
+        rgb_level_mm: 0.123456,
+        depth_confidence: Number.NaN,
+        audio_rms_dbfs: Number.NaN,
+        motion_norm: Number.NaN,
+        roi_valid: true,
+      },
+    ],
+  });
+
+  assert.deepEqual(payload.samples, [
+    {
+      t_s: 0.5,
+      depth_level_mm: null,
+      rgb_level_mm: 0.1235,
+      depth_confidence: 0,
+      audio_rms_dbfs: -120,
+      motion_norm: 1,
+      roi_valid: true,
+    },
+    {
+      t_s: 2.1235,
+      depth_level_mm: 0,
+      rgb_level_mm: null,
+      depth_confidence: 1,
+      audio_rms_dbfs: 0,
+      motion_norm: 1,
+      roi_valid: false,
+    },
+  ]);
 });
 
 test("buildCaptureContractPayloadFromSamples sanitizes runtime analysis", () => {


### PR DESCRIPTION
## What changed

- Sanitizes runtime capture samples before building `ios_capture_v1` payloads.
- Drops malformed samples with negative or non-finite timestamps.
- Rounds/sorts timestamps and level readings, normalizes invalid nullable levels to `null`, and clamps confidence, audio, and motion fields into payload-safe ranges.
- Keeps existing empty-sample fallback and one-sample duplication behavior after sanitization.

## Why

Mobile capture payloads should remain deterministic and safe even when runtime sensors produce malformed, missing, or out-of-range values. This closes another edge in the offline/mobile readiness path before upload or queued retry.

## Validation

Already run locally on this branch before push:

- `npm run test:unit` in `apps/field-mobile` (`22` tests passed)
- `.venv/bin/ruff check . && .venv/bin/pytest -q` (`95` Python tests passed)
- `npm run validate:ci` in `apps/field-mobile` including TypeScript, unit tests, Expo Doctor, audit, and iOS/Android exports
