### PR TITLE
[codex] Add traceability to mobile readiness artifact

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -120,7 +120,7 @@ CI:
   - `wait_for_build` (`true` / `false`)
 - `mobile-build` uploads:
   - `mobile-release-manifest` (version + git SHA + model/schema traceability)
-  - `mobile-release-readiness` (local readiness checks + explicit external credential blockers)
+  - `mobile-release-readiness` (git traceability + local readiness checks + explicit external credential blockers)
   - `mobile-eas-build-result-<run_id>` (raw EAS JSON response for build IDs/URLs)
 - Workflow summary includes release readiness status and direct EAS build links for operator/release use.
 

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -49,6 +49,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - selected build profile/channel.
 
 Workflow also generates artifact `mobile-release-readiness` containing:
+- git SHA/ref/run-id/workflow traceability,
 - local mobile readiness checks (`app.json`, `eas.json`, package scripts, lockfile, pinned tooling, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -47,6 +47,15 @@ def _check(
     )
 
 
+def _build_traceability(env: dict[str, str]) -> dict[str, str]:
+    return {
+        "git_sha": env.get("GITHUB_SHA", "local"),
+        "git_ref": env.get("GITHUB_REF", "local"),
+        "git_run_id": env.get("GITHUB_RUN_ID", "local"),
+        "workflow": env.get("GITHUB_WORKFLOW", "local"),
+    }
+
+
 def _build_next_actions(
     external_items: list[dict[str, Any]],
     manual_external_items: list[dict[str, Any]],
@@ -404,6 +413,7 @@ def build_readiness_report(
 
     return {
         "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "traceability": _build_traceability(env),
         "status": status,
         "local_checks_status": "pass" if not local_failures else "fail",
         "external_readiness_status": "pass" if not external_missing else "blocked",

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -47,6 +47,12 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
     assert payload["authenticated_eas_status"] == "blocked"
     assert payload["authenticated_eas_blockers"] == ["expo_token", "eas_project_identity"]
     assert payload["clinical_hub_live_api_status"] == "missing"
+    assert payload["traceability"] == {
+        "git_ref": "local",
+        "git_run_id": "local",
+        "git_sha": "local",
+        "workflow": "local",
+    }
     assert {item["id"] for item in payload["external_items"] if item["status"] == "missing"} == {
         "clinical_hub_live_api",
         "eas_project_identity",
@@ -86,6 +92,10 @@ def test_mobile_release_readiness_passes_authenticated_preflight_env(tmp_path: P
             "CLINICAL_HUB_URL": "https://clinical.example.test",
             "EAS_PROJECT_ID": "00000000-0000-0000-0000-000000000000",
             "EXPO_TOKEN": "test-token",
+            "GITHUB_REF": "refs/heads/main",
+            "GITHUB_RUN_ID": "123456",
+            "GITHUB_SHA": "abc123",
+            "GITHUB_WORKFLOW": "Mobile Build",
         },
     )
 
@@ -95,6 +105,12 @@ def test_mobile_release_readiness_passes_authenticated_preflight_env(tmp_path: P
     assert payload["authenticated_eas_status"] == "pass"
     assert payload["authenticated_eas_blockers"] == []
     assert payload["clinical_hub_live_api_status"] == "present"
+    assert payload["traceability"] == {
+        "git_ref": "refs/heads/main",
+        "git_run_id": "123456",
+        "git_sha": "abc123",
+        "workflow": "Mobile Build",
+    }
     assert all(item["status"] == "present" for item in payload["external_items"])
     assert {item["status"] for item in payload["manual_external_items"]} == {"manual_required"}
     assert {item["id"] for item in payload["next_actions"]} == {


### PR DESCRIPTION
## What changed

- Adds a `traceability` object to `mobile-release-readiness.json` with GitHub SHA, ref, run id, and workflow name.
- Keeps local/default generation deterministic by using `local` when GitHub Actions environment values are absent.
- Updates mobile README and release runbook wording so the documented readiness artifact matches the generated JSON.

## Why

The manifest already carried GitHub traceability, but the readiness artifact did not. Adding the same run identity directly to readiness makes release/build audits self-contained: the blocker/status report can now be tied back to the exact workflow run without pairing it with a separate manifest first.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`95` tests passed)
- Local readiness generation with synthetic GitHub env confirmed `traceability` in output while preserving `ready_except_external_credentials`.
