### PR TITLE
[codex] Add pending sync queue unit coverage

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -113,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, mobile helper/API + capture-contract + ROI signal + runtime metric unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, mobile helper/API + capture-contract + ROI signal + runtime metric + pending queue unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -2,10 +2,12 @@
 set -eu
 
 BUILD_DIR="${MOBILE_UNIT_BUILD_DIR:-/tmp/uroflow-field-mobile-unit}"
+TEST_FILES=""
 
 rm -rf "$BUILD_DIR"
 tsc --ignoreConfig \
   src/utils/appHelpers.ts \
+  src/utils/pendingSyncQueue.ts \
   src/api/clinicalHub.ts \
   src/capture/buildCaptureContract.ts \
   src/capture/runtimeMetrics.ts \
@@ -18,4 +20,13 @@ tsc --ignoreConfig \
   --skipLibCheck \
   --esModuleInterop
 
-MOBILE_UNIT_BUILD_DIR="$BUILD_DIR" node --test tests/*.test.js
+if command -v git >/dev/null 2>&1 && git rev-parse --show-toplevel >/dev/null 2>&1; then
+  TEST_FILES="$(git ls-files --cached --others --exclude-standard 'tests/*.test.js')"
+fi
+if [ -z "$TEST_FILES" ]; then
+  TEST_FILES="$(find tests -maxdepth 1 -name '*.test.js' | sort)"
+fi
+
+# Test filenames are repo-controlled and intentionally do not contain spaces.
+# shellcheck disable=SC2086
+MOBILE_UNIT_BUILD_DIR="$BUILD_DIR" node --test $TEST_FILES

--- a/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
+++ b/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
@@ -13,8 +13,11 @@ import type {
   RequestHeaderContext,
 } from "../types";
 import { createPendingId, resolvePendingHeaderContext } from "../utils/appHelpers";
-
-const MAX_PENDING_SYNC_BATCH_SIZE = 10;
+import {
+  buildPendingSyncAttempt,
+  buildPendingSyncStatusMessage,
+  splitPendingSyncBatch,
+} from "../utils/pendingSyncQueue";
 
 type UsePendingSyncQueueOptions = {
   apiBaseUrl: string;
@@ -87,8 +90,7 @@ export function usePendingSyncQueue({
           return;
         }
 
-        const batch = queue.slice(0, MAX_PENDING_SYNC_BATCH_SIZE);
-        const deferred = queue.slice(MAX_PENDING_SYNC_BATCH_SIZE);
+        const { batch, deferred } = splitPendingSyncBatch(queue);
         const retryableBatchItems: PendingSubmission[] = [];
         let syncedPaired = 0;
         let syncedCapture = 0;
@@ -103,24 +105,22 @@ export function usePendingSyncQueue({
             endpointPayload: item.payload,
             headerContext,
           });
-          const attemptedItem: PendingSubmission = {
-            ...item,
-            request_headers: headerContext,
-            attempt_count: item.attempt_count + 1,
-            last_attempt_at: new Date().toISOString(),
-            last_status_code: result.statusCode,
-            last_error: result.ok ? null : result.body,
-          };
-          if (result.ok) {
-            if (item.endpoint === "capture_packages") {
-              syncedCapture += 1;
-            } else {
-              syncedPaired += 1;
-            }
+          const attempt = buildPendingSyncAttempt({
+            item,
+            headerContext,
+            result,
+            attemptedAtIso: new Date().toISOString(),
+          });
+          if (attempt.outcome === "synced_capture") {
+            syncedCapture += 1;
             continue;
           }
-          if (result.retryable) {
-            retryableBatchItems.push(attemptedItem);
+          if (attempt.outcome === "synced_paired") {
+            syncedPaired += 1;
+            continue;
+          }
+          if (attempt.outcome === "retryable") {
+            retryableBatchItems.push(attempt.attemptedItem);
             continue;
           }
           droppedNonRetryable += 1;
@@ -129,11 +129,15 @@ export function usePendingSyncQueue({
         const remaining = [...retryableBatchItems, ...deferred];
         await persistPendingQueue(remaining);
 
-        const statusMessage =
-          `Sync batch completed (${batch.length}/${queue.length}). ` +
-          `Synced paired: ${syncedPaired}, synced capture: ${syncedCapture}, ` +
-          `remaining queued: ${remaining.length}, ` +
-          `deferred: ${deferred.length}, dropped non-retryable: ${droppedNonRetryable}.`;
+        const statusMessage = buildPendingSyncStatusMessage({
+          batchCount: batch.length,
+          totalCount: queue.length,
+          syncedPaired,
+          syncedCapture,
+          remainingQueued: remaining.length,
+          deferred: deferred.length,
+          droppedNonRetryable,
+        });
         setSyncStatusMessage(statusMessage);
         onLastResponse(statusMessage);
         if (showAlert) {

--- a/apps/field-mobile/src/utils/pendingSyncQueue.ts
+++ b/apps/field-mobile/src/utils/pendingSyncQueue.ts
@@ -1,0 +1,82 @@
+import type {
+  PendingSubmission,
+  RequestHeaderContext,
+  SubmitAttemptResult,
+} from "../types";
+
+export const MAX_PENDING_SYNC_BATCH_SIZE = 10;
+
+export type PendingSyncItemOutcome =
+  | "synced_paired"
+  | "synced_capture"
+  | "retryable"
+  | "dropped_non_retryable";
+
+export type PendingSyncAttempt = {
+  attemptedItem: PendingSubmission;
+  outcome: PendingSyncItemOutcome;
+};
+
+export type PendingSyncStatusSummary = {
+  batchCount: number;
+  totalCount: number;
+  syncedPaired: number;
+  syncedCapture: number;
+  remainingQueued: number;
+  deferred: number;
+  droppedNonRetryable: number;
+};
+
+export function splitPendingSyncBatch(
+  queue: PendingSubmission[],
+  maxBatchSize = MAX_PENDING_SYNC_BATCH_SIZE,
+): { batch: PendingSubmission[]; deferred: PendingSubmission[] } {
+  const batchSize = Number.isFinite(maxBatchSize)
+    ? Math.max(0, Math.floor(maxBatchSize))
+    : MAX_PENDING_SYNC_BATCH_SIZE;
+  return {
+    batch: queue.slice(0, batchSize),
+    deferred: queue.slice(batchSize),
+  };
+}
+
+export function buildPendingSyncAttempt(options: {
+  item: PendingSubmission;
+  headerContext: RequestHeaderContext;
+  result: SubmitAttemptResult;
+  attemptedAtIso: string;
+}): PendingSyncAttempt {
+  const attemptCount = Number.isFinite(options.item.attempt_count)
+    ? Math.max(0, Math.floor(options.item.attempt_count))
+    : 0;
+  const attemptedItem: PendingSubmission = {
+    ...options.item,
+    request_headers: options.headerContext,
+    attempt_count: attemptCount + 1,
+    last_attempt_at: options.attemptedAtIso,
+    last_status_code: options.result.statusCode,
+    last_error: options.result.ok ? null : options.result.body,
+  };
+
+  if (options.result.ok) {
+    return {
+      attemptedItem,
+      outcome:
+        options.item.endpoint === "capture_packages" ? "synced_capture" : "synced_paired",
+    };
+  }
+
+  return {
+    attemptedItem,
+    outcome: options.result.retryable ? "retryable" : "dropped_non_retryable",
+  };
+}
+
+export function buildPendingSyncStatusMessage(summary: PendingSyncStatusSummary): string {
+  return (
+    `Sync batch completed (${summary.batchCount}/${summary.totalCount}). ` +
+    `Synced paired: ${summary.syncedPaired}, synced capture: ${summary.syncedCapture}, ` +
+    `remaining queued: ${summary.remainingQueued}, ` +
+    `deferred: ${summary.deferred}, dropped non-retryable: ${summary.droppedNonRetryable}.`
+  );
+}

--- a/apps/field-mobile/tests/pendingSyncQueue.test.js
+++ b/apps/field-mobile/tests/pendingSyncQueue.test.js
@@ -1,0 +1,152 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const pending = require(path.join(buildDir, "utils/pendingSyncQueue.js"));
+
+function buildPayload(syncId = "SYNC-001") {
+  return {
+    session: {
+      session_id: "SESSION-001",
+      sync_id: syncId,
+      site_id: "SITE-001",
+      subject_id: "SUBJ-001",
+      operator_id: "OP-001",
+      attempt_number: 1,
+      measured_at: "2026-06-04T00:00:00Z",
+      platform: "ios",
+      device_model: "iPhone",
+      app_version: "0.1.0",
+      capture_mode: "water_impact",
+    },
+  };
+}
+
+function buildPendingSubmission(overrides = {}) {
+  return {
+    id: "PENDING-001",
+    created_at: "2026-06-04T00:00:00.000Z",
+    endpoint: "paired_measurements",
+    payload: buildPayload(),
+    request_headers: {
+      api_key: "",
+      actor_role: "operator",
+      site_id: "SITE-QUEUED",
+      operator_id: "OP-QUEUED",
+      request_id: "REQ-QUEUED",
+    },
+    attempt_count: 0,
+    last_attempt_at: null,
+    last_error: null,
+    last_status_code: null,
+    ...overrides,
+  };
+}
+
+test("splitPendingSyncBatch caps sync batches and preserves deferred order", () => {
+  const queue = Array.from({ length: 12 }, (_, index) =>
+    buildPendingSubmission({ id: `PENDING-${String(index).padStart(3, "0")}` }),
+  );
+
+  const { batch, deferred } = pending.splitPendingSyncBatch(queue);
+
+  assert.equal(batch.length, pending.MAX_PENDING_SYNC_BATCH_SIZE);
+  assert.equal(deferred.length, 2);
+  assert.equal(batch[0].id, "PENDING-000");
+  assert.equal(batch.at(-1).id, "PENDING-009");
+  assert.deepEqual(
+    deferred.map((item) => item.id),
+    ["PENDING-010", "PENDING-011"],
+  );
+});
+
+test("buildPendingSyncAttempt records successful capture package submissions", () => {
+  const headerContext = {
+    api_key: "current-key",
+    actor_role: "admin",
+    site_id: "SITE-CURRENT",
+    operator_id: "OP-CURRENT",
+    request_id: "REQ-CURRENT",
+  };
+
+  const attempt = pending.buildPendingSyncAttempt({
+    item: buildPendingSubmission({
+      endpoint: "capture_packages",
+      payload: {
+        session: buildPayload("SYNC-CAPTURE").session,
+        package_type: "capture_contract_json",
+        capture_payload: {},
+        paired_measurement_id: null,
+        notes: null,
+      },
+      attempt_count: 2,
+      last_error: "previous failure",
+      last_status_code: 503,
+    }),
+    headerContext,
+    result: { ok: true, statusCode: 201, body: '{"id":7}', retryable: false },
+    attemptedAtIso: "2026-06-04T01:02:03.000Z",
+  });
+
+  assert.equal(attempt.outcome, "synced_capture");
+  assert.equal(attempt.attemptedItem.attempt_count, 3);
+  assert.equal(attempt.attemptedItem.last_attempt_at, "2026-06-04T01:02:03.000Z");
+  assert.equal(attempt.attemptedItem.last_status_code, 201);
+  assert.equal(attempt.attemptedItem.last_error, null);
+  assert.deepEqual(attempt.attemptedItem.request_headers, headerContext);
+});
+
+test("buildPendingSyncAttempt keeps retryable failures queued with attempt metadata", () => {
+  const attempt = pending.buildPendingSyncAttempt({
+    item: buildPendingSubmission({ attempt_count: Number.NaN }),
+    headerContext: {
+      api_key: "current-key",
+      actor_role: "operator",
+      site_id: "SITE-CURRENT",
+      operator_id: "OP-CURRENT",
+      request_id: "REQ-CURRENT",
+    },
+    result: { ok: false, statusCode: 503, body: "upstream unavailable", retryable: true },
+    attemptedAtIso: "2026-06-04T01:02:03.000Z",
+  });
+
+  assert.equal(attempt.outcome, "retryable");
+  assert.equal(attempt.attemptedItem.attempt_count, 1);
+  assert.equal(attempt.attemptedItem.last_status_code, 503);
+  assert.equal(attempt.attemptedItem.last_error, "upstream unavailable");
+});
+
+test("buildPendingSyncAttempt drops non-retryable failed paired submissions", () => {
+  const attempt = pending.buildPendingSyncAttempt({
+    item: buildPendingSubmission(),
+    headerContext: {
+      api_key: "current-key",
+      actor_role: "operator",
+      site_id: "SITE-CURRENT",
+      operator_id: "OP-CURRENT",
+      request_id: "REQ-CURRENT",
+    },
+    result: { ok: false, statusCode: 422, body: "validation error", retryable: false },
+    attemptedAtIso: "2026-06-04T01:02:03.000Z",
+  });
+
+  assert.equal(attempt.outcome, "dropped_non_retryable");
+  assert.equal(attempt.attemptedItem.attempt_count, 1);
+  assert.equal(attempt.attemptedItem.last_status_code, 422);
+});
+
+test("buildPendingSyncStatusMessage preserves operator-facing sync wording", () => {
+  assert.equal(
+    pending.buildPendingSyncStatusMessage({
+      batchCount: 10,
+      totalCount: 12,
+      syncedPaired: 3,
+      syncedCapture: 2,
+      remainingQueued: 7,
+      deferred: 2,
+      droppedNonRetryable: 1,
+    }),
+    "Sync batch completed (10/12). Synced paired: 3, synced capture: 2, remaining queued: 7, deferred: 2, dropped non-retryable: 1.",
+  );
+});

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -273,6 +273,7 @@ def build_readiness_report(
     capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
     roi_signal_tests_path = mobile_root / "tests" / "roiSignalEstimator.test.js"
     runtime_metrics_tests_path = mobile_root / "tests" / "runtimeMetrics.test.js"
+    pending_sync_queue_tests_path = mobile_root / "tests" / "pendingSyncQueue.test.js"
     _check(
         checks,
         "unit_test_script",
@@ -314,6 +315,12 @@ def build_readiness_report(
         "runtime_metrics_unit_tests_present",
         runtime_metrics_tests_path.is_file(),
         f"path={runtime_metrics_tests_path}",
+    )
+    _check(
+        checks,
+        "pending_sync_queue_unit_tests_present",
+        pending_sync_queue_tests_path.is_file(),
+        f"path={pending_sync_queue_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -66,6 +66,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "unit_test_runner_script",
         "mobile_helper_unit_tests_present",
         "capture_contract_unit_tests_present",
+        "pending_sync_queue_unit_tests_present",
         "roi_signal_unit_tests_present",
         "runtime_metrics_unit_tests_present",
     }.issubset(local_check_ids)


### PR DESCRIPTION
## What changed

- Extracts deterministic pending sync queue accounting into `src/utils/pendingSyncQueue.ts`.
- Keeps the React hook responsible for storage, network submission, app lifecycle, and alerts while delegating batch split, attempt accounting, retry/drop outcomes, and status-message formatting to pure functions.
- Adds Node unit coverage for pending sync batch limits, retryable failures, non-retryable drops, capture-package success accounting, and operator-facing sync summary wording.
- Updates the mobile unit-test runner to compile the pending queue utility and select repo-controlled `.test.js` files deterministically.
- Adds pending sync queue unit-test presence to the mobile release readiness artifact.

## Why

Pending/offline sync is part of the mobile release path. The retry/drop accounting should be easy to test without React Native storage or network mocks, and release readiness should show that this queue behavior is covered.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`95` tests passed)
- `.venv/bin/pytest tests/test_mobile_release_readiness_script.py -q` (`3` tests passed)
- `npm run typecheck`
- `npm run test:unit` (`27` tests passed)
- `npm run validate:ci` including TypeScript, `27` unit tests, Expo Doctor `21/21`, production audit `0 vulnerabilities`, and iOS/Android Expo exports
