### PR TITLE
[codex] Harden pending submission storage normalization

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -113,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, mobile helper/API + capture-contract + ROI signal + runtime metric + pending queue unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, mobile helper/API + capture-contract + ROI signal + runtime metric + pending queue/storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -8,6 +8,7 @@ rm -rf "$BUILD_DIR"
 tsc --ignoreConfig \
   src/utils/appHelpers.ts \
   src/utils/pendingSyncQueue.ts \
+  src/storage/pendingSubmissionStorage.ts \
   src/api/clinicalHub.ts \
   src/capture/buildCaptureContract.ts \
   src/capture/runtimeMetrics.ts \

--- a/apps/field-mobile/src/storage/appStorage.ts
+++ b/apps/field-mobile/src/storage/appStorage.ts
@@ -1,79 +1,15 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SecureStore from "expo-secure-store";
 import type { AppSettings, PendingSubmission, SummaryQualityStatus } from "../types";
+import { normalizePendingSubmission } from "./pendingSubmissionStorage";
 import {
   DEFAULT_REQUEST_TIMEOUT_MS,
-  buildHeaderContextFromValues,
-  createPendingId,
   normalizeActorRoleInput,
-  normalizePendingEndpoint,
 } from "../utils/appHelpers";
 
 const PENDING_SUBMISSIONS_KEY = "uroflow_pending_submissions_v1";
 const APP_SETTINGS_KEY = "uroflow_field_settings_v1";
 const APP_SETTINGS_API_KEY_SECURE_KEY = "uroflow_field_api_key_secure_v1";
-
-function normalizeRequestHeaderContext(
-  raw: unknown,
-  payload: { session: { site_id: string; operator_id: string } },
-) {
-  if (!raw || typeof raw !== "object") {
-    return buildHeaderContextFromValues(
-      "",
-      "operator",
-      payload.session.site_id ?? "",
-      payload.session.operator_id ?? "",
-    );
-  }
-  const candidate = raw as Record<string, unknown>;
-  return buildHeaderContextFromValues(
-    typeof candidate.api_key === "string" ? candidate.api_key : "",
-    typeof candidate.actor_role === "string" ? candidate.actor_role : "operator",
-    typeof candidate.site_id === "string" ? candidate.site_id : payload.session.site_id ?? "",
-    typeof candidate.operator_id === "string"
-      ? candidate.operator_id
-      : payload.session.operator_id ?? "",
-    typeof candidate.request_id === "string" ? candidate.request_id : "",
-  );
-}
-
-function normalizePendingSubmission(raw: unknown): PendingSubmission | null {
-  if (!raw || typeof raw !== "object") {
-    return null;
-  }
-  const candidate = raw as Record<string, unknown>;
-  const payload = candidate.payload;
-  if (!payload || typeof payload !== "object") {
-    return null;
-  }
-
-  const id =
-    typeof candidate.id === "string" && candidate.id.trim() ? candidate.id : createPendingId();
-  const createdAt =
-    typeof candidate.created_at === "string" && candidate.created_at.trim()
-      ? candidate.created_at
-      : new Date().toISOString();
-  const attemptCountRaw = Number(candidate.attempt_count);
-  const attemptCount = Number.isFinite(attemptCountRaw)
-    ? Math.max(0, Math.round(attemptCountRaw))
-    : 0;
-
-  return {
-    id,
-    created_at: createdAt,
-    endpoint: normalizePendingEndpoint(candidate.endpoint),
-    payload: payload as PendingSubmission["payload"],
-    request_headers: normalizeRequestHeaderContext(
-      candidate.request_headers,
-      payload as { session: { site_id: string; operator_id: string } },
-    ),
-    attempt_count: attemptCount,
-    last_attempt_at: typeof candidate.last_attempt_at === "string" ? candidate.last_attempt_at : null,
-    last_error: typeof candidate.last_error === "string" ? candidate.last_error : null,
-    last_status_code:
-      typeof candidate.last_status_code === "number" ? candidate.last_status_code : null,
-  };
-}
 
 export async function loadPendingSubmissions(): Promise<PendingSubmission[]> {
   const raw = await AsyncStorage.getItem(PENDING_SUBMISSIONS_KEY);

--- a/apps/field-mobile/src/storage/pendingSubmissionStorage.ts
+++ b/apps/field-mobile/src/storage/pendingSubmissionStorage.ts
@@ -1,0 +1,92 @@
+import type { PendingSubmission, RequestHeaderContext } from "../types";
+import {
+  buildHeaderContextFromValues,
+  createPendingId,
+  normalizePendingEndpoint,
+} from "../utils/appHelpers";
+
+type SessionContext = {
+  site_id: string;
+  operator_id: string;
+};
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function extractSessionContext(payload: unknown): SessionContext | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const session = (payload as { session?: unknown }).session;
+  if (!session || typeof session !== "object") {
+    return null;
+  }
+  const candidate = session as Record<string, unknown>;
+  return {
+    site_id: readString(candidate.site_id),
+    operator_id: readString(candidate.operator_id),
+  };
+}
+
+export function normalizeRequestHeaderContext(
+  raw: unknown,
+  sessionContext: SessionContext,
+): RequestHeaderContext {
+  if (!raw || typeof raw !== "object") {
+    return buildHeaderContextFromValues(
+      "",
+      "operator",
+      sessionContext.site_id,
+      sessionContext.operator_id,
+    );
+  }
+  const candidate = raw as Record<string, unknown>;
+  return buildHeaderContextFromValues(
+    readString(candidate.api_key),
+    readString(candidate.actor_role) || "operator",
+    readString(candidate.site_id) || sessionContext.site_id,
+    readString(candidate.operator_id) || sessionContext.operator_id,
+    readString(candidate.request_id),
+  );
+}
+
+export function normalizePendingSubmission(
+  raw: unknown,
+  options: {
+    createId?: () => string;
+    nowIso?: () => string;
+  } = {},
+): PendingSubmission | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const candidate = raw as Record<string, unknown>;
+  const payload = candidate.payload;
+  const sessionContext = extractSessionContext(payload);
+  if (!sessionContext) {
+    return null;
+  }
+
+  const createId = options.createId ?? createPendingId;
+  const nowIso = options.nowIso ?? (() => new Date().toISOString());
+  const id = readString(candidate.id).trim() || createId();
+  const createdAt = readString(candidate.created_at).trim() || nowIso();
+  const attemptCountRaw = Number(candidate.attempt_count);
+  const attemptCount = Number.isFinite(attemptCountRaw)
+    ? Math.max(0, Math.round(attemptCountRaw))
+    : 0;
+
+  return {
+    id,
+    created_at: createdAt,
+    endpoint: normalizePendingEndpoint(candidate.endpoint),
+    payload: payload as PendingSubmission["payload"],
+    request_headers: normalizeRequestHeaderContext(candidate.request_headers, sessionContext),
+    attempt_count: attemptCount,
+    last_attempt_at: readString(candidate.last_attempt_at) || null,
+    last_error: readString(candidate.last_error) || null,
+    last_status_code:
+      typeof candidate.last_status_code === "number" ? candidate.last_status_code : null,
+  };
+}

--- a/apps/field-mobile/tests/pendingSubmissionStorage.test.js
+++ b/apps/field-mobile/tests/pendingSubmissionStorage.test.js
@@ -1,0 +1,133 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const storage = require(path.join(buildDir, "storage/pendingSubmissionStorage.js"));
+
+function buildSession(overrides = {}) {
+  return {
+    session_id: "SESSION-001",
+    sync_id: "SYNC-001",
+    site_id: "SITE-001",
+    subject_id: "SUBJ-001",
+    operator_id: "OP-001",
+    attempt_number: 1,
+    measured_at: "2026-06-04T00:00:00Z",
+    platform: "ios",
+    device_model: "iPhone",
+    app_version: "0.1.0",
+    capture_mode: "water_impact",
+    ...overrides,
+  };
+}
+
+function buildPairedPayload(overrides = {}) {
+  return {
+    session: buildSession(),
+    app: {
+      metrics: {
+        qmax_ml_s: null,
+        qavg_ml_s: null,
+        vvoid_ml: null,
+        flow_time_s: null,
+        tqmax_s: null,
+      },
+      quality_status: "valid",
+      quality_score: null,
+      model_id: null,
+    },
+    reference: {
+      metrics: {
+        qmax_ml_s: null,
+        qavg_ml_s: null,
+        vvoid_ml: null,
+        flow_time_s: null,
+        tqmax_s: null,
+      },
+      device_model: null,
+      device_serial: null,
+    },
+    notes: null,
+    ...overrides,
+  };
+}
+
+test("normalizePendingSubmission fills migrated queue metadata deterministically", () => {
+  const item = storage.normalizePendingSubmission(
+    {
+      id: "",
+      created_at: "",
+      endpoint: "legacy_endpoint",
+      payload: buildPairedPayload(),
+      request_headers: {
+        actor_role: "Investigator",
+        request_id: " REQ-001 ",
+      },
+      attempt_count: "2.6",
+      last_attempt_at: 123,
+      last_error: 456,
+      last_status_code: "503",
+    },
+    {
+      createId: () => "PENDING-FALLBACK",
+      nowIso: () => "2026-06-04T01:02:03.000Z",
+    },
+  );
+
+  assert.ok(item);
+  assert.equal(item.id, "PENDING-FALLBACK");
+  assert.equal(item.created_at, "2026-06-04T01:02:03.000Z");
+  assert.equal(item.endpoint, "paired_measurements");
+  assert.equal(item.attempt_count, 3);
+  assert.equal(item.last_attempt_at, null);
+  assert.equal(item.last_error, null);
+  assert.equal(item.last_status_code, null);
+  assert.deepEqual(item.request_headers, {
+    api_key: "",
+    actor_role: "investigator",
+    site_id: "SITE-001",
+    operator_id: "OP-001",
+    request_id: "REQ-001",
+  });
+});
+
+test("normalizePendingSubmission preserves capture package payloads", () => {
+  const payload = {
+    session: buildSession({ sync_id: "SYNC-CAPTURE" }),
+    package_type: "capture_contract_json",
+    capture_payload: { schema_version: "ios_capture_v1" },
+    paired_measurement_id: 42,
+    notes: null,
+  };
+
+  const item = storage.normalizePendingSubmission({
+    id: "PENDING-CAPTURE",
+    created_at: "2026-06-04T00:00:00.000Z",
+    endpoint: "capture_packages",
+    payload,
+    request_headers: null,
+    attempt_count: 0,
+    last_attempt_at: null,
+    last_error: null,
+    last_status_code: 503,
+  });
+
+  assert.ok(item);
+  assert.equal(item.endpoint, "capture_packages");
+  assert.equal(item.payload, payload);
+  assert.equal(item.request_headers.site_id, "SITE-001");
+  assert.equal(item.request_headers.operator_id, "OP-001");
+  assert.equal(item.last_status_code, 503);
+});
+
+test("normalizePendingSubmission drops corrupt payloads without session context", () => {
+  assert.equal(
+    storage.normalizePendingSubmission({
+      id: "PENDING-BROKEN",
+      endpoint: "paired_measurements",
+      payload: { not_session: true },
+    }),
+    null,
+  );
+});

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -274,6 +274,9 @@ def build_readiness_report(
     roi_signal_tests_path = mobile_root / "tests" / "roiSignalEstimator.test.js"
     runtime_metrics_tests_path = mobile_root / "tests" / "runtimeMetrics.test.js"
     pending_sync_queue_tests_path = mobile_root / "tests" / "pendingSyncQueue.test.js"
+    pending_submission_storage_tests_path = (
+        mobile_root / "tests" / "pendingSubmissionStorage.test.js"
+    )
     _check(
         checks,
         "unit_test_script",
@@ -321,6 +324,12 @@ def build_readiness_report(
         "pending_sync_queue_unit_tests_present",
         pending_sync_queue_tests_path.is_file(),
         f"path={pending_sync_queue_tests_path}",
+    )
+    _check(
+        checks,
+        "pending_submission_storage_unit_tests_present",
+        pending_submission_storage_tests_path.is_file(),
+        f"path={pending_submission_storage_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -66,6 +66,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "unit_test_runner_script",
         "mobile_helper_unit_tests_present",
         "capture_contract_unit_tests_present",
+        "pending_submission_storage_unit_tests_present",
         "pending_sync_queue_unit_tests_present",
         "roi_signal_unit_tests_present",
         "runtime_metrics_unit_tests_present",


### PR DESCRIPTION
## What changed

- Extracts pending submission storage normalization into `src/storage/pendingSubmissionStorage.ts`.
- Drops corrupt pending items that do not contain a usable `payload.session` instead of letting one malformed item poison the whole loaded queue.
- Preserves migrated queue behavior for fallback ids, timestamps, endpoint normalization, header context fallback, attempt counts, and status/error fields.
- Adds unit coverage for migrated metadata, capture-package payload preservation, and corrupt payload rejection.
- Includes pending submission storage unit-test presence in the mobile release readiness artifact.

## Why

Pending/offline submissions can survive app upgrades and partial writes. A malformed stored item should not cause valid queued submissions to disappear from the loaded queue. This makes the mobile offline path more resilient before release.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`95` tests passed)
- `npm run validate:ci` including TypeScript, `30` unit tests, Expo Doctor `21/21`, production audit `0 vulnerabilities`, and iOS/Android Expo exports
