### PR TITLE
[codex] Add app settings storage unit coverage

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -113,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, mobile helper/API + capture-contract + ROI signal + runtime metric + pending queue/storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, mobile helper/API + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -8,6 +8,7 @@ rm -rf "$BUILD_DIR"
 tsc --ignoreConfig \
   src/utils/appHelpers.ts \
   src/utils/pendingSyncQueue.ts \
+  src/storage/appSettingsStorage.ts \
   src/storage/pendingSubmissionStorage.ts \
   src/api/clinicalHub.ts \
   src/capture/buildCaptureContract.ts \

--- a/apps/field-mobile/src/storage/appSettingsStorage.ts
+++ b/apps/field-mobile/src/storage/appSettingsStorage.ts
@@ -1,0 +1,75 @@
+import type { AppSettings, SummaryQualityStatus } from "../types";
+import { DEFAULT_REQUEST_TIMEOUT_MS, normalizeActorRoleInput } from "../utils/appHelpers";
+
+export const DEFAULT_API_BASE_URL = "http://127.0.0.1:8000";
+export const DEFAULT_SITE_ID = "SITE-001";
+export const DEFAULT_OPERATOR_ID = "OP-01";
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function normalizeSummaryQualityStatus(raw: unknown): SummaryQualityStatus {
+  if (raw === "all" || raw === "valid" || raw === "repeat" || raw === "reject") {
+    return raw;
+  }
+  return "valid";
+}
+
+export function buildDefaultAppSettings(apiKey: string): AppSettings {
+  return {
+    api_base_url: DEFAULT_API_BASE_URL,
+    api_key: apiKey,
+    actor_role: "operator",
+    site_id: DEFAULT_SITE_ID,
+    operator_id: DEFAULT_OPERATOR_ID,
+    summary_quality_status: "valid",
+    summary_sync_id: "",
+    request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
+  };
+}
+
+export function normalizeStoredAppSettings(
+  rawSettings: unknown,
+  secureApiKey: string,
+): AppSettings | null {
+  if (!rawSettings || typeof rawSettings !== "object") {
+    return null;
+  }
+  const parsed = rawSettings as Record<string, unknown>;
+  const apiBaseUrl = readString(parsed.api_base_url).trim();
+  const requestTimeoutMs = readString(parsed.request_timeout_ms).trim();
+
+  return {
+    api_base_url: apiBaseUrl || DEFAULT_API_BASE_URL,
+    api_key: secureApiKey || readString(parsed.api_key),
+    actor_role: normalizeActorRoleInput(readString(parsed.actor_role) || "operator"),
+    site_id: readString(parsed.site_id) || DEFAULT_SITE_ID,
+    operator_id: readString(parsed.operator_id) || DEFAULT_OPERATOR_ID,
+    summary_quality_status: normalizeSummaryQualityStatus(parsed.summary_quality_status),
+    summary_sync_id: readString(parsed.summary_sync_id),
+    request_timeout_ms: requestTimeoutMs || DEFAULT_REQUEST_TIMEOUT_MS,
+  };
+}
+
+export function parseStoredAppSettings(
+  rawSettingsJson: string | null,
+  secureApiKey: string,
+): AppSettings | null {
+  if (!rawSettingsJson) {
+    return secureApiKey ? buildDefaultAppSettings(secureApiKey) : null;
+  }
+
+  try {
+    return normalizeStoredAppSettings(JSON.parse(rawSettingsJson), secureApiKey);
+  } catch {
+    return null;
+  }
+}
+
+export function buildPlainStoredAppSettings(settings: AppSettings): AppSettings {
+  return {
+    ...settings,
+    api_key: "",
+  };
+}

--- a/apps/field-mobile/src/storage/appStorage.ts
+++ b/apps/field-mobile/src/storage/appStorage.ts
@@ -1,11 +1,11 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SecureStore from "expo-secure-store";
-import type { AppSettings, PendingSubmission, SummaryQualityStatus } from "../types";
-import { normalizePendingSubmission } from "./pendingSubmissionStorage";
+import type { AppSettings, PendingSubmission } from "../types";
 import {
-  DEFAULT_REQUEST_TIMEOUT_MS,
-  normalizeActorRoleInput,
-} from "../utils/appHelpers";
+  buildPlainStoredAppSettings,
+  parseStoredAppSettings,
+} from "./appSettingsStorage";
+import { normalizePendingSubmission } from "./pendingSubmissionStorage";
 
 const PENDING_SUBMISSIONS_KEY = "uroflow_pending_submissions_v1";
 const APP_SETTINGS_KEY = "uroflow_field_settings_v1";
@@ -42,61 +42,13 @@ export async function loadAppSettings(): Promise<AppSettings | null> {
   } catch {
     secureApiKey = "";
   }
-  if (!raw) {
-    if (!secureApiKey) {
-      return null;
-    }
-    return {
-      api_base_url: "http://127.0.0.1:8000",
-      api_key: secureApiKey,
-      actor_role: "operator",
-      site_id: "SITE-001",
-      operator_id: "OP-01",
-      summary_quality_status: "valid",
-      summary_sync_id: "",
-      request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
-    };
-  }
-  try {
-    const parsed = JSON.parse(raw) as Partial<AppSettings>;
-    if (!parsed || typeof parsed !== "object") {
-      return null;
-    }
-    const summaryQualityStatus: SummaryQualityStatus =
-      parsed.summary_quality_status === "all" ||
-      parsed.summary_quality_status === "valid" ||
-      parsed.summary_quality_status === "repeat" ||
-      parsed.summary_quality_status === "reject"
-        ? parsed.summary_quality_status
-        : "valid";
-    return {
-      api_base_url:
-        typeof parsed.api_base_url === "string" && parsed.api_base_url.trim()
-          ? parsed.api_base_url
-          : "http://127.0.0.1:8000",
-      api_key: secureApiKey || (typeof parsed.api_key === "string" ? parsed.api_key : ""),
-      actor_role: normalizeActorRoleInput(
-        typeof parsed.actor_role === "string" ? parsed.actor_role : "operator",
-      ),
-      site_id: typeof parsed.site_id === "string" ? parsed.site_id : "SITE-001",
-      operator_id: typeof parsed.operator_id === "string" ? parsed.operator_id : "OP-01",
-      summary_quality_status: summaryQualityStatus,
-      summary_sync_id: typeof parsed.summary_sync_id === "string" ? parsed.summary_sync_id : "",
-      request_timeout_ms:
-        typeof parsed.request_timeout_ms === "string" && parsed.request_timeout_ms.trim()
-          ? parsed.request_timeout_ms
-          : DEFAULT_REQUEST_TIMEOUT_MS,
-    };
-  } catch {
-    return null;
-  }
+  return parseStoredAppSettings(raw, secureApiKey);
 }
 
 export async function saveAppSettings(settings: AppSettings): Promise<void> {
-  const { api_key: apiKeyValue, ...plainSettings } = settings;
-  await AsyncStorage.setItem(APP_SETTINGS_KEY, JSON.stringify({ ...plainSettings, api_key: "" }));
+  await AsyncStorage.setItem(APP_SETTINGS_KEY, JSON.stringify(buildPlainStoredAppSettings(settings)));
   try {
-    await SecureStore.setItemAsync(APP_SETTINGS_API_KEY_SECURE_KEY, apiKeyValue);
+    await SecureStore.setItemAsync(APP_SETTINGS_API_KEY_SECURE_KEY, settings.api_key);
   } catch {
     await AsyncStorage.setItem(APP_SETTINGS_KEY, JSON.stringify(settings));
   }

--- a/apps/field-mobile/tests/appSettingsStorage.test.js
+++ b/apps/field-mobile/tests/appSettingsStorage.test.js
@@ -1,0 +1,81 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const settings = require(path.join(buildDir, "storage/appSettingsStorage.js"));
+
+test("parseStoredAppSettings builds defaults when only secure API key remains", () => {
+  assert.deepEqual(settings.parseStoredAppSettings(null, "secure-key"), {
+    api_base_url: settings.DEFAULT_API_BASE_URL,
+    api_key: "secure-key",
+    actor_role: "operator",
+    site_id: settings.DEFAULT_SITE_ID,
+    operator_id: settings.DEFAULT_OPERATOR_ID,
+    summary_quality_status: "valid",
+    summary_sync_id: "",
+    request_timeout_ms: "15000",
+  });
+});
+
+test("parseStoredAppSettings normalizes migrated plain settings and prefers secure key", () => {
+  const parsed = settings.parseStoredAppSettings(
+    JSON.stringify({
+      api_base_url: "   ",
+      api_key: "plain-key",
+      actor_role: " Admin ",
+      site_id: 123,
+      operator_id: null,
+      summary_quality_status: "unknown",
+      summary_sync_id: 456,
+      request_timeout_ms: "",
+    }),
+    "secure-key",
+  );
+
+  assert.deepEqual(parsed, {
+    api_base_url: settings.DEFAULT_API_BASE_URL,
+    api_key: "secure-key",
+    actor_role: "admin",
+    site_id: settings.DEFAULT_SITE_ID,
+    operator_id: settings.DEFAULT_OPERATOR_ID,
+    summary_quality_status: "valid",
+    summary_sync_id: "",
+    request_timeout_ms: "15000",
+  });
+});
+
+test("parseStoredAppSettings falls back to legacy plain API key when secure key is absent", () => {
+  const parsed = settings.parseStoredAppSettings(
+    JSON.stringify({
+      api_base_url: "https://clinical.example.test",
+      api_key: "legacy-plain-key",
+      actor_role: "data_manager",
+      site_id: "SITE-002",
+      operator_id: "OP-99",
+      summary_quality_status: "all",
+      summary_sync_id: "SYNC-123",
+      request_timeout_ms: "45000",
+    }),
+    "",
+  );
+
+  assert.equal(parsed.api_key, "legacy-plain-key");
+  assert.equal(parsed.api_base_url, "https://clinical.example.test");
+  assert.equal(parsed.actor_role, "data_manager");
+  assert.equal(parsed.summary_quality_status, "all");
+});
+
+test("parseStoredAppSettings rejects invalid JSON and empty settings without secrets", () => {
+  assert.equal(settings.parseStoredAppSettings("{broken", "secure-key"), null);
+  assert.equal(settings.parseStoredAppSettings(null, ""), null);
+});
+
+test("buildPlainStoredAppSettings strips API key before AsyncStorage persistence", () => {
+  const stored = settings.buildPlainStoredAppSettings(
+    settings.buildDefaultAppSettings("secret-api-key"),
+  );
+
+  assert.equal(stored.api_key, "");
+  assert.equal(stored.api_base_url, settings.DEFAULT_API_BASE_URL);
+});

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -270,6 +270,7 @@ def build_readiness_report(
     test_unit_script = scripts.get("test:unit", "")
     unit_runner_path = mobile_root / "scripts" / "run-unit-tests.sh"
     helper_tests_path = mobile_root / "tests" / "appHelpers.test.js"
+    app_settings_storage_tests_path = mobile_root / "tests" / "appSettingsStorage.test.js"
     capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
     roi_signal_tests_path = mobile_root / "tests" / "roiSignalEstimator.test.js"
     runtime_metrics_tests_path = mobile_root / "tests" / "runtimeMetrics.test.js"
@@ -300,6 +301,12 @@ def build_readiness_report(
         "mobile_helper_unit_tests_present",
         helper_tests_path.is_file(),
         f"path={helper_tests_path}",
+    )
+    _check(
+        checks,
+        "app_settings_storage_unit_tests_present",
+        app_settings_storage_tests_path.is_file(),
+        f"path={app_settings_storage_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -61,6 +61,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
     assert all(item["status"] == "pass" for item in payload["local_checks"])
     local_check_ids = {item["id"] for item in payload["local_checks"]}
     assert {
+        "app_settings_storage_unit_tests_present",
         "unit_test_script",
         "validate_ci_runs_unit_tests",
         "unit_test_runner_script",


### PR DESCRIPTION
## What changed

- Extracts app settings normalization into `src/storage/appSettingsStorage.ts` so settings migration and credential-splitting behavior can be tested without React Native storage mocks.
- Keeps `loadAppSettings`/`saveAppSettings` behavior intact while moving defaults, role/quality normalization, secure-key precedence, and plain AsyncStorage payload construction into pure functions.
- Adds unit coverage for secure API key fallback, migrated plain settings normalization, legacy plain API key fallback, invalid JSON handling, and API key stripping before AsyncStorage persistence.
- Adds app settings storage unit-test presence to the mobile release readiness artifact.

## Why

Clinical Hub credentials are an external release blocker, and the mobile app must keep local credential handling predictable. This makes the API key storage split explicit, tested, and visible in readiness evidence.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`95` tests passed)
- `npm run validate:ci` including TypeScript, `35` unit tests, Expo Doctor `21/21`, production audit `0 vulnerabilities`, and iOS/Android Expo exports
