### PR TITLE
[codex] Add paired payload unit coverage

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -30,6 +30,10 @@ import { RuntimeCaptureSection } from "./src/components/RuntimeCaptureSection";
 import { styles } from "./src/styles/appStyles";
 import { usePendingSyncQueue } from "./src/hooks/usePendingSyncQueue";
 import {
+  buildPairedPayloadFromForm,
+  validatePairedPayloadForSubmission,
+} from "./src/payload/pairedPayload";
+import {
   loadAppSettings,
   saveAppSettings,
 } from "./src/storage/appStorage";
@@ -52,7 +56,6 @@ import {
   createSessionId,
   createSyncId,
   extractCreatedRecordId,
-  parseNumber,
   runtimeCaptureMatchesSession,
 } from "./src/utils/appHelpers";
 
@@ -161,45 +164,35 @@ export default function App() {
   });
 
   const payload = useMemo<PairedPayload>(() => {
-    return {
-      session: {
-        session_id: sessionId.trim(),
-        sync_id: syncId.trim() || null,
-        site_id: siteId.trim(),
-        subject_id: subjectId.trim(),
-        operator_id: operatorId.trim(),
-        attempt_number: parseNumber(attemptNumber),
-        measured_at: measuredAt.trim(),
-        platform,
-        device_model: deviceModel.trim() || null,
-        app_version: appVersion.trim() || null,
-        capture_mode: captureMode,
-      },
-      app: {
-        metrics: {
-          qmax_ml_s: parseNumber(appQmax),
-          qavg_ml_s: parseNumber(appQavg),
-          vvoid_ml: parseNumber(appVvoid),
-          flow_time_s: parseNumber(appFlowTime),
-          tqmax_s: parseNumber(appTqmax),
-        },
-        quality_status: appQualityStatus,
-        quality_score: parseNumber(appQualityScore),
-        model_id: appModelId.trim() || null,
-      },
-      reference: {
-        metrics: {
-          qmax_ml_s: parseNumber(refQmax),
-          qavg_ml_s: parseNumber(refQavg),
-          vvoid_ml: parseNumber(refVvoid),
-          flow_time_s: parseNumber(refFlowTime),
-          tqmax_s: parseNumber(refTqmax),
-        },
-        device_model: refDeviceModel.trim() || null,
-        device_serial: refDeviceSerial.trim() || null,
-      },
-      notes: notes.trim() || null,
-    };
+    return buildPairedPayloadFromForm({
+      sessionId,
+      syncId,
+      siteId,
+      subjectId,
+      operatorId,
+      attemptNumber,
+      measuredAt,
+      platform,
+      deviceModel,
+      appVersion,
+      captureMode,
+      appQmax,
+      appQavg,
+      appVvoid,
+      appFlowTime,
+      appTqmax,
+      appQualityStatus,
+      appQualityScore,
+      appModelId,
+      refQmax,
+      refQavg,
+      refVvoid,
+      refFlowTime,
+      refTqmax,
+      refDeviceModel,
+      refDeviceSerial,
+      notes,
+    });
   }, [
     appFlowTime,
     appModelId,
@@ -574,28 +567,7 @@ export default function App() {
   }
 
   function validateRequired(): string | null {
-    if (captureRunning) {
-      return "Stop runtime capture before submitting.";
-    }
-    if (!payload.session.session_id) {
-      return "session_id is required";
-    }
-    if (!payload.session.site_id || !payload.session.subject_id || !payload.session.operator_id) {
-      return "site_id, subject_id, operator_id are required";
-    }
-    if (!payload.session.attempt_number || payload.session.attempt_number < 1) {
-      return "attempt_number must be >= 1";
-    }
-    if (!payload.session.measured_at) {
-      return "measured_at is required";
-    }
-    if (payload.app.metrics.qmax_ml_s == null || payload.app.metrics.qavg_ml_s == null || payload.app.metrics.vvoid_ml == null) {
-      return "App metrics qmax/qavg/vvoid are required";
-    }
-    if (payload.reference.metrics.qmax_ml_s == null || payload.reference.metrics.qavg_ml_s == null || payload.reference.metrics.vvoid_ml == null) {
-      return "Reference metrics qmax/qavg/vvoid are required";
-    }
-    return null;
+    return validatePairedPayloadForSubmission(payload, { captureRunning });
   }
 
   async function submitPayload() {

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -113,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, mobile helper/API + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, mobile helper/API + paired-payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -10,6 +10,7 @@ tsc --ignoreConfig \
   src/utils/pendingSyncQueue.ts \
   src/storage/appSettingsStorage.ts \
   src/storage/pendingSubmissionStorage.ts \
+  src/payload/pairedPayload.ts \
   src/api/clinicalHub.ts \
   src/capture/buildCaptureContract.ts \
   src/capture/runtimeMetrics.ts \

--- a/apps/field-mobile/src/payload/pairedPayload.ts
+++ b/apps/field-mobile/src/payload/pairedPayload.ts
@@ -1,0 +1,110 @@
+import type { PairedPayload, QualityStatus } from "../types";
+import { parseNumber } from "../utils/appHelpers";
+
+export type PairedPayloadFormValues = {
+  sessionId: string;
+  syncId: string;
+  siteId: string;
+  subjectId: string;
+  operatorId: string;
+  attemptNumber: string;
+  measuredAt: string;
+  platform: string;
+  deviceModel: string;
+  appVersion: string;
+  captureMode: string;
+  appQmax: string;
+  appQavg: string;
+  appVvoid: string;
+  appFlowTime: string;
+  appTqmax: string;
+  appQualityStatus: QualityStatus;
+  appQualityScore: string;
+  appModelId: string;
+  refQmax: string;
+  refQavg: string;
+  refVvoid: string;
+  refFlowTime: string;
+  refTqmax: string;
+  refDeviceModel: string;
+  refDeviceSerial: string;
+  notes: string;
+};
+
+export function buildPairedPayloadFromForm(values: PairedPayloadFormValues): PairedPayload {
+  return {
+    session: {
+      session_id: values.sessionId.trim(),
+      sync_id: values.syncId.trim() || null,
+      site_id: values.siteId.trim(),
+      subject_id: values.subjectId.trim(),
+      operator_id: values.operatorId.trim(),
+      attempt_number: parseNumber(values.attemptNumber),
+      measured_at: values.measuredAt.trim(),
+      platform: values.platform,
+      device_model: values.deviceModel.trim() || null,
+      app_version: values.appVersion.trim() || null,
+      capture_mode: values.captureMode,
+    },
+    app: {
+      metrics: {
+        qmax_ml_s: parseNumber(values.appQmax),
+        qavg_ml_s: parseNumber(values.appQavg),
+        vvoid_ml: parseNumber(values.appVvoid),
+        flow_time_s: parseNumber(values.appFlowTime),
+        tqmax_s: parseNumber(values.appTqmax),
+      },
+      quality_status: values.appQualityStatus,
+      quality_score: parseNumber(values.appQualityScore),
+      model_id: values.appModelId.trim() || null,
+    },
+    reference: {
+      metrics: {
+        qmax_ml_s: parseNumber(values.refQmax),
+        qavg_ml_s: parseNumber(values.refQavg),
+        vvoid_ml: parseNumber(values.refVvoid),
+        flow_time_s: parseNumber(values.refFlowTime),
+        tqmax_s: parseNumber(values.refTqmax),
+      },
+      device_model: values.refDeviceModel.trim() || null,
+      device_serial: values.refDeviceSerial.trim() || null,
+    },
+    notes: values.notes.trim() || null,
+  };
+}
+
+export function validatePairedPayloadForSubmission(
+  payload: PairedPayload,
+  options: { captureRunning: boolean },
+): string | null {
+  if (options.captureRunning) {
+    return "Stop runtime capture before submitting.";
+  }
+  if (!payload.session.session_id) {
+    return "session_id is required";
+  }
+  if (!payload.session.site_id || !payload.session.subject_id || !payload.session.operator_id) {
+    return "site_id, subject_id, operator_id are required";
+  }
+  if (!payload.session.attempt_number || payload.session.attempt_number < 1) {
+    return "attempt_number must be >= 1";
+  }
+  if (!payload.session.measured_at) {
+    return "measured_at is required";
+  }
+  if (
+    payload.app.metrics.qmax_ml_s == null ||
+    payload.app.metrics.qavg_ml_s == null ||
+    payload.app.metrics.vvoid_ml == null
+  ) {
+    return "App metrics qmax/qavg/vvoid are required";
+  }
+  if (
+    payload.reference.metrics.qmax_ml_s == null ||
+    payload.reference.metrics.qavg_ml_s == null ||
+    payload.reference.metrics.vvoid_ml == null
+  ) {
+    return "Reference metrics qmax/qavg/vvoid are required";
+  }
+  return null;
+}

--- a/apps/field-mobile/tests/pairedPayload.test.js
+++ b/apps/field-mobile/tests/pairedPayload.test.js
@@ -1,0 +1,148 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const paired = require(path.join(buildDir, "payload/pairedPayload.js"));
+
+function buildForm(overrides = {}) {
+  return {
+    sessionId: " SESSION-001 ",
+    syncId: " SYNC-001 ",
+    siteId: " SITE-001 ",
+    subjectId: " SUBJ-001 ",
+    operatorId: " OP-001 ",
+    attemptNumber: "2",
+    measuredAt: " 2026-06-04T00:00:00Z ",
+    platform: "ios",
+    deviceModel: " iPhone 15 ",
+    appVersion: " 0.1.0 ",
+    captureMode: "water_impact",
+    appQmax: "12.5",
+    appQavg: "8.25",
+    appVvoid: "250",
+    appFlowTime: "18",
+    appTqmax: "4.5",
+    appQualityStatus: "valid",
+    appQualityScore: "91.5",
+    appModelId: " fusion-v0.1 ",
+    refQmax: "13.2",
+    refQavg: "8.8",
+    refVvoid: "260",
+    refFlowTime: "19",
+    refTqmax: "4.8",
+    refDeviceModel: " Reference Uroflow ",
+    refDeviceSerial: " REF-123 ",
+    notes: " field notes ",
+    ...overrides,
+  };
+}
+
+test("buildPairedPayloadFromForm trims identifiers and parses metrics", () => {
+  const payload = paired.buildPairedPayloadFromForm(buildForm());
+
+  assert.deepEqual(payload.session, {
+    session_id: "SESSION-001",
+    sync_id: "SYNC-001",
+    site_id: "SITE-001",
+    subject_id: "SUBJ-001",
+    operator_id: "OP-001",
+    attempt_number: 2,
+    measured_at: "2026-06-04T00:00:00Z",
+    platform: "ios",
+    device_model: "iPhone 15",
+    app_version: "0.1.0",
+    capture_mode: "water_impact",
+  });
+  assert.deepEqual(payload.app.metrics, {
+    qmax_ml_s: 12.5,
+    qavg_ml_s: 8.25,
+    vvoid_ml: 250,
+    flow_time_s: 18,
+    tqmax_s: 4.5,
+  });
+  assert.equal(payload.app.quality_score, 91.5);
+  assert.equal(payload.app.model_id, "fusion-v0.1");
+  assert.equal(payload.reference.device_model, "Reference Uroflow");
+  assert.equal(payload.reference.device_serial, "REF-123");
+  assert.equal(payload.notes, "field notes");
+});
+
+test("buildPairedPayloadFromForm converts blank optional fields to null", () => {
+  const payload = paired.buildPairedPayloadFromForm(
+    buildForm({
+      syncId: " ",
+      deviceModel: "",
+      appVersion: "",
+      appFlowTime: "",
+      appTqmax: "",
+      appQualityScore: "",
+      appModelId: "",
+      refFlowTime: "",
+      refTqmax: "",
+      refDeviceModel: "",
+      refDeviceSerial: "",
+      notes: "",
+    }),
+  );
+
+  assert.equal(payload.session.sync_id, null);
+  assert.equal(payload.session.device_model, null);
+  assert.equal(payload.session.app_version, null);
+  assert.equal(payload.app.metrics.flow_time_s, null);
+  assert.equal(payload.app.metrics.tqmax_s, null);
+  assert.equal(payload.app.quality_score, null);
+  assert.equal(payload.app.model_id, null);
+  assert.equal(payload.reference.metrics.flow_time_s, null);
+  assert.equal(payload.reference.metrics.tqmax_s, null);
+  assert.equal(payload.reference.device_model, null);
+  assert.equal(payload.reference.device_serial, null);
+  assert.equal(payload.notes, null);
+});
+
+test("validatePairedPayloadForSubmission reports required field failures", () => {
+  const validPayload = paired.buildPairedPayloadFromForm(buildForm());
+
+  assert.equal(
+    paired.validatePairedPayloadForSubmission(validPayload, { captureRunning: true }),
+    "Stop runtime capture before submitting.",
+  );
+  assert.equal(
+    paired.validatePairedPayloadForSubmission(
+      paired.buildPairedPayloadFromForm(buildForm({ sessionId: "" })),
+      { captureRunning: false },
+    ),
+    "session_id is required",
+  );
+  assert.equal(
+    paired.validatePairedPayloadForSubmission(
+      paired.buildPairedPayloadFromForm(buildForm({ attemptNumber: "0" })),
+      { captureRunning: false },
+    ),
+    "attempt_number must be >= 1",
+  );
+  assert.equal(
+    paired.validatePairedPayloadForSubmission(
+      paired.buildPairedPayloadFromForm(buildForm({ appQmax: "" })),
+      { captureRunning: false },
+    ),
+    "App metrics qmax/qavg/vvoid are required",
+  );
+  assert.equal(
+    paired.validatePairedPayloadForSubmission(
+      paired.buildPairedPayloadFromForm(buildForm({ refVvoid: "" })),
+      { captureRunning: false },
+    ),
+    "Reference metrics qmax/qavg/vvoid are required",
+  );
+});
+
+test("validatePairedPayloadForSubmission accepts a complete payload", () => {
+  assert.equal(
+    paired.validatePairedPayloadForSubmission(
+      paired.buildPairedPayloadFromForm(buildForm()),
+      { captureRunning: false },
+    ),
+    null,
+  );
+});

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -272,6 +272,7 @@ def build_readiness_report(
     helper_tests_path = mobile_root / "tests" / "appHelpers.test.js"
     app_settings_storage_tests_path = mobile_root / "tests" / "appSettingsStorage.test.js"
     capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
+    paired_payload_tests_path = mobile_root / "tests" / "pairedPayload.test.js"
     roi_signal_tests_path = mobile_root / "tests" / "roiSignalEstimator.test.js"
     runtime_metrics_tests_path = mobile_root / "tests" / "runtimeMetrics.test.js"
     pending_sync_queue_tests_path = mobile_root / "tests" / "pendingSyncQueue.test.js"
@@ -313,6 +314,12 @@ def build_readiness_report(
         "capture_contract_unit_tests_present",
         capture_tests_path.is_file(),
         f"path={capture_tests_path}",
+    )
+    _check(
+        checks,
+        "paired_payload_unit_tests_present",
+        paired_payload_tests_path.is_file(),
+        f"path={paired_payload_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -62,6 +62,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
     local_check_ids = {item["id"] for item in payload["local_checks"]}
     assert {
         "app_settings_storage_unit_tests_present",
+        "paired_payload_unit_tests_present",
         "unit_test_script",
         "validate_ci_runs_unit_tests",
         "unit_test_runner_script",


### PR DESCRIPTION
## What changed

- Extracts paired measurement payload construction and submission validation from `App.tsx` into `src/payload/pairedPayload.ts`.
- Keeps current UI behavior while making trim/null/number conversion and required-field validation independently testable.
- Adds unit coverage for payload normalization, blank optional fields, validation failure messages, and complete payload acceptance.
- Adds paired payload unit-test presence to the mobile release readiness artifact.

## Why

The paired measurement payload is the primary Clinical Hub submission path. It should be verified without launching React Native, especially before release handoff where live Clinical Hub credentials remain external.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`95` tests passed)
- `npm run validate:ci` including TypeScript, `39` unit tests, Expo Doctor `21/21`, production audit `0 vulnerabilities`, and iOS/Android Expo exports
