### PR TITLE
[codex] Add capture package payload unit coverage

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -14,10 +14,7 @@ import {
   buildRequestHeaders,
   fetchWithTimeout,
 } from "./src/api/clinicalHub";
-import {
-  buildCaptureContractPayload,
-  buildCaptureContractPayloadFromSamples,
-} from "./src/capture/buildCaptureContract";
+import { buildCaptureContractPayloadFromSamples } from "./src/capture/buildCaptureContract";
 import {
   RuntimeCaptureSession,
   type RuntimeFlowPoint,
@@ -29,6 +26,7 @@ import { ResponseAndSummarySection } from "./src/components/ResponseAndSummarySe
 import { RuntimeCaptureSection } from "./src/components/RuntimeCaptureSection";
 import { styles } from "./src/styles/appStyles";
 import { usePendingSyncQueue } from "./src/hooks/usePendingSyncQueue";
+import { buildCapturePackagePayloadFromPaired } from "./src/payload/capturePackagePayload";
 import {
   buildPairedPayloadFromForm,
   validatePairedPayloadForSubmission,
@@ -41,7 +39,6 @@ import type {
   AppSettings,
   AuthContextResponse,
   CaptureCoverageSummaryResponse,
-  CapturePackagePayload,
   ComparisonSummaryResponse,
   PairedPayload,
   QualityStatus,
@@ -56,7 +53,6 @@ import {
   createSessionId,
   createSyncId,
   extractCreatedRecordId,
-  runtimeCaptureMatchesSession,
 } from "./src/utils/appHelpers";
 
 const defaultMeasuredAt = new Date().toISOString().slice(0, 19) + "Z";
@@ -482,39 +478,6 @@ export default function App() {
     return requestHeaderContext;
   }
 
-  function buildCapturePackagePayloadFromPaired(
-    currentPayload: PairedPayload,
-    pairedMeasurementId: number | null,
-  ): CapturePackagePayload {
-    let captureContractPayload: Record<string, unknown>;
-    let notes = "mobile_scaffold_capture_contract_v0.1";
-    const runtimePayload = runtimeCaptureContractPayload;
-    if (runtimePayload && runtimeCaptureMatchesSession(runtimePayload, currentPayload.session)) {
-      captureContractPayload = runtimePayload;
-      notes = "mobile_runtime_capture_contract_audio_imu_v0.1";
-    } else {
-      captureContractPayload = buildCaptureContractPayload({
-        sessionId: currentPayload.session.session_id,
-        syncId: currentPayload.session.sync_id,
-        startedAtIso: currentPayload.session.measured_at,
-        captureMode: currentPayload.session.capture_mode,
-        deviceModel: currentPayload.session.device_model,
-        iosVersion: String(Platform.Version),
-        appVersion: currentPayload.session.app_version,
-        qmaxMlS: currentPayload.app.metrics.qmax_ml_s,
-        qavgMlS: currentPayload.app.metrics.qavg_ml_s,
-        flowTimeS: currentPayload.app.metrics.flow_time_s,
-      }) as unknown as Record<string, unknown>;
-    }
-    return {
-      session: currentPayload.session,
-      package_type: "capture_contract_json",
-      capture_payload: captureContractPayload,
-      paired_measurement_id: pairedMeasurementId,
-      notes,
-    };
-  }
-
   async function testApiConnection(): Promise<void> {
     const baseUrl = buildBaseUrl(apiBaseUrl);
     const authContextUrl = `${baseUrl}/api/v1/auth-context`;
@@ -595,10 +558,12 @@ export default function App() {
       });
       if (result.ok) {
         const pairedMeasurementId = extractCreatedRecordId(result.body);
-        const capturePayload = buildCapturePackagePayloadFromPaired(
-          payload,
+        const capturePayload = buildCapturePackagePayloadFromPaired({
+          currentPayload: payload,
           pairedMeasurementId,
-        );
+          runtimeCaptureContractPayload,
+          platformVersion: String(Platform.Version),
+        });
         const captureRequestHeaderContext: RequestHeaderContext = {
           ...requestHeaderContext,
           request_id: createRequestId(),
@@ -661,7 +626,12 @@ export default function App() {
         return;
       }
 
-      const capturePayloadWithoutPair = buildCapturePackagePayloadFromPaired(payload, null);
+      const capturePayloadWithoutPair = buildCapturePackagePayloadFromPaired({
+        currentPayload: payload,
+        pairedMeasurementId: null,
+        runtimeCaptureContractPayload,
+        platformVersion: String(Platform.Version),
+      });
       const captureRetryHeaderContext: RequestHeaderContext = {
         ...requestHeaderContext,
         request_id: createRequestId(),

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -113,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, mobile helper/API + paired-payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, mobile helper/API + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -10,6 +10,7 @@ tsc --ignoreConfig \
   src/utils/pendingSyncQueue.ts \
   src/storage/appSettingsStorage.ts \
   src/storage/pendingSubmissionStorage.ts \
+  src/payload/capturePackagePayload.ts \
   src/payload/pairedPayload.ts \
   src/api/clinicalHub.ts \
   src/capture/buildCaptureContract.ts \

--- a/apps/field-mobile/src/payload/capturePackagePayload.ts
+++ b/apps/field-mobile/src/payload/capturePackagePayload.ts
@@ -1,0 +1,49 @@
+import { buildCaptureContractPayload } from "../capture/buildCaptureContract";
+import type { CapturePackagePayload, PairedPayload } from "../types";
+import { runtimeCaptureMatchesSession } from "../utils/appHelpers";
+
+export type BuildCapturePackagePayloadOptions = {
+  currentPayload: PairedPayload;
+  pairedMeasurementId: number | null;
+  runtimeCaptureContractPayload: Record<string, unknown> | null;
+  platformVersion: string;
+};
+
+export function buildCapturePackagePayloadFromPaired({
+  currentPayload,
+  pairedMeasurementId,
+  runtimeCaptureContractPayload,
+  platformVersion,
+}: BuildCapturePackagePayloadOptions): CapturePackagePayload {
+  let captureContractPayload: Record<string, unknown>;
+  let notes = "mobile_scaffold_capture_contract_v0.1";
+
+  if (
+    runtimeCaptureContractPayload &&
+    runtimeCaptureMatchesSession(runtimeCaptureContractPayload, currentPayload.session)
+  ) {
+    captureContractPayload = runtimeCaptureContractPayload;
+    notes = "mobile_runtime_capture_contract_audio_imu_v0.1";
+  } else {
+    captureContractPayload = buildCaptureContractPayload({
+      sessionId: currentPayload.session.session_id,
+      syncId: currentPayload.session.sync_id,
+      startedAtIso: currentPayload.session.measured_at,
+      captureMode: currentPayload.session.capture_mode,
+      deviceModel: currentPayload.session.device_model,
+      iosVersion: platformVersion,
+      appVersion: currentPayload.session.app_version,
+      qmaxMlS: currentPayload.app.metrics.qmax_ml_s,
+      qavgMlS: currentPayload.app.metrics.qavg_ml_s,
+      flowTimeS: currentPayload.app.metrics.flow_time_s,
+    }) as unknown as Record<string, unknown>;
+  }
+
+  return {
+    session: currentPayload.session,
+    package_type: "capture_contract_json",
+    capture_payload: captureContractPayload,
+    paired_measurement_id: pairedMeasurementId,
+    notes,
+  };
+}

--- a/apps/field-mobile/tests/capturePackagePayload.test.js
+++ b/apps/field-mobile/tests/capturePackagePayload.test.js
@@ -1,0 +1,110 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const capturePackage = require(path.join(buildDir, "payload/capturePackagePayload.js"));
+
+function buildPairedPayload(overrides = {}) {
+  const session = {
+    session_id: "SESSION-001",
+    sync_id: "SYNC-001",
+    site_id: "SITE-001",
+    subject_id: "SUBJ-001",
+    operator_id: "OP-001",
+    attempt_number: 1,
+    measured_at: "2026-06-04T00:00:00Z",
+    platform: "ios",
+    device_model: "iPhone 15",
+    app_version: "0.1.0",
+    capture_mode: "water_impact",
+    ...(overrides.session ?? {}),
+  };
+  return {
+    session,
+    app: {
+      metrics: {
+        qmax_ml_s: 12.5,
+        qavg_ml_s: 8.2,
+        vvoid_ml: 240,
+        flow_time_s: 18,
+        tqmax_s: 4.1,
+      },
+      quality_status: "valid",
+      quality_score: 91,
+      model_id: "fusion-v0.1",
+    },
+    reference: {
+      metrics: {
+        qmax_ml_s: 13,
+        qavg_ml_s: 8.4,
+        vvoid_ml: 245,
+        flow_time_s: 18.2,
+        tqmax_s: 4.2,
+      },
+      device_model: "reference",
+      device_serial: "REF-001",
+    },
+    notes: null,
+    ...overrides,
+  };
+}
+
+test("buildCapturePackagePayloadFromPaired uses matching runtime capture payload", () => {
+  const runtimePayload = {
+    schema_version: "ios_capture_v1",
+    session: {
+      session_id: "SESSION-001",
+      sync_id: "SYNC-001",
+    },
+    samples: [],
+  };
+
+  const payload = capturePackage.buildCapturePackagePayloadFromPaired({
+    currentPayload: buildPairedPayload(),
+    pairedMeasurementId: 42,
+    runtimeCaptureContractPayload: runtimePayload,
+    platformVersion: "19.0",
+  });
+
+  assert.equal(payload.capture_payload, runtimePayload);
+  assert.equal(payload.paired_measurement_id, 42);
+  assert.equal(payload.package_type, "capture_contract_json");
+  assert.equal(payload.notes, "mobile_runtime_capture_contract_audio_imu_v0.1");
+});
+
+test("buildCapturePackagePayloadFromPaired falls back to scaffold when runtime session mismatches", () => {
+  const payload = capturePackage.buildCapturePackagePayloadFromPaired({
+    currentPayload: buildPairedPayload(),
+    pairedMeasurementId: null,
+    runtimeCaptureContractPayload: {
+      schema_version: "ios_capture_v1",
+      session: { session_id: "SESSION-OTHER", sync_id: "SYNC-001" },
+    },
+    platformVersion: "19.0",
+  });
+
+  assert.equal(payload.notes, "mobile_scaffold_capture_contract_v0.1");
+  assert.equal(payload.paired_measurement_id, null);
+  assert.equal(payload.capture_payload.schema_version, "ios_capture_v1");
+  assert.equal(payload.capture_payload.session.session_id, "SESSION-001");
+  assert.equal(payload.capture_payload.session.sync_id, "SYNC-001");
+  assert.ok(payload.capture_payload.samples.length >= 8);
+  assert.equal(
+    payload.capture_payload.samples.every((sample) => sample.roi_valid === true),
+    true,
+  );
+});
+
+test("buildCapturePackagePayloadFromPaired creates scaffold when runtime payload is absent", () => {
+  const payload = capturePackage.buildCapturePackagePayloadFromPaired({
+    currentPayload: buildPairedPayload({ session: { sync_id: null } }),
+    pairedMeasurementId: 7,
+    runtimeCaptureContractPayload: null,
+    platformVersion: "android-16",
+  });
+
+  assert.equal(payload.notes, "mobile_scaffold_capture_contract_v0.1");
+  assert.equal(payload.capture_payload.session.sync_id, null);
+  assert.equal(payload.capture_payload.session.device.ios_version, "android-16");
+});

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -271,6 +271,7 @@ def build_readiness_report(
     unit_runner_path = mobile_root / "scripts" / "run-unit-tests.sh"
     helper_tests_path = mobile_root / "tests" / "appHelpers.test.js"
     app_settings_storage_tests_path = mobile_root / "tests" / "appSettingsStorage.test.js"
+    capture_package_payload_tests_path = mobile_root / "tests" / "capturePackagePayload.test.js"
     capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
     paired_payload_tests_path = mobile_root / "tests" / "pairedPayload.test.js"
     roi_signal_tests_path = mobile_root / "tests" / "roiSignalEstimator.test.js"
@@ -314,6 +315,12 @@ def build_readiness_report(
         "capture_contract_unit_tests_present",
         capture_tests_path.is_file(),
         f"path={capture_tests_path}",
+    )
+    _check(
+        checks,
+        "capture_package_payload_unit_tests_present",
+        capture_package_payload_tests_path.is_file(),
+        f"path={capture_package_payload_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -62,6 +62,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
     local_check_ids = {item["id"] for item in payload["local_checks"]}
     assert {
         "app_settings_storage_unit_tests_present",
+        "capture_package_payload_unit_tests_present",
         "paired_payload_unit_tests_present",
         "unit_test_script",
         "validate_ci_runs_unit_tests",


### PR DESCRIPTION
## What changed

- Extracts capture package payload construction from `App.tsx` into `src/payload/capturePackagePayload.ts`.
- Keeps runtime capture contract preference when the runtime payload matches the paired session, and falls back to scaffold capture contract otherwise.
- Adds unit coverage for matching runtime payload use, mismatched runtime fallback, and null runtime fallback.
- Adds capture package payload unit-test presence to the mobile release readiness artifact.

## Why

The mobile submission flow uploads a paired measurement plus a capture package. The runtime-vs-scaffold capture selection is release-critical and should be tested without launching the UI.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`95` tests passed)
- `npm run validate:ci` including TypeScript, `42` unit tests, Expo Doctor `21/21`, production audit `0 vulnerabilities`, and iOS/Android Expo exports
