### PR TITLE
[codex] Add Clinical Hub API client unit coverage

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -113,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, mobile helper/API + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, Clinical Hub API client + mobile helper/API + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/tests/clinicalHub.test.js
+++ b/apps/field-mobile/tests/clinicalHub.test.js
@@ -1,0 +1,132 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const clinicalHub = require(path.join(buildDir, "api/clinicalHub.js"));
+
+function buildPayload() {
+  return {
+    session: {
+      session_id: "SESSION-001",
+      sync_id: "SYNC-001",
+      site_id: "SITE-001",
+      subject_id: "SUBJ-001",
+      operator_id: "OP-001",
+      attempt_number: 1,
+      measured_at: "2026-06-04T00:00:00Z",
+      platform: "ios",
+      device_model: "iPhone",
+      app_version: "0.1.0",
+      capture_mode: "water_impact",
+    },
+  };
+}
+
+test("buildBaseUrl and endpointPath normalize Clinical Hub targets", () => {
+  assert.equal(clinicalHub.buildBaseUrl("https://clinical.example.test/"), "https://clinical.example.test");
+  assert.equal(clinicalHub.buildBaseUrl("https://clinical.example.test"), "https://clinical.example.test");
+  assert.equal(clinicalHub.endpointPath("paired_measurements"), "/api/v1/paired-measurements");
+  assert.equal(clinicalHub.endpointPath("capture_packages"), "/api/v1/capture-packages");
+});
+
+test("attemptSubmitEndpoint posts serialized payloads with request headers", async () => {
+  const originalFetch = global.fetch;
+  try {
+    global.fetch = async (url, init) => {
+      assert.equal(url, "https://clinical.example.test/api/v1/paired-measurements");
+      assert.equal(init.method, "POST");
+      assert.equal(init.headers["Content-Type"], "application/json");
+      assert.equal(init.headers["x-api-key"], "secret-key");
+      assert.equal(init.headers["x-actor-role"], "operator");
+      assert.equal(init.headers["x-site-id"], "SITE-001");
+      assert.equal(init.headers["x-operator-id"], "OP-001");
+      assert.equal(init.headers["x-request-id"], "REQ-001");
+      assert.deepEqual(JSON.parse(init.body), buildPayload());
+      return new Response('{"id": 17}', { status: 201 });
+    };
+
+    const result = await clinicalHub.attemptSubmitEndpoint({
+      apiBaseUrl: "https://clinical.example.test/",
+      requestTimeoutMs: "15000",
+      endpoint: "paired_measurements",
+      endpointPayload: buildPayload(),
+      headerContext: {
+        api_key: "secret-key",
+        actor_role: "operator",
+        site_id: "SITE-001",
+        operator_id: "OP-001",
+        request_id: "REQ-001",
+      },
+    });
+
+    assert.deepEqual(result, {
+      ok: true,
+      statusCode: 201,
+      body: '{"id": 17}',
+      retryable: false,
+    });
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("attemptSubmitEndpoint marks validation responses non-retryable", async () => {
+  const originalFetch = global.fetch;
+  try {
+    global.fetch = async () => new Response("validation error", { status: 422 });
+
+    const result = await clinicalHub.attemptSubmitEndpoint({
+      apiBaseUrl: "https://clinical.example.test",
+      requestTimeoutMs: "15000",
+      endpoint: "capture_packages",
+      endpointPayload: buildPayload(),
+      headerContext: {
+        api_key: "",
+        actor_role: "operator",
+        site_id: "",
+        operator_id: "",
+        request_id: "REQ-422",
+      },
+    });
+
+    assert.deepEqual(result, {
+      ok: false,
+      statusCode: 422,
+      body: "validation error",
+      retryable: false,
+    });
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("attemptSubmitEndpoint keeps network failures retryable", async () => {
+  const originalFetch = global.fetch;
+  try {
+    global.fetch = async () => {
+      throw new Error("failed to fetch");
+    };
+
+    const result = await clinicalHub.attemptSubmitEndpoint({
+      apiBaseUrl: "https://clinical.example.test",
+      requestTimeoutMs: "15000",
+      endpoint: "paired_measurements",
+      endpointPayload: buildPayload(),
+      headerContext: {
+        api_key: "",
+        actor_role: "operator",
+        site_id: "",
+        operator_id: "",
+        request_id: "REQ-NETWORK",
+      },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.statusCode, null);
+    assert.equal(result.retryable, true);
+    assert.match(result.body, /failed to fetch/);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -271,6 +271,7 @@ def build_readiness_report(
     unit_runner_path = mobile_root / "scripts" / "run-unit-tests.sh"
     helper_tests_path = mobile_root / "tests" / "appHelpers.test.js"
     app_settings_storage_tests_path = mobile_root / "tests" / "appSettingsStorage.test.js"
+    clinical_hub_api_tests_path = mobile_root / "tests" / "clinicalHub.test.js"
     capture_package_payload_tests_path = mobile_root / "tests" / "capturePackagePayload.test.js"
     capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
     paired_payload_tests_path = mobile_root / "tests" / "pairedPayload.test.js"
@@ -309,6 +310,12 @@ def build_readiness_report(
         "app_settings_storage_unit_tests_present",
         app_settings_storage_tests_path.is_file(),
         f"path={app_settings_storage_tests_path}",
+    )
+    _check(
+        checks,
+        "clinical_hub_api_unit_tests_present",
+        clinical_hub_api_tests_path.is_file(),
+        f"path={clinical_hub_api_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -62,6 +62,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
     local_check_ids = {item["id"] for item in payload["local_checks"]}
     assert {
         "app_settings_storage_unit_tests_present",
+        "clinical_hub_api_unit_tests_present",
         "capture_package_payload_unit_tests_present",
         "paired_payload_unit_tests_present",
         "unit_test_script",


### PR DESCRIPTION
## What changed

- Adds unit coverage for the mobile Clinical Hub API client.
- Verifies base URL normalization, endpoint path mapping, serialized POST payloads, request headers, non-retryable validation responses, and retryable network failures.
- Adds Clinical Hub API client unit-test presence to the mobile release readiness artifact.

## Why

Live Clinical Hub credentials remain an external blocker, but the mobile client behavior before those secrets are configured should still be deterministic and tested. This strengthens the primary upload path without requiring private API access.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`95` tests passed)
- `npm run validate:ci` including TypeScript, `46` unit tests, Expo Doctor `21/21`, production audit `0 vulnerabilities`, and iOS/Android Expo exports
