### PR TITLE
[codex] Add Clinical Hub summary request unit coverage

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -14,6 +14,10 @@ import {
   buildRequestHeaders,
   fetchWithTimeout,
 } from "./src/api/clinicalHub";
+import {
+  buildCaptureCoverageSummaryUrl,
+  buildComparisonSummaryUrl,
+} from "./src/api/summaryRequests";
 import { buildCaptureContractPayloadFromSamples } from "./src/capture/buildCaptureContract";
 import {
   RuntimeCaptureSession,
@@ -674,16 +678,12 @@ export default function App() {
   }
 
   async function loadComparisonSummary() {
-    const baseUrl = buildBaseUrl(apiBaseUrl);
-    const params = new URLSearchParams();
-    if (siteId.trim()) {
-      params.set("site_id", siteId.trim());
-    }
-    if (summarySyncId.trim()) {
-      params.set("sync_id", summarySyncId.trim());
-    }
-    params.set("quality_status", summaryQualityStatus);
-    const url = `${baseUrl}/api/v1/comparison-summary?${params.toString()}`;
+    const url = buildComparisonSummaryUrl({
+      apiBaseUrl,
+      siteId,
+      summarySyncId,
+      summaryQualityStatus,
+    });
 
     setSummaryLoading(true);
     setSummaryError("");
@@ -713,16 +713,12 @@ export default function App() {
   }
 
   async function loadCaptureCoverageSummary() {
-    const baseUrl = buildBaseUrl(apiBaseUrl);
-    const params = new URLSearchParams();
-    if (siteId.trim()) {
-      params.set("site_id", siteId.trim());
-    }
-    if (summarySyncId.trim()) {
-      params.set("sync_id", summarySyncId.trim());
-    }
-    params.set("quality_status", summaryQualityStatus);
-    const url = `${baseUrl}/api/v1/capture-coverage-summary?${params.toString()}`;
+    const url = buildCaptureCoverageSummaryUrl({
+      apiBaseUrl,
+      siteId,
+      summarySyncId,
+      summaryQualityStatus,
+    });
 
     setCoverageLoading(true);
     setCoverageError("");

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -113,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, Clinical Hub API client + mobile helper/API + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, Clinical Hub API client/summary requests + mobile helper/API + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -13,6 +13,7 @@ tsc --ignoreConfig \
   src/payload/capturePackagePayload.ts \
   src/payload/pairedPayload.ts \
   src/api/clinicalHub.ts \
+  src/api/summaryRequests.ts \
   src/capture/buildCaptureContract.ts \
   src/capture/runtimeMetrics.ts \
   src/capture/roiSignalEstimator.ts \

--- a/apps/field-mobile/src/api/summaryRequests.ts
+++ b/apps/field-mobile/src/api/summaryRequests.ts
@@ -1,0 +1,35 @@
+import type { SummaryQualityStatus } from "../types";
+import { buildBaseUrl } from "./clinicalHub";
+
+type SummaryUrlOptions = {
+  apiBaseUrl: string;
+  siteId: string;
+  summarySyncId: string;
+  summaryQualityStatus: SummaryQualityStatus;
+};
+
+function buildSummaryQuery(options: SummaryUrlOptions): string {
+  const params = new URLSearchParams();
+  const siteId = options.siteId.trim();
+  const syncId = options.summarySyncId.trim();
+  if (siteId) {
+    params.set("site_id", siteId);
+  }
+  if (syncId) {
+    params.set("sync_id", syncId);
+  }
+  params.set("quality_status", options.summaryQualityStatus);
+  return params.toString();
+}
+
+export function buildComparisonSummaryUrl(options: SummaryUrlOptions): string {
+  return `${buildBaseUrl(options.apiBaseUrl)}/api/v1/comparison-summary?${buildSummaryQuery(
+    options,
+  )}`;
+}
+
+export function buildCaptureCoverageSummaryUrl(options: SummaryUrlOptions): string {
+  return `${buildBaseUrl(
+    options.apiBaseUrl,
+  )}/api/v1/capture-coverage-summary?${buildSummaryQuery(options)}`;
+}

--- a/apps/field-mobile/tests/summaryRequests.test.js
+++ b/apps/field-mobile/tests/summaryRequests.test.js
@@ -1,0 +1,44 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const summary = require(path.join(buildDir, "api/summaryRequests.js"));
+
+test("buildComparisonSummaryUrl includes trimmed site, sync, and quality filters", () => {
+  assert.equal(
+    summary.buildComparisonSummaryUrl({
+      apiBaseUrl: "https://clinical.example.test/",
+      siteId: " SITE-001 ",
+      summarySyncId: " SYNC-001 ",
+      summaryQualityStatus: "repeat",
+    }),
+    "https://clinical.example.test/api/v1/comparison-summary?site_id=SITE-001&sync_id=SYNC-001&quality_status=repeat",
+  );
+});
+
+test("buildCaptureCoverageSummaryUrl omits blank optional filters", () => {
+  assert.equal(
+    summary.buildCaptureCoverageSummaryUrl({
+      apiBaseUrl: "https://clinical.example.test",
+      siteId: " ",
+      summarySyncId: "",
+      summaryQualityStatus: "all",
+    }),
+    "https://clinical.example.test/api/v1/capture-coverage-summary?quality_status=all",
+  );
+});
+
+test("summary URL builders encode filter values", () => {
+  const url = summary.buildComparisonSummaryUrl({
+    apiBaseUrl: "https://clinical.example.test",
+    siteId: "SITE 1",
+    summarySyncId: "SYNC/001",
+    summaryQualityStatus: "valid",
+  });
+
+  assert.equal(
+    url,
+    "https://clinical.example.test/api/v1/comparison-summary?site_id=SITE+1&sync_id=SYNC%2F001&quality_status=valid",
+  );
+});

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -281,6 +281,7 @@ def build_readiness_report(
     pending_submission_storage_tests_path = (
         mobile_root / "tests" / "pendingSubmissionStorage.test.js"
     )
+    summary_requests_tests_path = mobile_root / "tests" / "summaryRequests.test.js"
     _check(
         checks,
         "unit_test_script",
@@ -358,6 +359,12 @@ def build_readiness_report(
         "pending_submission_storage_unit_tests_present",
         pending_submission_storage_tests_path.is_file(),
         f"path={pending_submission_storage_tests_path}",
+    )
+    _check(
+        checks,
+        "summary_requests_unit_tests_present",
+        summary_requests_tests_path.is_file(),
+        f"path={summary_requests_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -74,6 +74,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "pending_sync_queue_unit_tests_present",
         "roi_signal_unit_tests_present",
         "runtime_metrics_unit_tests_present",
+        "summary_requests_unit_tests_present",
     }.issubset(local_check_ids)
     assert {item["id"] for item in payload["next_actions"]} == {
         "configure_clinical_hub_live_api",


### PR DESCRIPTION
## Summary
- Extract Clinical Hub comparison/capture coverage summary URL builders from App.tsx into a testable API helper.
- Add unit coverage for trimmed filters, omitted blank filters, and URL encoding behavior.
- Wire the new test into the mobile unit runner and release-readiness evidence.

## Local validation
- `npm run validate:ci` in `apps/field-mobile` (`49/49` unit tests, Expo Doctor `21/21`, audit clean, iOS/Android exports)
- `.venv/bin/ruff check . && .venv/bin/pytest -q` (`95 passed`)

## External blockers unchanged
- Expo token / EAS project identity are still required for authenticated EAS build readiness.
- Live Clinical Hub API secrets and Apple/Google store accounts remain external provisioning tasks.
