### PR TITLE
[codex] Add submit outcome message unit coverage

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -39,6 +39,12 @@ import {
   loadAppSettings,
   saveAppSettings,
 } from "./src/storage/appStorage";
+import {
+  buildNonRetryableUploadMessage,
+  buildQueuedCapturePackageMessage,
+  buildQueuedPairedAndCaptureMessage,
+  buildRejectedCapturePackageMessage,
+} from "./src/utils/submitOutcome";
 import type {
   AppSettings,
   AuthContextResponse,
@@ -588,17 +594,11 @@ export default function App() {
               captureResult.body,
               captureResult.statusCode,
             );
-            const queuedMessage =
-              `Paired uploaded; capture package queued for retry: ` +
-              `${captureResult.statusCode ? `HTTP ${captureResult.statusCode}` : "NETWORK"} ` +
-              `${captureResult.body}`;
+            const queuedMessage = buildQueuedCapturePackageMessage(captureResult);
             setLastResponse(queuedMessage);
             Alert.alert("Submitted with queued capture", queuedMessage);
           } else {
-            const warningMessage =
-              `Paired measurement uploaded, but capture package rejected: ` +
-              `${captureResult.statusCode ? `HTTP ${captureResult.statusCode}` : "ERROR"} ` +
-              `${captureResult.body}`;
+            const warningMessage = buildRejectedCapturePackageMessage(captureResult);
             setLastResponse(warningMessage);
             Alert.alert("Submitted with warning", warningMessage);
           }
@@ -619,9 +619,7 @@ export default function App() {
       }
 
       if (!result.retryable) {
-        const nonRetryableMessage =
-          `Upload rejected and not queued. ` +
-          `${result.statusCode ? `HTTP ${result.statusCode}` : "ERROR"} ${result.body}`;
+        const nonRetryableMessage = buildNonRetryableUploadMessage(result);
         setLastResponse(nonRetryableMessage);
         Alert.alert(
           "Upload rejected",
@@ -654,11 +652,7 @@ export default function App() {
         "queued_with_paired_retry",
         null,
       );
-      setLastResponse(
-        `Queued paired+capture for retry. Last paired error: ${
-          result.statusCode ? `HTTP ${result.statusCode}` : "NETWORK"
-        } ${result.body}`
-      );
+      setLastResponse(buildQueuedPairedAndCaptureMessage(result));
       Alert.alert(
         "Saved offline",
         "No successful upload now. Paired and capture records added to pending queue.",

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -113,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, Clinical Hub API client/summary requests + mobile helper/API + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, Clinical Hub API client/summary requests + mobile helper/API + submit outcome + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -8,6 +8,7 @@ rm -rf "$BUILD_DIR"
 tsc --ignoreConfig \
   src/utils/appHelpers.ts \
   src/utils/pendingSyncQueue.ts \
+  src/utils/submitOutcome.ts \
   src/storage/appSettingsStorage.ts \
   src/storage/pendingSubmissionStorage.ts \
   src/payload/capturePackagePayload.ts \

--- a/apps/field-mobile/src/utils/submitOutcome.ts
+++ b/apps/field-mobile/src/utils/submitOutcome.ts
@@ -1,0 +1,41 @@
+import type { SubmitAttemptResult } from "../types";
+
+function formatAttemptProblem(
+  result: SubmitAttemptResult,
+  fallbackStatusLabel: "ERROR" | "NETWORK",
+): string {
+  return `${result.statusCode ? `HTTP ${result.statusCode}` : fallbackStatusLabel} ${result.body}`;
+}
+
+export function buildQueuedCapturePackageMessage(
+  result: SubmitAttemptResult,
+): string {
+  return `Paired uploaded; capture package queued for retry: ${formatAttemptProblem(
+    result,
+    "NETWORK",
+  )}`;
+}
+
+export function buildRejectedCapturePackageMessage(
+  result: SubmitAttemptResult,
+): string {
+  return `Paired measurement uploaded, but capture package rejected: ${formatAttemptProblem(
+    result,
+    "ERROR",
+  )}`;
+}
+
+export function buildNonRetryableUploadMessage(
+  result: SubmitAttemptResult,
+): string {
+  return `Upload rejected and not queued. ${formatAttemptProblem(result, "ERROR")}`;
+}
+
+export function buildQueuedPairedAndCaptureMessage(
+  result: SubmitAttemptResult,
+): string {
+  return `Queued paired+capture for retry. Last paired error: ${formatAttemptProblem(
+    result,
+    "NETWORK",
+  )}`;
+}

--- a/apps/field-mobile/tests/submitOutcome.test.js
+++ b/apps/field-mobile/tests/submitOutcome.test.js
@@ -1,0 +1,54 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const submitOutcome = require(path.join(buildDir, "utils/submitOutcome.js"));
+
+test("buildQueuedCapturePackageMessage preserves retryable HTTP wording", () => {
+  assert.equal(
+    submitOutcome.buildQueuedCapturePackageMessage({
+      ok: false,
+      statusCode: 503,
+      body: "upstream unavailable",
+      retryable: true,
+    }),
+    "Paired uploaded; capture package queued for retry: HTTP 503 upstream unavailable",
+  );
+});
+
+test("buildRejectedCapturePackageMessage uses ERROR fallback for non-HTTP failures", () => {
+  assert.equal(
+    submitOutcome.buildRejectedCapturePackageMessage({
+      ok: false,
+      statusCode: null,
+      body: "invalid capture payload",
+      retryable: false,
+    }),
+    "Paired measurement uploaded, but capture package rejected: ERROR invalid capture payload",
+  );
+});
+
+test("buildNonRetryableUploadMessage preserves validation rejection wording", () => {
+  assert.equal(
+    submitOutcome.buildNonRetryableUploadMessage({
+      ok: false,
+      statusCode: 422,
+      body: "validation error",
+      retryable: false,
+    }),
+    "Upload rejected and not queued. HTTP 422 validation error",
+  );
+});
+
+test("buildQueuedPairedAndCaptureMessage uses NETWORK fallback for retryable network failures", () => {
+  assert.equal(
+    submitOutcome.buildQueuedPairedAndCaptureMessage({
+      ok: false,
+      statusCode: null,
+      body: "TypeError: failed to fetch",
+      retryable: true,
+    }),
+    "Queued paired+capture for retry. Last paired error: NETWORK TypeError: failed to fetch",
+  );
+});

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -282,6 +282,7 @@ def build_readiness_report(
         mobile_root / "tests" / "pendingSubmissionStorage.test.js"
     )
     summary_requests_tests_path = mobile_root / "tests" / "summaryRequests.test.js"
+    submit_outcome_tests_path = mobile_root / "tests" / "submitOutcome.test.js"
     _check(
         checks,
         "unit_test_script",
@@ -365,6 +366,12 @@ def build_readiness_report(
         "summary_requests_unit_tests_present",
         summary_requests_tests_path.is_file(),
         f"path={summary_requests_tests_path}",
+    )
+    _check(
+        checks,
+        "submit_outcome_unit_tests_present",
+        submit_outcome_tests_path.is_file(),
+        f"path={submit_outcome_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -75,6 +75,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "roi_signal_unit_tests_present",
         "runtime_metrics_unit_tests_present",
         "summary_requests_unit_tests_present",
+        "submit_outcome_unit_tests_present",
     }.issubset(local_check_ids)
     assert {item["id"] for item in payload["next_actions"]} == {
         "configure_clinical_hub_live_api",


### PR DESCRIPTION
## Summary
- Extract submit outcome message builders from `App.tsx` into a testable helper.
- Add unit coverage for retryable capture queueing, capture rejection warnings, non-retryable paired upload rejection, and paired+capture offline queue messaging.
- Wire the new test into the mobile unit runner and release-readiness evidence.

## Local validation
- First `npm run validate:ci` reached TypeScript + `53/53` unit tests, then hit a transient `expo-doctor` subprocess exit 7.
- Retried `npm run doctor`: Expo Doctor `21/21` passed.
- Retried full `npm run validate:ci`: `53/53` unit tests, Expo Doctor `21/21`, production audit clean, iOS/Android exports passed.
- `.venv/bin/ruff check . && .venv/bin/pytest -q` (`95 passed`)

## External blockers unchanged
- Expo token / EAS project identity are still required for authenticated EAS build readiness.
- Live Clinical Hub API secrets and Apple/Google store accounts remain external provisioning tasks.
