### PR TITLE
[codex] Add API connection check unit coverage

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -10,10 +10,17 @@ import { StatusBar } from "expo-status-bar";
 import { CameraView, useCameraPermissions } from "expo-camera";
 import {
   attemptSubmitEndpoint,
-  buildBaseUrl,
   buildRequestHeaders,
   fetchWithTimeout,
 } from "./src/api/clinicalHub";
+import {
+  buildApiCheckFailedMessage,
+  buildAuthContextCheckFailedMessage,
+  buildAuthContextOkMessage,
+  buildAuthContextUrl,
+  buildHealthCheckFailedMessage,
+  buildHealthUrl,
+} from "./src/api/connectionCheck";
 import {
   buildCaptureCoverageSummaryUrl,
   buildComparisonSummaryUrl,
@@ -489,8 +496,7 @@ export default function App() {
   }
 
   async function testApiConnection(): Promise<void> {
-    const baseUrl = buildBaseUrl(apiBaseUrl);
-    const authContextUrl = `${baseUrl}/api/v1/auth-context`;
+    const authContextUrl = buildAuthContextUrl(apiBaseUrl);
     try {
       const response = await fetchWithTimeout(
         authContextUrl,
@@ -502,7 +508,7 @@ export default function App() {
       );
       if (response.status === 404) {
         const healthResponse = await fetchWithTimeout(
-          `${baseUrl}/health`,
+          buildHealthUrl(apiBaseUrl),
           {
             method: "GET",
             headers: buildRequestHeaders(false, createCurrentRequestHeaderContext()),
@@ -510,7 +516,7 @@ export default function App() {
           requestTimeoutMs,
         );
         if (!healthResponse.ok) {
-          setLastResponse(`Health check failed: HTTP ${healthResponse.status}`);
+          setLastResponse(buildHealthCheckFailedMessage(healthResponse.status));
           Alert.alert("API check failed", `HTTP ${healthResponse.status}`);
           return;
         }
@@ -520,21 +526,18 @@ export default function App() {
       }
       if (!response.ok) {
         const body = await response.text();
-        setLastResponse(`Auth-context check failed: HTTP ${response.status} ${body}`);
+        setLastResponse(buildAuthContextCheckFailedMessage(response.status, body));
         Alert.alert("API check failed", `HTTP ${response.status}`);
         return;
       }
       const body = await response.text();
       const authContext = JSON.parse(body) as AuthContextResponse;
-      const message =
-        `Auth context OK: auth=${authContext.auth_result}, ` +
-        `role=${authContext.actor_role ?? "n/a"}, ` +
-        `site=${authContext.actor_site_id ?? "n/a"}`;
+      const message = buildAuthContextOkMessage(authContext);
       setLastResponse(message);
       Alert.alert("API reachable", message);
     } catch (error) {
       const message = String(error);
-      setLastResponse(`API check failed: ${message}`);
+      setLastResponse(buildApiCheckFailedMessage(error));
       Alert.alert("API check failed", message);
     }
   }

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -113,7 +113,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, Clinical Hub API client/summary requests + mobile helper/API + submit outcome + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, Clinical Hub API client/connection check/summary requests + mobile helper/API + submit outcome + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -14,6 +14,7 @@ tsc --ignoreConfig \
   src/payload/capturePackagePayload.ts \
   src/payload/pairedPayload.ts \
   src/api/clinicalHub.ts \
+  src/api/connectionCheck.ts \
   src/api/summaryRequests.ts \
   src/capture/buildCaptureContract.ts \
   src/capture/runtimeMetrics.ts \

--- a/apps/field-mobile/src/api/connectionCheck.ts
+++ b/apps/field-mobile/src/api/connectionCheck.ts
@@ -1,0 +1,35 @@
+import type { AuthContextResponse } from "../types";
+import { buildBaseUrl } from "./clinicalHub";
+
+export function buildAuthContextUrl(apiBaseUrl: string): string {
+  return `${buildBaseUrl(apiBaseUrl)}/api/v1/auth-context`;
+}
+
+export function buildHealthUrl(apiBaseUrl: string): string {
+  return `${buildBaseUrl(apiBaseUrl)}/health`;
+}
+
+export function buildHealthCheckFailedMessage(status: number): string {
+  return `Health check failed: HTTP ${status}`;
+}
+
+export function buildAuthContextCheckFailedMessage(
+  status: number,
+  body: string,
+): string {
+  return `Auth-context check failed: HTTP ${status} ${body}`;
+}
+
+export function buildAuthContextOkMessage(
+  authContext: AuthContextResponse,
+): string {
+  return (
+    `Auth context OK: auth=${authContext.auth_result}, ` +
+    `role=${authContext.actor_role ?? "n/a"}, ` +
+    `site=${authContext.actor_site_id ?? "n/a"}`
+  );
+}
+
+export function buildApiCheckFailedMessage(error: unknown): string {
+  return `API check failed: ${String(error)}`;
+}

--- a/apps/field-mobile/tests/connectionCheck.test.js
+++ b/apps/field-mobile/tests/connectionCheck.test.js
@@ -1,0 +1,48 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const connectionCheck = require(path.join(buildDir, "api/connectionCheck.js"));
+
+test("connection check URL builders normalize API base URL", () => {
+  assert.equal(
+    connectionCheck.buildAuthContextUrl("https://clinical.example.test/"),
+    "https://clinical.example.test/api/v1/auth-context",
+  );
+  assert.equal(
+    connectionCheck.buildHealthUrl("https://clinical.example.test"),
+    "https://clinical.example.test/health",
+  );
+});
+
+test("connection check failure messages preserve HTTP status and body", () => {
+  assert.equal(
+    connectionCheck.buildHealthCheckFailedMessage(503),
+    "Health check failed: HTTP 503",
+  );
+  assert.equal(
+    connectionCheck.buildAuthContextCheckFailedMessage(403, "forbidden"),
+    "Auth-context check failed: HTTP 403 forbidden",
+  );
+});
+
+test("buildAuthContextOkMessage summarizes actor context with n/a fallbacks", () => {
+  assert.equal(
+    connectionCheck.buildAuthContextOkMessage({
+      auth_result: "api_key_valid",
+      actor_role: null,
+      actor_site_id: null,
+      actor_operator_id: "OP-001",
+      cross_site_allowed: false,
+    }),
+    "Auth context OK: auth=api_key_valid, role=n/a, site=n/a",
+  );
+});
+
+test("buildApiCheckFailedMessage stringifies thrown errors", () => {
+  assert.equal(
+    connectionCheck.buildApiCheckFailedMessage(new Error("network down")),
+    "API check failed: Error: network down",
+  );
+});

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -272,6 +272,7 @@ def build_readiness_report(
     helper_tests_path = mobile_root / "tests" / "appHelpers.test.js"
     app_settings_storage_tests_path = mobile_root / "tests" / "appSettingsStorage.test.js"
     clinical_hub_api_tests_path = mobile_root / "tests" / "clinicalHub.test.js"
+    connection_check_tests_path = mobile_root / "tests" / "connectionCheck.test.js"
     capture_package_payload_tests_path = mobile_root / "tests" / "capturePackagePayload.test.js"
     capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
     paired_payload_tests_path = mobile_root / "tests" / "pairedPayload.test.js"
@@ -318,6 +319,12 @@ def build_readiness_report(
         "clinical_hub_api_unit_tests_present",
         clinical_hub_api_tests_path.is_file(),
         f"path={clinical_hub_api_tests_path}",
+    )
+    _check(
+        checks,
+        "connection_check_unit_tests_present",
+        connection_check_tests_path.is_file(),
+        f"path={connection_check_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -69,6 +69,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "validate_ci_runs_unit_tests",
         "unit_test_runner_script",
         "mobile_helper_unit_tests_present",
+        "connection_check_unit_tests_present",
         "capture_contract_unit_tests_present",
         "pending_submission_storage_unit_tests_present",
         "pending_sync_queue_unit_tests_present",


### PR DESCRIPTION
## Summary
- Extract API connection check URL/message helpers from `App.tsx` into `src/api/connectionCheck.ts`.
- Add unit coverage for auth-context/health URLs, HTTP failure messages, auth-context OK summaries, and thrown error stringification.
- Wire the new test into the mobile unit runner and release-readiness evidence.

## Local validation
- `npm run validate:ci` in `apps/field-mobile` (`57/57` unit tests, Expo Doctor `21/21`, audit clean, iOS/Android exports)
- `.venv/bin/ruff check . && .venv/bin/pytest -q` (`95 passed`)

## External blockers unchanged
- Expo token / EAS project identity are still required for authenticated EAS build readiness.
- Live Clinical Hub API secrets and Apple/Google store accounts remain external provisioning tasks.
