### PR TITLE
[codex] Strengthen mobile release metadata readiness checks

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -129,6 +129,9 @@ CI:
 `mobile-release-readiness` intentionally separates local readiness from external account and
 secret blockers. The artifact has separate machine-readable gates:
 
+- `local_checks_status`: local app metadata, EAS profile shape, store privacy declarations,
+  dependency lock alignment, and unit-test evidence that can be verified without external
+  credentials.
 - `authenticated_eas_status`: whether `EXPO_TOKEN` and deterministic EAS project identity are ready for an authenticated EAS build trigger.
 - `clinical_hub_live_api_status`: whether live Clinical Hub API smoke/report-push credentials are configured.
 - `external_readiness_status`: aggregate external status across Expo/EAS + Clinical Hub.

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -185,6 +185,9 @@ def build_readiness_report(
     checks: list[dict[str, Any]] = []
 
     platforms = expo.get("platforms", [])
+    package_dependencies = package_payload.get("dependencies", {})
+    lock_dependencies = root_lock.get("dependencies", {})
+    lock_dev_dependencies = root_lock.get("devDependencies", {})
     _check(
         checks,
         "platforms_ios_android",
@@ -196,6 +199,16 @@ def build_readiness_report(
     _check(checks, "expo_version", bool(expo.get("version")), f"version={expo.get('version')!r}")
     _check(
         checks,
+        "app_version_matches_package_version",
+        expo.get("version") == package_payload.get("version") == root_lock.get("version"),
+        (
+            f"expo.version={expo.get('version')!r}, "
+            f"package.version={package_payload.get('version')!r}, "
+            f"lock.version={root_lock.get('version')!r}"
+        ),
+    )
+    _check(
+        checks,
         "ios_bundle_identifier",
         bool(ios.get("bundleIdentifier")),
         f"bundleIdentifier={ios.get('bundleIdentifier')!r}",
@@ -205,6 +218,22 @@ def build_readiness_report(
         "ios_build_number",
         bool(ios.get("buildNumber")),
         f"buildNumber={ios.get('buildNumber')!r}",
+    )
+    ios_info_plist = ios.get("infoPlist", {})
+    required_ios_privacy_strings = {
+        "NSCameraUsageDescription",
+        "NSMicrophoneUsageDescription",
+        "NSMotionUsageDescription",
+    }
+    _check(
+        checks,
+        "ios_privacy_usage_descriptions",
+        required_ios_privacy_strings.issubset(set(ios_info_plist))
+        and all(
+            isinstance(ios_info_plist.get(key), str) and bool(ios_info_plist.get(key, "").strip())
+            for key in required_ios_privacy_strings
+        ),
+        f"infoPlist keys={sorted(ios_info_plist)}",
     )
     _check(
         checks,
@@ -245,6 +274,38 @@ def build_readiness_report(
         {"CAMERA", "RECORD_AUDIO"}.issubset(set(android.get("permissions", []))),
         f"permissions={android.get('permissions', [])!r}",
     )
+    _check(
+        checks,
+        "android_runtime_permissions_minimal",
+        set(android.get("permissions", [])) == {"CAMERA", "RECORD_AUDIO"},
+        f"permissions={android.get('permissions', [])!r}",
+        severity="warning",
+    )
+    _check(
+        checks,
+        "secure_store_plugin",
+        _has_plugin(plugins, "expo-secure-store"),
+        "expo-secure-store plugin configured",
+    )
+    _check(
+        checks,
+        "secure_store_dependency_locked",
+        "expo-secure-store" in package_dependencies
+        and package_dependencies.get("expo-secure-store")
+        == lock_dependencies.get("expo-secure-store"),
+        (
+            "expo-secure-store dependency="
+            f"{package_dependencies.get('expo-secure-store')!r}, "
+            f"lock={lock_dependencies.get('expo-secure-store')!r}"
+        ),
+    )
+    _check(
+        checks,
+        "audio_microphone_permission",
+        isinstance(audio_options.get("microphonePermission"), str)
+        and bool(audio_options.get("microphonePermission", "").strip()),
+        f"microphonePermission={audio_options.get('microphonePermission')!r}",
+    )
 
     for profile in ("development", "preview", "production"):
         _check(
@@ -253,6 +314,30 @@ def build_readiness_report(
             profile in eas_build,
             f"eas build profiles={list(eas_build)}",
         )
+    _check(
+        checks,
+        "eas_cli_version_declared",
+        bool(eas_payload.get("cli", {}).get("version")),
+        f"eas.cli.version={eas_payload.get('cli', {}).get('version')!r}",
+    )
+    _check(
+        checks,
+        "eas_profile_channels",
+        eas_build.get("development", {}).get("channel") == "development"
+        and eas_build.get("preview", {}).get("channel") == "preview"
+        and eas_build.get("production", {}).get("channel") == "production",
+        (
+            f"development={eas_build.get('development', {}).get('channel')!r}, "
+            f"preview={eas_build.get('preview', {}).get('channel')!r}, "
+            f"production={eas_build.get('production', {}).get('channel')!r}"
+        ),
+    )
+    _check(
+        checks,
+        "eas_production_auto_increment",
+        eas_build.get("production", {}).get("autoIncrement") is True,
+        f"production.autoIncrement={eas_build.get('production', {}).get('autoIncrement')!r}",
+    )
     _check(
         checks,
         "preview_android_apk",
@@ -389,14 +474,18 @@ def build_readiness_report(
     _check(
         checks,
         "package_lock_matches_root",
-        root_lock.get("name") == package_payload.get("name"),
-        f"lock root={root_lock.get('name')!r}, package={package_payload.get('name')!r}",
+        root_lock.get("name") == package_payload.get("name")
+        and root_lock.get("version") == package_payload.get("version"),
+        (
+            f"lock root={root_lock.get('name')!r}/{root_lock.get('version')!r}, "
+            f"package={package_payload.get('name')!r}/{package_payload.get('version')!r}"
+        ),
     )
     _check(
         checks,
         "expo_doctor_pinned",
         package_payload.get("devDependencies", {}).get("expo-doctor") == "1.19.8"
-        and root_lock.get("devDependencies", {}).get("expo-doctor") == "1.19.8",
+        and lock_dev_dependencies.get("expo-doctor") == "1.19.8",
         "expo-doctor devDependency is pinned in package.json and package-lock.json",
     )
 

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -13,26 +13,39 @@ PACKAGE_JSON = Path("apps/field-mobile/package.json")
 PACKAGE_LOCK = Path("apps/field-mobile/package-lock.json")
 
 
-def _run_readiness(output: Path, env: dict[str, str]) -> dict:
+def _run_readiness_with_paths(
+    output: Path,
+    env: dict[str, str],
+    *,
+    app_json: Path = APP_JSON,
+    eas_json: Path = EAS_JSON,
+    package_json: Path = PACKAGE_JSON,
+    package_lock: Path = PACKAGE_LOCK,
+    check: bool = True,
+) -> dict:
     subprocess.run(
         [
             sys.executable,
             str(SCRIPT),
             "--app-json",
-            str(APP_JSON),
+            str(app_json),
             "--eas-json",
-            str(EAS_JSON),
+            str(eas_json),
             "--package-json",
-            str(PACKAGE_JSON),
+            str(package_json),
             "--package-lock",
-            str(PACKAGE_LOCK),
+            str(package_lock),
             "--output",
             str(output),
         ],
-        check=True,
+        check=check,
         env=env,
     )
     return json.loads(output.read_text(encoding="utf-8"))
+
+
+def _run_readiness(output: Path, env: dict[str, str]) -> dict:
+    return _run_readiness_with_paths(output, env)
 
 
 def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> None:
@@ -61,10 +74,20 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
     assert all(item["status"] == "pass" for item in payload["local_checks"])
     local_check_ids = {item["id"] for item in payload["local_checks"]}
     assert {
+        "android_runtime_permissions_minimal",
+        "app_version_matches_package_version",
         "app_settings_storage_unit_tests_present",
+        "audio_microphone_permission",
         "clinical_hub_api_unit_tests_present",
         "capture_package_payload_unit_tests_present",
+        "eas_cli_version_declared",
+        "eas_production_auto_increment",
+        "eas_profile_channels",
+        "ios_privacy_usage_descriptions",
         "paired_payload_unit_tests_present",
+        "package_lock_matches_root",
+        "secure_store_dependency_locked",
+        "secure_store_plugin",
         "unit_test_script",
         "validate_ci_runs_unit_tests",
         "unit_test_runner_script",
@@ -90,6 +113,30 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
     )
     assert expo_action["secret_names"] == ["EXPO_TOKEN"]
     assert expo_action["verification"]
+
+
+def test_mobile_release_readiness_fails_local_version_mismatch(tmp_path: Path) -> None:
+    mutated_app_json = tmp_path / "app.json"
+    app_payload = json.loads(APP_JSON.read_text(encoding="utf-8"))
+    app_payload["expo"]["version"] = "9.9.9"
+    mutated_app_json.write_text(json.dumps(app_payload), encoding="utf-8")
+
+    payload = _run_readiness_with_paths(
+        tmp_path / "readiness.json",
+        env={"PATH": os.environ.get("PATH", "")},
+        app_json=mutated_app_json,
+        check=False,
+    )
+
+    check = next(
+        item
+        for item in payload["local_checks"]
+        if item["id"] == "app_version_matches_package_version"
+    )
+    assert payload["status"] == "not_ready"
+    assert payload["local_checks_status"] == "fail"
+    assert check["status"] == "fail"
+    assert "expo.version='9.9.9'" in check["evidence"]
 
 
 def test_mobile_release_readiness_passes_authenticated_preflight_env(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Strengthen `mobile-release-readiness` local gates for store/release metadata: app/package/lock version alignment, iOS privacy strings, minimal Android runtime permissions, secure-store plugin/dependency lock, EAS CLI/channels/production auto-increment.
- Add a negative pytest proving a local version mismatch produces `status=not_ready` and `local_checks_status=fail`.
- Document that local readiness now covers app metadata, EAS profile shape, store privacy declarations, dependency lock alignment, and unit-test evidence.

## Local validation
- `.venv/bin/ruff check . && .venv/bin/pytest -q` (`96 passed`)
- `scripts/check_mobile_release_readiness.py` via `.venv/bin/python`: `status=ready_except_external_credentials`, selected new local gates `pass`
- `npm run validate:ci` in `apps/field-mobile` (`57/57` unit tests, Expo Doctor `21/21`, audit clean, iOS/Android exports)

## External blockers unchanged
- Expo token / EAS project identity are still required for authenticated EAS build readiness.
- Live Clinical Hub API secrets and Apple/Google store accounts remain external provisioning tasks.
