### PR TITLE
[codex] Run mobile build preflight for release script changes

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -31,6 +31,14 @@ on:
       - main
     paths:
       - "apps/field-mobile/**"
+      - "scripts/build_mobile_release_manifest.py"
+      - "scripts/check_mobile_release_readiness.py"
+      - ".github/workflows/mobile-build.yml"
+  pull_request:
+    paths:
+      - "apps/field-mobile/**"
+      - "scripts/build_mobile_release_manifest.py"
+      - "scripts/check_mobile_release_readiness.py"
       - ".github/workflows/mobile-build.yml"
 
 concurrency:

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -114,7 +114,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
 - `validate:ci` covers TypeScript, Clinical Hub API client/connection check/summary requests + mobile helper/API + submit outcome + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
-- `.github/workflows/mobile-build.yml` provides manual EAS build trigger (`workflow_dispatch`) with inputs:
+- `.github/workflows/mobile-build.yml` runs release preflight for mobile app/release-script changes and provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)
   - `wait_for_build` (`true` / `false`)

--- a/tests/test_mobile_build_workflow.py
+++ b/tests/test_mobile_build_workflow.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(".github/workflows/mobile-build.yml")
+
+
+def _workflow_triggers() -> dict:
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    # PyYAML follows YAML 1.1 and may parse the GitHub Actions `on` key as True.
+    return payload.get("on") or payload[True]
+
+
+def test_mobile_build_workflow_runs_for_release_script_changes() -> None:
+    triggers = _workflow_triggers()
+    required_paths = {
+        "apps/field-mobile/**",
+        "scripts/build_mobile_release_manifest.py",
+        "scripts/check_mobile_release_readiness.py",
+        ".github/workflows/mobile-build.yml",
+    }
+
+    assert required_paths.issubset(set(triggers["push"]["paths"]))
+    assert required_paths.issubset(set(triggers["pull_request"]["paths"]))


### PR DESCRIPTION
## Summary
- Add `pull_request` preflight coverage to `Mobile Build` for mobile app and release-script changes.
- Extend `Mobile Build` push path filters to include the release manifest/readiness scripts it executes.
- Add pytest coverage that parses the workflow and asserts release-script paths are included for both push and PR triggers.
- Update mobile README to describe release preflight behavior separately from manual EAS dispatch.

## Local validation
- `.venv/bin/ruff check . && .venv/bin/pytest -q` (`97 passed`)
- `npm run validate:ci` in `apps/field-mobile` (`57/57` unit tests, Expo Doctor `21/21`, audit clean, iOS/Android exports)

## External blockers unchanged
- Expo token / EAS project identity are still required for authenticated EAS build readiness.
- Live Clinical Hub API secrets and Apple/Google store accounts remain external provisioning tasks.
