### PR TITLE
[codex] Upload mobile readiness artifact before local failure

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -75,18 +75,23 @@ jobs:
         run: npm run validate:ci
 
       - name: Build release readiness report
+        shell: bash
         env:
           CLINICAL_HUB_API_KEY: ${{ secrets.CLINICAL_HUB_API_KEY }}
           CLINICAL_HUB_URL: ${{ secrets.CLINICAL_HUB_URL }}
           EAS_PROJECT_ID: ${{ vars.EAS_PROJECT_ID }}
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
+          set +e
           python3 ../../scripts/check_mobile_release_readiness.py \
             --app-json app.json \
             --eas-json eas.json \
             --package-json package.json \
             --package-lock package-lock.json \
             --output /tmp/mobile-release-readiness.json
+          readiness_exit_code=$?
+          set -e
+          echo "$readiness_exit_code" > /tmp/mobile-release-readiness-exit-code
 
       - name: Export release readiness outputs
         id: readiness
@@ -181,6 +186,17 @@ jobs:
         with:
           name: mobile-release-readiness
           path: /tmp/mobile-release-readiness.json
+
+      - name: Fail on local release readiness errors
+        shell: bash
+        run: |
+          set -euo pipefail
+          readiness_exit_code="$(cat /tmp/mobile-release-readiness-exit-code 2>/dev/null || echo 1)"
+          if [[ "$readiness_exit_code" != "0" ]]; then
+            echo "Mobile release readiness failed with exit code $readiness_exit_code."
+            echo "See the mobile-release-readiness artifact for local check details."
+            exit "$readiness_exit_code"
+          fi
 
   eas-build:
     runs-on: ubuntu-latest

--- a/tests/test_mobile_build_workflow.py
+++ b/tests/test_mobile_build_workflow.py
@@ -24,3 +24,17 @@ def test_mobile_build_workflow_runs_for_release_script_changes() -> None:
 
     assert required_paths.issubset(set(triggers["push"]["paths"]))
     assert required_paths.issubset(set(triggers["pull_request"]["paths"]))
+
+
+def test_mobile_build_workflow_uploads_readiness_before_local_failure() -> None:
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = payload["jobs"]["preflight"]["steps"]
+    step_names = [step.get("name") for step in steps]
+
+    build_index = step_names.index("Build release readiness report")
+    upload_index = step_names.index("Upload release readiness report")
+    fail_index = step_names.index("Fail on local release readiness errors")
+
+    assert build_index < upload_index < fail_index
+    assert "mobile-release-readiness-exit-code" in steps[build_index]["run"]
+    assert "mobile-release-readiness artifact" in steps[fail_index]["run"]


### PR DESCRIPTION
## Summary
- Keep `Mobile Build` readiness JSON generation from aborting the job before artifacts are uploaded.
- Store the readiness script exit code and add a final fail step after release manifest/readiness artifacts are uploaded.
- Add pytest coverage that enforces `Build release readiness report` runs before `Upload release readiness report`, which runs before the final local-readiness fail step.

## Local validation
- `.venv/bin/ruff check . && .venv/bin/pytest -q` (`98 passed`)
- `npm run validate:ci` in `apps/field-mobile` (`57/57` unit tests, Expo Doctor `21/21`, audit clean, iOS/Android exports)

## External blockers unchanged
- Expo token / EAS project identity are still required for authenticated EAS build readiness.
- Live Clinical Hub API secrets and Apple/Google store accounts remain external provisioning tasks.
