### PR TITLE
[codex] Add mobile release asset fingerprints to manifest

### DIFF
--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -44,6 +44,8 @@ npm run build:preview
 
 Workflow generates artifact `mobile-release-manifest` containing:
 - app version and package IDs,
+- iOS build number and Android versionCode,
+- icon/adaptive-icon paths, SHA-256 fingerprints, byte sizes, and PNG dimensions,
 - git SHA/ref/run-id,
 - model_id and capture schema version.
 - selected build profile/channel.

--- a/scripts/build_mobile_release_manifest.py
+++ b/scripts/build_mobile_release_manifest.py
@@ -2,10 +2,41 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
+
+
+def _asset_path(app_json: Path, raw_path: Any) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = app_json.parent / candidate
+    return candidate
+
+
+def _png_dimensions(path: Path) -> list[int] | None:
+    header = path.read_bytes()[:24]
+    if len(header) < 24 or header[:8] != b"\x89PNG\r\n\x1a\n" or header[12:16] != b"IHDR":
+        return None
+    return [int.from_bytes(header[16:20], "big"), int.from_bytes(header[20:24], "big")]
+
+
+def _asset_metadata(app_json: Path, raw_path: Any) -> dict[str, Any] | None:
+    path = _asset_path(app_json, raw_path)
+    if path is None or not path.is_file():
+        return None
+    data = path.read_bytes()
+    return {
+        "path": raw_path,
+        "bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "png_dimensions": _png_dimensions(path),
+    }
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,6 +56,9 @@ def main() -> int:
     args = parse_args()
     app_payload = json.loads(args.app_json.read_text(encoding="utf-8"))
     expo = app_payload.get("expo", {})
+    ios = expo.get("ios", {})
+    android = expo.get("android", {})
+    android_adaptive_icon = android.get("adaptiveIcon", {})
 
     manifest = {
         "generated_at_utc": datetime.now(timezone.utc).isoformat(),
@@ -37,8 +71,19 @@ def main() -> int:
             "name": expo.get("name"),
             "slug": expo.get("slug"),
             "version": expo.get("version"),
-            "ios_bundle_identifier": expo.get("ios", {}).get("bundleIdentifier"),
-            "android_package": expo.get("android", {}).get("package"),
+            "ios_bundle_identifier": ios.get("bundleIdentifier"),
+            "ios_build_number": ios.get("buildNumber"),
+            "android_package": android.get("package"),
+            "android_version_code": android.get("versionCode"),
+        },
+        "assets": {
+            "icon": _asset_metadata(args.app_json, expo.get("icon")),
+            "android_adaptive_icon": {
+                "foreground": _asset_metadata(
+                    args.app_json, android_adaptive_icon.get("foregroundImage")
+                ),
+                "background_color": android_adaptive_icon.get("backgroundColor"),
+            },
         },
         "traceability": {
             "git_sha": os.environ.get("GITHUB_SHA", "local"),

--- a/tests/test_mobile_release_manifest_script.py
+++ b/tests/test_mobile_release_manifest_script.py
@@ -3,12 +3,37 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import zlib
 from pathlib import Path
+
+
+def _write_png(path: Path, width: int, height: int) -> None:
+    import struct
+
+    def chunk(kind: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + kind
+            + data
+            + struct.pack(">I", zlib.crc32(kind + data) & 0xFFFFFFFF)
+        )
+
+    row = b"\x00" + (b"\x00\x00\x00\xff" * width)
+    raw = row * height
+    payload = b"\x89PNG\r\n\x1a\n"
+    payload += chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0))
+    payload += chunk(b"IDAT", zlib.compress(raw, 9))
+    payload += chunk(b"IEND", b"")
+    path.write_bytes(payload)
 
 
 def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     app_json = tmp_path / "app.json"
     output = tmp_path / "manifest.json"
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    _write_png(assets / "icon.png", 1024, 1024)
+    _write_png(assets / "adaptive-icon.png", 1024, 1024)
 
     app_json.write_text(
         json.dumps(
@@ -17,9 +42,20 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
                     "name": "Uroflow Field",
                     "slug": "uroflow-field-mobile",
                     "version": "0.1.0",
+                    "icon": "./assets/icon.png",
                     "platforms": ["ios", "android"],
-                    "ios": {"bundleIdentifier": "com.uroflow.field"},
-                    "android": {"package": "com.uroflow.field"},
+                    "ios": {
+                        "bundleIdentifier": "com.uroflow.field",
+                        "buildNumber": "1",
+                    },
+                    "android": {
+                        "package": "com.uroflow.field",
+                        "versionCode": 1,
+                        "adaptiveIcon": {
+                            "foregroundImage": "./assets/adaptive-icon.png",
+                            "backgroundColor": "#0B1F2A",
+                        },
+                    },
                 }
             }
         ),
@@ -51,5 +87,19 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     assert payload["release"]["profile"] == "preview"
     assert payload["release"]["channel"] == "preview"
     assert payload["app"]["name"] == "Uroflow Field"
+    assert payload["app"]["ios_build_number"] == "1"
+    assert payload["app"]["android_version_code"] == 1
+    assert payload["assets"]["icon"]["path"] == "./assets/icon.png"
+    assert payload["assets"]["icon"]["bytes"] > 0
+    assert len(payload["assets"]["icon"]["sha256"]) == 64
+    assert payload["assets"]["icon"]["png_dimensions"] == [1024, 1024]
+    assert payload["assets"]["android_adaptive_icon"]["foreground"]["path"] == (
+        "./assets/adaptive-icon.png"
+    )
+    assert payload["assets"]["android_adaptive_icon"]["foreground"]["png_dimensions"] == [
+        1024,
+        1024,
+    ]
+    assert payload["assets"]["android_adaptive_icon"]["background_color"] == "#0B1F2A"
     assert payload["algorithm"]["model_id"] == "fusion-v0.1"
     assert payload["algorithm"]["capture_schema_version"] == "ios_capture_v1"


### PR DESCRIPTION
## Summary
- Extend `mobile-release-manifest` with iOS build number and Android versionCode.
- Add icon/adaptive-icon traceability: path, byte size, SHA-256 fingerprint, and PNG dimensions.
- Update manifest pytest coverage with generated PNG fixtures.
- Document the added manifest fields in the mobile release runbook.

## Local validation
- `.venv/bin/ruff check . && .venv/bin/pytest -q` (`99 passed`)
- `scripts/build_mobile_release_manifest.py` via `.venv/bin/python`: manifest includes build numbers and icon/adaptive-icon SHA-256 + dimensions
- `npm run validate:ci` in `apps/field-mobile` (`57/57` unit tests, Expo Doctor `21/21`, audit clean, iOS/Android exports)

## External blockers unchanged
- Expo token / EAS project identity are still required for authenticated EAS build readiness.
- Live Clinical Hub API secrets and Apple/Google store accounts remain external provisioning tasks.
