### PR TITLE
[codex] Remove localhost mobile API default

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -10,8 +10,10 @@ import { StatusBar } from "expo-status-bar";
 import { CameraView, useCameraPermissions } from "expo-camera";
 import {
   attemptSubmitEndpoint,
+  buildMissingApiBaseUrlMessage,
   buildRequestHeaders,
   fetchWithTimeout,
+  isConfiguredApiBaseUrl,
 } from "./src/api/clinicalHub";
 import {
   buildApiCheckFailedMessage,
@@ -47,6 +49,7 @@ import {
   loadAppSettings,
   saveAppSettings,
 } from "./src/storage/appStorage";
+import { DEFAULT_API_BASE_URL } from "./src/storage/appSettingsStorage";
 import {
   buildNonRetryableUploadMessage,
   buildQueuedCapturePackageMessage,
@@ -79,7 +82,7 @@ export default function App() {
   const defaultPlatform = Platform.OS === "ios" ? "ios" : "android";
   const [cameraPermission, requestCameraPermission] = useCameraPermissions();
 
-  const [apiBaseUrl, setApiBaseUrl] = useState("http://127.0.0.1:8000");
+  const [apiBaseUrl, setApiBaseUrl] = useState(DEFAULT_API_BASE_URL);
   const [apiKey, setApiKey] = useState("");
   const [actorRole, setActorRole] = useState("operator");
   const [requestTimeoutMs, setRequestTimeoutMs] = useState(DEFAULT_REQUEST_TIMEOUT_MS);
@@ -497,6 +500,12 @@ export default function App() {
   }
 
   async function testApiConnection(): Promise<void> {
+    if (!isConfiguredApiBaseUrl(apiBaseUrl)) {
+      const message = buildMissingApiBaseUrlMessage();
+      setLastResponse(message);
+      Alert.alert("API URL required", message);
+      return;
+    }
     const authContextUrl = buildAuthContextUrl(apiBaseUrl);
     try {
       const response = await fetchWithTimeout(
@@ -544,7 +553,20 @@ export default function App() {
   }
 
   function validateRequired(): string | null {
+    if (!isConfiguredApiBaseUrl(apiBaseUrl)) {
+      return buildMissingApiBaseUrlMessage();
+    }
     return validatePairedPayloadForSubmission(payload, { captureRunning });
+  }
+
+  async function syncPendingQueueWithConfiguredApi(): Promise<void> {
+    if (!isConfiguredApiBaseUrl(apiBaseUrl)) {
+      const message = buildMissingApiBaseUrlMessage();
+      setLastResponse(message);
+      Alert.alert("API URL required", message);
+      return;
+    }
+    await syncPendingSubmissions();
   }
 
   async function submitPayload() {
@@ -676,6 +698,11 @@ export default function App() {
   }
 
   async function loadComparisonSummary() {
+    if (!isConfiguredApiBaseUrl(apiBaseUrl)) {
+      setSummary(null);
+      setSummaryError(buildMissingApiBaseUrlMessage());
+      return;
+    }
     const url = buildComparisonSummaryUrl({
       apiBaseUrl,
       siteId,
@@ -711,6 +738,11 @@ export default function App() {
   }
 
   async function loadCaptureCoverageSummary() {
+    if (!isConfiguredApiBaseUrl(apiBaseUrl)) {
+      setCoverageSummary(null);
+      setCoverageError(buildMissingApiBaseUrlMessage());
+      return;
+    }
     const url = buildCaptureCoverageSummaryUrl({
       apiBaseUrl,
       siteId,
@@ -773,7 +805,7 @@ export default function App() {
           onActorRoleChange={setActorRole}
           onRequestTimeoutMsChange={setRequestTimeoutMs}
           onTestApiConnection={testApiConnection}
-          onSyncPendingSubmissions={syncPendingSubmissions}
+          onSyncPendingSubmissions={syncPendingQueueWithConfiguredApi}
           onClearPendingSubmissions={clearPendingSubmissions}
         />
 

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -130,8 +130,9 @@ CI:
 secret blockers. The artifact has separate machine-readable gates:
 
 - `local_checks_status`: local app metadata, runtime release metadata, EAS profile shape,
-  store privacy declarations, launch/icon assets, dependency lock alignment, and unit-test
-  evidence that can be verified without external credentials.
+  runtime defaults such as non-localhost API URL defaults, store privacy declarations,
+  launch/icon assets, dependency lock alignment, and unit-test evidence that can be verified
+  without external credentials.
 - `authenticated_eas_status`: whether `EXPO_TOKEN` and deterministic EAS project identity are ready for an authenticated EAS build trigger.
 - `clinical_hub_live_api_status`: whether live Clinical Hub API smoke/report-push credentials are configured.
 - `external_readiness_status`: aggregate external status across Expo/EAS + Clinical Hub.

--- a/apps/field-mobile/src/api/clinicalHub.ts
+++ b/apps/field-mobile/src/api/clinicalHub.ts
@@ -7,7 +7,15 @@ import type {
 import { clampTimeoutMs, classifyRetryable, createRequestId } from "../utils/appHelpers";
 
 export function buildBaseUrl(apiBaseUrl: string): string {
-  return apiBaseUrl.replace(/\/$/, "");
+  return apiBaseUrl.trim().replace(/\/+$/, "");
+}
+
+export function isConfiguredApiBaseUrl(apiBaseUrl: string): boolean {
+  return /^https?:\/\//i.test(buildBaseUrl(apiBaseUrl));
+}
+
+export function buildMissingApiBaseUrlMessage(): string {
+  return "Configure Clinical Hub API Base URL before testing, submitting, or syncing.";
 }
 
 export function endpointPath(endpoint: PendingEndpoint): string {

--- a/apps/field-mobile/src/components/ApiConnectionSection.tsx
+++ b/apps/field-mobile/src/components/ApiConnectionSection.tsx
@@ -43,7 +43,17 @@ export function ApiConnectionSection({
   return (
     <>
       <Text style={styles.sectionTitle}>API</Text>
-      <LabeledInput label="API Base URL" value={apiBaseUrl} onChangeText={onApiBaseUrlChange} />
+      <LabeledInput
+        label="API Base URL"
+        value={apiBaseUrl}
+        onChangeText={onApiBaseUrlChange}
+        placeholder="https://<clinical-hub-host>"
+      />
+      {!apiBaseUrl.trim() ? (
+        <Text style={styles.helperText}>
+          Configure the Clinical Hub URL before Test API, Submit, or Sync Queue.
+        </Text>
+      ) : null}
       <LabeledInput
         label="API Key (x-api-key)"
         value={apiKey}

--- a/apps/field-mobile/src/components/LabeledInput.tsx
+++ b/apps/field-mobile/src/components/LabeledInput.tsx
@@ -7,6 +7,7 @@ export type LabeledInputProps = {
   onChangeText: (text: string) => void;
   keyboardType?: "default" | "number-pad" | "decimal-pad";
   multiline?: boolean;
+  placeholder?: string;
   secureTextEntry?: boolean;
 };
 
@@ -16,6 +17,7 @@ export function LabeledInput({
   onChangeText,
   keyboardType = "default",
   multiline = false,
+  placeholder,
   secureTextEntry = false,
 }: LabeledInputProps) {
   return (
@@ -27,6 +29,8 @@ export function LabeledInput({
         onChangeText={onChangeText}
         keyboardType={keyboardType}
         multiline={multiline}
+        placeholder={placeholder}
+        placeholderTextColor="#94a3b8"
         secureTextEntry={secureTextEntry}
       />
     </View>

--- a/apps/field-mobile/src/storage/appSettingsStorage.ts
+++ b/apps/field-mobile/src/storage/appSettingsStorage.ts
@@ -1,7 +1,7 @@
 import type { AppSettings, SummaryQualityStatus } from "../types";
 import { DEFAULT_REQUEST_TIMEOUT_MS, normalizeActorRoleInput } from "../utils/appHelpers";
 
-export const DEFAULT_API_BASE_URL = "http://127.0.0.1:8000";
+export const DEFAULT_API_BASE_URL = "";
 export const DEFAULT_SITE_ID = "SITE-001";
 export const DEFAULT_OPERATOR_ID = "OP-01";
 

--- a/apps/field-mobile/tests/appSettingsStorage.test.js
+++ b/apps/field-mobile/tests/appSettingsStorage.test.js
@@ -5,6 +5,10 @@ const test = require("node:test");
 const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
 const settings = require(path.join(buildDir, "storage/appSettingsStorage.js"));
 
+test("default app settings do not point release devices at localhost", () => {
+  assert.equal(settings.DEFAULT_API_BASE_URL, "");
+});
+
 test("parseStoredAppSettings builds defaults when only secure API key remains", () => {
   assert.deepEqual(settings.parseStoredAppSettings(null, "secure-key"), {
     api_base_url: settings.DEFAULT_API_BASE_URL,

--- a/apps/field-mobile/tests/clinicalHub.test.js
+++ b/apps/field-mobile/tests/clinicalHub.test.js
@@ -24,10 +24,24 @@ function buildPayload() {
 }
 
 test("buildBaseUrl and endpointPath normalize Clinical Hub targets", () => {
-  assert.equal(clinicalHub.buildBaseUrl("https://clinical.example.test/"), "https://clinical.example.test");
+  assert.equal(
+    clinicalHub.buildBaseUrl(" https://clinical.example.test/// "),
+    "https://clinical.example.test",
+  );
   assert.equal(clinicalHub.buildBaseUrl("https://clinical.example.test"), "https://clinical.example.test");
   assert.equal(clinicalHub.endpointPath("paired_measurements"), "/api/v1/paired-measurements");
   assert.equal(clinicalHub.endpointPath("capture_packages"), "/api/v1/capture-packages");
+});
+
+test("isConfiguredApiBaseUrl requires explicit http or https Clinical Hub URL", () => {
+  assert.equal(clinicalHub.isConfiguredApiBaseUrl(""), false);
+  assert.equal(clinicalHub.isConfiguredApiBaseUrl("clinical.example.test"), false);
+  assert.equal(clinicalHub.isConfiguredApiBaseUrl("https://clinical.example.test"), true);
+  assert.equal(clinicalHub.isConfiguredApiBaseUrl("http://192.168.1.20:8000"), true);
+  assert.equal(
+    clinicalHub.buildMissingApiBaseUrlMessage(),
+    "Configure Clinical Hub API Base URL before testing, submitting, or syncing.",
+  );
 });
 
 test("attemptSubmitEndpoint posts serialized payloads with request headers", async () => {

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -47,13 +47,14 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - iOS build number and Android versionCode,
 - icon/adaptive-icon paths, `expo-splash-screen` image path, SHA-256 fingerprints, byte sizes, PNG dimensions, and splash background/resize/width config,
 - runtime release metadata from `apps/field-mobile/src/config/releaseMetadata.ts` for app version, model ID, and capture schema version,
+- runtime defaults such as `DEFAULT_API_BASE_URL` to prove release builds do not point field devices at localhost,
 - git SHA/ref/run-id,
 - model_id and capture schema version.
 - selected build profile/channel.
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata, package scripts, lockfile, pinned tooling, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/defaults, package scripts, lockfile, pinned tooling, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status,

--- a/scripts/build_mobile_release_manifest.py
+++ b/scripts/build_mobile_release_manifest.py
@@ -48,7 +48,7 @@ def _get_plugin_options(plugins: list[Any], plugin_name: str) -> dict[str, Any]:
 
 
 def _read_ts_string_constant(source: str, name: str) -> str | None:
-    pattern = re.compile(rf"export\s+const\s+{re.escape(name)}\s*=\s*[\"']([^\"']+)[\"']")
+    pattern = re.compile(rf"export\s+const\s+{re.escape(name)}\s*=\s*[\"']([^\"']*)[\"']")
     match = pattern.search(source)
     return match.group(1) if match else None
 
@@ -70,6 +70,17 @@ def _release_metadata(app_json: Path) -> dict[str, str | None]:
         "capture_schema_version": _read_ts_string_constant(
             source, "APP_CAPTURE_SCHEMA_VERSION"
         ),
+    }
+
+
+def _app_settings_defaults(app_json: Path) -> dict[str, str | None]:
+    path = app_json.parent / "src" / "storage" / "appSettingsStorage.ts"
+    if not path.is_file():
+        return {"path": str(path), "default_api_base_url": None}
+    source = path.read_text(encoding="utf-8")
+    return {
+        "path": str(path),
+        "default_api_base_url": _read_ts_string_constant(source, "DEFAULT_API_BASE_URL"),
     }
 
 
@@ -95,6 +106,7 @@ def main() -> int:
     android = expo.get("android", {})
     splash = _get_plugin_options(plugins, "expo-splash-screen")
     release_metadata = _release_metadata(args.app_json)
+    app_settings_defaults = _app_settings_defaults(args.app_json)
     android_adaptive_icon = android.get("adaptiveIcon", {})
 
     manifest = {
@@ -135,6 +147,7 @@ def main() -> int:
             "workflow": os.environ.get("GITHUB_WORKFLOW", "local"),
         },
         "runtime_release_metadata": release_metadata,
+        "runtime_defaults": app_settings_defaults,
         "algorithm": {
             "model_id": args.model_id,
             "capture_schema_version": args.schema_version,

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -42,7 +42,7 @@ def _is_six_digit_hex_color(value: Any) -> bool:
 
 
 def _read_ts_string_constant(source: str, name: str) -> str | None:
-    pattern = re.compile(rf"export\s+const\s+{re.escape(name)}\s*=\s*[\"']([^\"']+)[\"']")
+    pattern = re.compile(rf"export\s+const\s+{re.escape(name)}\s*=\s*[\"']([^\"']*)[\"']")
     match = pattern.search(source)
     return match.group(1) if match else None
 
@@ -65,6 +65,23 @@ def _load_release_metadata(app_json: Path) -> dict[str, str | None]:
             source, "APP_CAPTURE_SCHEMA_VERSION"
         ),
     }
+
+
+def _load_app_settings_defaults(app_json: Path) -> dict[str, str | None]:
+    path = app_json.parent / "src" / "storage" / "appSettingsStorage.ts"
+    if not path.is_file():
+        return {"path": str(path), "default_api_base_url": None}
+    source = path.read_text(encoding="utf-8")
+    return {
+        "path": str(path),
+        "default_api_base_url": _read_ts_string_constant(source, "DEFAULT_API_BASE_URL"),
+    }
+
+
+def _is_localhost_url(value: str | None) -> bool:
+    if value is None:
+        return False
+    return bool(re.match(r"^https?://(localhost|127\.0\.0\.1|0\.0\.0\.0)([:/]|$)", value))
 
 
 def _has_plugin(plugins: list[Any], plugin_name: str) -> bool:
@@ -227,6 +244,7 @@ def build_readiness_report(
     package_payload = _load_json(package_json)
     lock_payload = _load_json(package_lock)
     release_metadata = _load_release_metadata(app_json)
+    app_settings_defaults = _load_app_settings_defaults(app_json)
 
     expo = app_payload.get("expo", {})
     plugins = expo.get("plugins", [])
@@ -288,6 +306,16 @@ def build_readiness_report(
         "release_metadata_capture_schema_version",
         release_metadata.get("capture_schema_version") == "ios_capture_v1",
         f"capture_schema_version={release_metadata.get('capture_schema_version')!r}",
+    )
+    _check(
+        checks,
+        "default_api_base_url_not_localhost",
+        app_settings_defaults.get("default_api_base_url") is not None
+        and not _is_localhost_url(app_settings_defaults.get("default_api_base_url")),
+        (
+            f"path={app_settings_defaults.get('path')}, "
+            f"default_api_base_url={app_settings_defaults.get('default_api_base_url')!r}"
+        ),
     )
     app_icon_path = _asset_path(app_json, expo.get("icon"))
     app_icon_dimensions = _png_dimensions(app_icon_path)

--- a/tests/test_mobile_release_manifest_script.py
+++ b/tests/test_mobile_release_manifest_script.py
@@ -32,8 +32,10 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     output = tmp_path / "manifest.json"
     assets = tmp_path / "assets"
     metadata_path = tmp_path / "src" / "config" / "releaseMetadata.ts"
+    app_settings_path = tmp_path / "src" / "storage" / "appSettingsStorage.ts"
     assets.mkdir()
     metadata_path.parent.mkdir(parents=True)
+    app_settings_path.parent.mkdir(parents=True)
     _write_png(assets / "icon.png", 1024, 1024)
     _write_png(assets / "adaptive-icon.png", 1024, 1024)
     _write_png(assets / "splash.png", 1024, 1024)
@@ -85,6 +87,10 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
         ),
         encoding="utf-8",
     )
+    app_settings_path.write_text(
+        'export const DEFAULT_API_BASE_URL = "";\n',
+        encoding="utf-8",
+    )
 
     script_path = Path("scripts/build_mobile_release_manifest.py")
     subprocess.run(
@@ -133,5 +139,6 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     assert payload["runtime_release_metadata"]["app_version"] == "0.1.0"
     assert payload["runtime_release_metadata"]["model_id"] == "fusion-v0.1"
     assert payload["runtime_release_metadata"]["capture_schema_version"] == "ios_capture_v1"
+    assert payload["runtime_defaults"]["default_api_base_url"] == ""
     assert payload["algorithm"]["model_id"] == "fusion-v0.1"
     assert payload["algorithm"]["capture_schema_version"] == "ios_capture_v1"

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -83,6 +83,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "audio_microphone_permission",
         "clinical_hub_api_unit_tests_present",
         "capture_package_payload_unit_tests_present",
+        "default_api_base_url_not_localhost",
         "eas_cli_version_declared",
         "eas_production_auto_increment",
         "eas_profile_channels",
@@ -232,6 +233,35 @@ def test_mobile_release_readiness_fails_release_metadata_version_mismatch(
     assert payload["local_checks_status"] == "fail"
     assert check["status"] == "fail"
     assert "release_metadata.app_version='9.9.9'" in check["evidence"]
+
+
+def test_mobile_release_readiness_fails_localhost_default_api_url(tmp_path: Path) -> None:
+    mutated_app_json = tmp_path / "app.json"
+    app_settings_path = tmp_path / "src" / "storage" / "appSettingsStorage.ts"
+    app_settings_path.parent.mkdir(parents=True)
+    app_payload = json.loads(APP_JSON.read_text(encoding="utf-8"))
+    mutated_app_json.write_text(json.dumps(app_payload), encoding="utf-8")
+    app_settings_path.write_text(
+        'export const DEFAULT_API_BASE_URL = "http://127.0.0.1:8000";\n',
+        encoding="utf-8",
+    )
+
+    payload = _run_readiness_with_paths(
+        tmp_path / "readiness.json",
+        env={"PATH": os.environ.get("PATH", "")},
+        app_json=mutated_app_json,
+        check=False,
+    )
+
+    check = next(
+        item
+        for item in payload["local_checks"]
+        if item["id"] == "default_api_base_url_not_localhost"
+    )
+    assert payload["status"] == "not_ready"
+    assert payload["local_checks_status"] == "fail"
+    assert check["status"] == "fail"
+    assert "http://127.0.0.1:8000" in check["evidence"]
 
 
 def test_mobile_release_readiness_passes_authenticated_preflight_env(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

- Removed the `http://127.0.0.1:8000` default from the field mobile app settings so fresh release installs do not point iPhone/Android devices at localhost.
- Added an explicit runtime guard before Test API, Submit, Sync Queue, and summary fetch actions so operators must configure an `http(s)` Clinical Hub URL first.
- Added UI placeholder/helper copy for the Clinical Hub API URL.
- Extended mobile release readiness and manifest output with runtime default evidence, including a `default_api_base_url_not_localhost` gate and `runtime_defaults.default_api_base_url` manifest field.

## Why

Release devices cannot use the desktop localhost default. The app should preserve manual dev/local configuration, but fresh field installs should start unconfigured and fail safely until the Clinical Hub URL is set.

## Validation

- `.venv/bin/ruff check . && .venv/bin/pytest -q` -> `102 passed`
- `npm run validate:ci` -> TypeScript, 60 unit tests, Expo Doctor 21/21, production audit, iOS export, Android export all passed
- `scripts/check_mobile_release_readiness.py` -> `ready_except_external_credentials`, `local_checks_status=pass`, `default_api_base_url_not_localhost=pass`
- `scripts/build_mobile_release_manifest.py` -> `runtime_defaults.default_api_base_url=""`