### PR TITLE
[codex] Guard pending auto-sync without API URL

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -19,7 +19,7 @@ Cross-platform mobile client (Expo React Native) for collecting paired measureme
 - Sync reuses stored header context per item (prevents wrong-site replay after settings change)
 - Pending queue preview shows error categories, not raw server response bodies
 - Sync runs in bounded batches of 10 queued jobs to avoid long foreground stalls on large offline queues
-- Auto-sync retries queued jobs every ~25s while queue is non-empty and when app becomes active
+- Auto-sync retries queued jobs every ~25s only after API Base URL is configured
 - Queue controls: `Test API`, `Sync Queue`, `Clear Queue`
 - Persisted local settings (`API URL`, `site/operator`, timeout, summary filter)
 - `API Key` stored in device secure storage (`expo-secure-store`) with AsyncStorage fallback

--- a/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
+++ b/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Alert, AppState } from "react-native";
 
-import { attemptSubmitEndpoint } from "../api/clinicalHub";
+import {
+  attemptSubmitEndpoint,
+  buildMissingApiBaseUrlMessage,
+  isConfiguredApiBaseUrl,
+} from "../api/clinicalHub";
 import {
   loadPendingSubmissions,
   savePendingSubmissions,
@@ -16,6 +20,7 @@ import { createPendingId, resolvePendingHeaderContext } from "../utils/appHelper
 import {
   buildPendingSyncAttempt,
   buildPendingSyncStatusMessage,
+  shouldAutoSyncPendingQueue,
   splitPendingSyncBatch,
 } from "../utils/pendingSyncQueue";
 
@@ -39,6 +44,7 @@ export function usePendingSyncQueue({
   const [syncStatusMessage, setSyncStatusMessage] = useState("");
   const syncInFlightRef = useRef(false);
   const autoSyncIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const apiConfigured = isConfiguredApiBaseUrl(apiBaseUrl);
 
   const persistPendingQueue = useCallback(async (queue: PendingSubmission[]): Promise<void> => {
     await savePendingSubmissions(queue);
@@ -76,6 +82,15 @@ export function usePendingSyncQueue({
 
   const syncPendingSubmissions = useCallback(
     async (showAlert = true): Promise<void> => {
+      if (!apiConfigured) {
+        const message = buildMissingApiBaseUrlMessage();
+        setSyncStatusMessage(message);
+        onLastResponse(message);
+        if (showAlert) {
+          Alert.alert("API URL required", message);
+        }
+        return;
+      }
       if (syncInFlightRef.current) {
         return;
       }
@@ -149,6 +164,7 @@ export function usePendingSyncQueue({
       }
     },
     [
+      apiConfigured,
       apiBaseUrl,
       onLastResponse,
       persistPendingQueue,
@@ -182,10 +198,19 @@ export function usePendingSyncQueue({
   }, []);
 
   useEffect(() => {
-    if (!settingsHydrated || pendingQueue.length === 0) {
+    const shouldAutoSync = shouldAutoSyncPendingQueue({
+      settingsHydrated,
+      pendingCount: pendingQueue.length,
+      apiConfigured,
+    });
+
+    if (!shouldAutoSync) {
       if (autoSyncIntervalRef.current != null) {
         clearInterval(autoSyncIntervalRef.current);
         autoSyncIntervalRef.current = null;
+      }
+      if (settingsHydrated && pendingQueue.length > 0 && !apiConfigured) {
+        setSyncStatusMessage(buildMissingApiBaseUrlMessage());
       }
       return;
     }
@@ -204,18 +229,18 @@ export function usePendingSyncQueue({
         autoSyncIntervalRef.current = null;
       }
     };
-  }, [pendingQueue.length, settingsHydrated, syncPendingSubmissions]);
+  }, [apiConfigured, pendingQueue.length, settingsHydrated, syncPendingSubmissions]);
 
   useEffect(() => {
     const subscription = AppState.addEventListener("change", (state) => {
-      if (state === "active" && pendingQueue.length > 0) {
+      if (state === "active" && pendingQueue.length > 0 && apiConfigured) {
         void syncPendingSubmissions(false);
       }
     });
     return () => {
       subscription.remove();
     };
-  }, [pendingQueue.length, syncPendingSubmissions]);
+  }, [apiConfigured, pendingQueue.length, syncPendingSubmissions]);
 
   return {
     pendingQueue,

--- a/apps/field-mobile/src/utils/pendingSyncQueue.ts
+++ b/apps/field-mobile/src/utils/pendingSyncQueue.ts
@@ -27,6 +27,12 @@ export type PendingSyncStatusSummary = {
   droppedNonRetryable: number;
 };
 
+export type PendingAutoSyncGate = {
+  settingsHydrated: boolean;
+  pendingCount: number;
+  apiConfigured: boolean;
+};
+
 export function splitPendingSyncBatch(
   queue: PendingSubmission[],
   maxBatchSize = MAX_PENDING_SYNC_BATCH_SIZE,
@@ -38,6 +44,10 @@ export function splitPendingSyncBatch(
     batch: queue.slice(0, batchSize),
     deferred: queue.slice(batchSize),
   };
+}
+
+export function shouldAutoSyncPendingQueue(gate: PendingAutoSyncGate): boolean {
+  return gate.settingsHydrated && gate.pendingCount > 0 && gate.apiConfigured;
 }
 
 export function buildPendingSyncAttempt(options: {

--- a/apps/field-mobile/tests/pendingSyncQueue.test.js
+++ b/apps/field-mobile/tests/pendingSyncQueue.test.js
@@ -61,6 +61,41 @@ test("splitPendingSyncBatch caps sync batches and preserves deferred order", () 
   );
 });
 
+test("shouldAutoSyncPendingQueue requires hydrated settings, pending work, and configured API", () => {
+  assert.equal(
+    pending.shouldAutoSyncPendingQueue({
+      settingsHydrated: true,
+      pendingCount: 1,
+      apiConfigured: true,
+    }),
+    true,
+  );
+  assert.equal(
+    pending.shouldAutoSyncPendingQueue({
+      settingsHydrated: false,
+      pendingCount: 1,
+      apiConfigured: true,
+    }),
+    false,
+  );
+  assert.equal(
+    pending.shouldAutoSyncPendingQueue({
+      settingsHydrated: true,
+      pendingCount: 0,
+      apiConfigured: true,
+    }),
+    false,
+  );
+  assert.equal(
+    pending.shouldAutoSyncPendingQueue({
+      settingsHydrated: true,
+      pendingCount: 1,
+      apiConfigured: false,
+    }),
+    false,
+  );
+});
+
 test("buildPendingSyncAttempt records successful capture package submissions", () => {
   const headerContext = {
     api_key: "current-key",

--- a/docs/mobile-install-and-field-test-runbook-v0.1.md
+++ b/docs/mobile-install-and-field-test-runbook-v0.1.md
@@ -75,6 +75,8 @@ In app API section set:
 - `Operator ID`: current operator code
 
 Verify with `Test API` button before first patient run.
+Pending queue auto-sync stays paused until `API Base URL` is configured and starts with
+`http://` or `https://`.
 
 ## 5. Paired Test Workflow
 


### PR DESCRIPTION
## What changed

- Added a hook-level guard so pending queue auto-sync does not start until `API Base URL` is configured with an explicit `http(s)` URL.
- Kept direct `syncPendingSubmissions` calls safe by returning the same operator-facing API URL message before any network fetch.
- Added a pure `shouldAutoSyncPendingQueue` gate and unit coverage for hydrated settings, pending count, and configured API conditions.
- Updated mobile README and field-test runbook to document that auto-sync stays paused until the Clinical Hub URL is configured.

## Why

The previous localhost-default fix guarded manual app actions, but the pending queue hook still had background triggers on hydration, interval, and app resume. This closes that bypass so queued submissions are not retried against an empty or relative URL on fresh release installs.

## Validation

- `.venv/bin/ruff check . && .venv/bin/pytest -q` -> `102 passed`
- `npm run typecheck && npm run test:unit` -> `61/61` mobile unit tests passed
- `npm run validate:ci` -> TypeScript, 61 unit tests, Expo Doctor 21/21, production audit, iOS export, Android export all passed
- `scripts/check_mobile_release_readiness.py` -> `ready_except_external_credentials`, `local_checks_status=pass`