### PR TITLE
[codex] Redact mobile API response bodies

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -74,6 +74,7 @@ import {
   createSessionId,
   createSyncId,
   extractCreatedRecordId,
+  formatSafeResponseProblem,
 } from "./src/utils/appHelpers";
 
 const defaultMeasuredAt = new Date().toISOString().slice(0, 19) + "Z";
@@ -546,8 +547,8 @@ export default function App() {
       setLastResponse(message);
       Alert.alert("API reachable", message);
     } catch (error) {
-      const message = String(error);
-      setLastResponse(buildApiCheckFailedMessage(error));
+      const message = buildApiCheckFailedMessage(error);
+      setLastResponse(message);
       Alert.alert("API check failed", message);
     }
   }
@@ -725,13 +726,13 @@ export default function App() {
       const body = await response.text();
       if (!response.ok) {
         setSummary(null);
-        setSummaryError(`HTTP ${response.status}: ${body}`);
+        setSummaryError(formatSafeResponseProblem(response.status, body));
         return;
       }
       setSummary(JSON.parse(body) as ComparisonSummaryResponse);
     } catch (error) {
       setSummary(null);
-      setSummaryError(String(error));
+      setSummaryError(formatSafeResponseProblem(null, String(error), "NETWORK"));
     } finally {
       setSummaryLoading(false);
     }
@@ -765,13 +766,13 @@ export default function App() {
       const body = await response.text();
       if (!response.ok) {
         setCoverageSummary(null);
-        setCoverageError(`HTTP ${response.status}: ${body}`);
+        setCoverageError(formatSafeResponseProblem(response.status, body));
         return;
       }
       setCoverageSummary(JSON.parse(body) as CaptureCoverageSummaryResponse);
     } catch (error) {
       setCoverageSummary(null);
-      setCoverageError(String(error));
+      setCoverageError(formatSafeResponseProblem(null, String(error), "NETWORK"));
     } finally {
       setCoverageLoading(false);
     }

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -18,6 +18,7 @@ Cross-platform mobile client (Expo React Native) for collecting paired measureme
 - Pending retries reuse a stable `x-request-id` per endpoint job to reduce duplicate risk after timeout/retry
 - Sync reuses stored header context per item (prevents wrong-site replay after settings change)
 - Pending queue preview shows error categories, not raw server response bodies
+- Operator-facing API errors keep HTTP status but redact raw response bodies into safe categories
 - Sync runs in bounded batches of 10 queued jobs to avoid long foreground stalls on large offline queues
 - Auto-sync retries queued jobs every ~25s only after API Base URL is configured
 - Queue controls: `Test API`, `Sync Queue`, `Clear Queue`

--- a/apps/field-mobile/src/api/connectionCheck.ts
+++ b/apps/field-mobile/src/api/connectionCheck.ts
@@ -1,5 +1,6 @@
 import type { AuthContextResponse } from "../types";
 import { buildBaseUrl } from "./clinicalHub";
+import { formatSafeResponseProblem } from "../utils/appHelpers";
 
 export function buildAuthContextUrl(apiBaseUrl: string): string {
   return `${buildBaseUrl(apiBaseUrl)}/api/v1/auth-context`;
@@ -17,7 +18,7 @@ export function buildAuthContextCheckFailedMessage(
   status: number,
   body: string,
 ): string {
-  return `Auth-context check failed: HTTP ${status} ${body}`;
+  return `Auth-context check failed: ${formatSafeResponseProblem(status, body)}`;
 }
 
 export function buildAuthContextOkMessage(
@@ -31,5 +32,5 @@ export function buildAuthContextOkMessage(
 }
 
 export function buildApiCheckFailedMessage(error: unknown): string {
-  return `API check failed: ${String(error)}`;
+  return `API check failed: ${formatSafeResponseProblem(null, String(error), "NETWORK")}`;
 }

--- a/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
+++ b/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
@@ -16,7 +16,11 @@ import type {
   PendingSubmission,
   RequestHeaderContext,
 } from "../types";
-import { createPendingId, resolvePendingHeaderContext } from "../utils/appHelpers";
+import {
+  createPendingId,
+  resolvePendingHeaderContext,
+  summarizePendingError,
+} from "../utils/appHelpers";
 import {
   buildPendingSyncAttempt,
   buildPendingSyncStatusMessage,
@@ -61,6 +65,9 @@ export function usePendingSyncQueue({
     ): Promise<void> => {
       const queue = await loadPendingSubmissions();
       const pendingId = createPendingId();
+      const storedLastError = lastError
+        ? summarizePendingError(lastError) ?? "server_or_client_response"
+        : null;
       const pendingItem: PendingSubmission = {
         id: pendingId,
         created_at: new Date().toISOString(),
@@ -72,7 +79,7 @@ export function usePendingSyncQueue({
         },
         attempt_count: 0,
         last_attempt_at: null,
-        last_error: lastError,
+        last_error: storedLastError,
         last_status_code: lastStatusCode,
       };
       await persistPendingQueue([...queue, pendingItem]);

--- a/apps/field-mobile/src/storage/pendingSubmissionStorage.ts
+++ b/apps/field-mobile/src/storage/pendingSubmissionStorage.ts
@@ -3,6 +3,7 @@ import {
   buildHeaderContextFromValues,
   createPendingId,
   normalizePendingEndpoint,
+  summarizePendingError,
 } from "../utils/appHelpers";
 
 type SessionContext = {
@@ -76,6 +77,10 @@ export function normalizePendingSubmission(
   const attemptCount = Number.isFinite(attemptCountRaw)
     ? Math.max(0, Math.round(attemptCountRaw))
     : 0;
+  const rawLastError = readString(candidate.last_error);
+  const lastError = rawLastError
+    ? summarizePendingError(rawLastError) ?? "server_or_client_response"
+    : null;
 
   return {
     id,
@@ -85,7 +90,7 @@ export function normalizePendingSubmission(
     request_headers: normalizeRequestHeaderContext(candidate.request_headers, sessionContext),
     attempt_count: attemptCount,
     last_attempt_at: readString(candidate.last_attempt_at) || null,
-    last_error: readString(candidate.last_error) || null,
+    last_error: lastError,
     last_status_code:
       typeof candidate.last_status_code === "number" ? candidate.last_status_code : null,
   };

--- a/apps/field-mobile/src/utils/appHelpers.ts
+++ b/apps/field-mobile/src/utils/appHelpers.ts
@@ -68,11 +68,21 @@ export function classifyRetryable(statusCode: number | null): boolean {
   return statusCode === 408 || statusCode === 425 || statusCode === 429;
 }
 
+const SAFE_PENDING_ERROR_CATEGORIES = new Set([
+  "network_or_timeout",
+  "auth_or_permission",
+  "validation",
+  "server_or_client_response",
+]);
+
 export function summarizePendingError(error: string | null): string | null {
   if (!error) {
     return null;
   }
   const normalized = error.toLowerCase();
+  if (SAFE_PENDING_ERROR_CATEGORIES.has(normalized)) {
+    return normalized;
+  }
   if (
     normalized.includes("abort") ||
     normalized.includes("network") ||
@@ -90,12 +100,22 @@ export function summarizePendingError(error: string | null): string | null {
   }
   if (
     normalized.includes("validation") ||
+    normalized.includes("invalid") ||
     normalized.includes("field required") ||
     normalized.includes("unprocessable")
   ) {
     return "validation";
   }
   return "server_or_client_response";
+}
+
+export function formatSafeResponseProblem(
+  statusCode: number | null,
+  responseBody: string,
+  fallbackStatusLabel: "ERROR" | "NETWORK" = "ERROR",
+): string {
+  const statusLabel = statusCode ? `HTTP ${statusCode}` : fallbackStatusLabel;
+  return `${statusLabel} ${summarizePendingError(responseBody) ?? "server_or_client_response"}`;
 }
 
 export function normalizeActorRoleInput(rawValue: string | null | undefined): string {

--- a/apps/field-mobile/src/utils/pendingSyncQueue.ts
+++ b/apps/field-mobile/src/utils/pendingSyncQueue.ts
@@ -3,6 +3,7 @@ import type {
   RequestHeaderContext,
   SubmitAttemptResult,
 } from "../types";
+import { summarizePendingError } from "./appHelpers";
 
 export const MAX_PENDING_SYNC_BATCH_SIZE = 10;
 
@@ -65,7 +66,9 @@ export function buildPendingSyncAttempt(options: {
     attempt_count: attemptCount + 1,
     last_attempt_at: options.attemptedAtIso,
     last_status_code: options.result.statusCode,
-    last_error: options.result.ok ? null : options.result.body,
+    last_error: options.result.ok
+      ? null
+      : summarizePendingError(options.result.body) ?? "server_or_client_response",
   };
 
   if (options.result.ok) {

--- a/apps/field-mobile/src/utils/submitOutcome.ts
+++ b/apps/field-mobile/src/utils/submitOutcome.ts
@@ -1,10 +1,11 @@
 import type { SubmitAttemptResult } from "../types";
+import { formatSafeResponseProblem } from "./appHelpers";
 
 function formatAttemptProblem(
   result: SubmitAttemptResult,
   fallbackStatusLabel: "ERROR" | "NETWORK",
 ): string {
-  return `${result.statusCode ? `HTTP ${result.statusCode}` : fallbackStatusLabel} ${result.body}`;
+  return formatSafeResponseProblem(result.statusCode, result.body, fallbackStatusLabel);
 }
 
 export function buildQueuedCapturePackageMessage(

--- a/apps/field-mobile/tests/appHelpers.test.js
+++ b/apps/field-mobile/tests/appHelpers.test.js
@@ -55,10 +55,23 @@ test("classifyRetryable separates transient and non-retryable statuses", () => {
 
 test("summarizePendingError redacts raw response bodies into safe categories", () => {
   assert.equal(helpers.summarizePendingError(null), null);
+  assert.equal(helpers.summarizePendingError("validation"), "validation");
   assert.equal(helpers.summarizePendingError("AbortError: request timed out"), "network_or_timeout");
   assert.equal(helpers.summarizePendingError("Unauthorized: bad API key"), "auth_or_permission");
   assert.equal(helpers.summarizePendingError("Validation error: field required"), "validation");
+  assert.equal(helpers.summarizePendingError("Invalid capture payload"), "validation");
   assert.equal(helpers.summarizePendingError("HTTP 503 upstream unavailable"), "server_or_client_response");
+});
+
+test("formatSafeResponseProblem preserves status without leaking raw response bodies", () => {
+  assert.equal(
+    helpers.formatSafeResponseProblem(422, "Validation error: patient_name=Jane"),
+    "HTTP 422 validation",
+  );
+  assert.equal(
+    helpers.formatSafeResponseProblem(null, "TypeError: failed to fetch", "NETWORK"),
+    "NETWORK network_or_timeout",
+  );
 });
 
 test("buildHeaderContextFromValues normalizes operator context and preserves request id", () => {

--- a/apps/field-mobile/tests/connectionCheck.test.js
+++ b/apps/field-mobile/tests/connectionCheck.test.js
@@ -16,14 +16,14 @@ test("connection check URL builders normalize API base URL", () => {
   );
 });
 
-test("connection check failure messages preserve HTTP status and body", () => {
+test("connection check failure messages preserve HTTP status without raw body", () => {
   assert.equal(
     connectionCheck.buildHealthCheckFailedMessage(503),
     "Health check failed: HTTP 503",
   );
   assert.equal(
-    connectionCheck.buildAuthContextCheckFailedMessage(403, "forbidden"),
-    "Auth-context check failed: HTTP 403 forbidden",
+    connectionCheck.buildAuthContextCheckFailedMessage(403, "forbidden for operator OP-001"),
+    "Auth-context check failed: HTTP 403 auth_or_permission",
   );
 });
 
@@ -40,9 +40,9 @@ test("buildAuthContextOkMessage summarizes actor context with n/a fallbacks", ()
   );
 });
 
-test("buildApiCheckFailedMessage stringifies thrown errors", () => {
+test("buildApiCheckFailedMessage redacts thrown error details", () => {
   assert.equal(
     connectionCheck.buildApiCheckFailedMessage(new Error("network down")),
-    "API check failed: Error: network down",
+    "API check failed: NETWORK network_or_timeout",
   );
 });

--- a/apps/field-mobile/tests/pendingSubmissionStorage.test.js
+++ b/apps/field-mobile/tests/pendingSubmissionStorage.test.js
@@ -121,6 +121,23 @@ test("normalizePendingSubmission preserves capture package payloads", () => {
   assert.equal(item.last_status_code, 503);
 });
 
+test("normalizePendingSubmission redacts migrated raw last errors", () => {
+  const item = storage.normalizePendingSubmission({
+    id: "PENDING-RAW-ERROR",
+    endpoint: "paired_measurements",
+    payload: buildPairedPayload(),
+    request_headers: null,
+    attempt_count: 1,
+    last_attempt_at: "2026-06-04T01:02:03.000Z",
+    last_error: "Validation error for patient_name=Jane Doe",
+    last_status_code: 422,
+  });
+
+  assert.ok(item);
+  assert.equal(item.last_error, "validation");
+  assert.equal(item.last_status_code, 422);
+});
+
 test("normalizePendingSubmission drops corrupt payloads without session context", () => {
   assert.equal(
     storage.normalizePendingSubmission({

--- a/apps/field-mobile/tests/pendingSyncQueue.test.js
+++ b/apps/field-mobile/tests/pendingSyncQueue.test.js
@@ -142,14 +142,19 @@ test("buildPendingSyncAttempt keeps retryable failures queued with attempt metad
       operator_id: "OP-CURRENT",
       request_id: "REQ-CURRENT",
     },
-    result: { ok: false, statusCode: 503, body: "upstream unavailable", retryable: true },
+    result: {
+      ok: false,
+      statusCode: 503,
+      body: "upstream unavailable for subject SUBJ-001",
+      retryable: true,
+    },
     attemptedAtIso: "2026-06-04T01:02:03.000Z",
   });
 
   assert.equal(attempt.outcome, "retryable");
   assert.equal(attempt.attemptedItem.attempt_count, 1);
   assert.equal(attempt.attemptedItem.last_status_code, 503);
-  assert.equal(attempt.attemptedItem.last_error, "upstream unavailable");
+  assert.equal(attempt.attemptedItem.last_error, "server_or_client_response");
 });
 
 test("buildPendingSyncAttempt drops non-retryable failed paired submissions", () => {
@@ -162,13 +167,19 @@ test("buildPendingSyncAttempt drops non-retryable failed paired submissions", ()
       operator_id: "OP-CURRENT",
       request_id: "REQ-CURRENT",
     },
-    result: { ok: false, statusCode: 422, body: "validation error", retryable: false },
+    result: {
+      ok: false,
+      statusCode: 422,
+      body: "validation error: patient name missing",
+      retryable: false,
+    },
     attemptedAtIso: "2026-06-04T01:02:03.000Z",
   });
 
   assert.equal(attempt.outcome, "dropped_non_retryable");
   assert.equal(attempt.attemptedItem.attempt_count, 1);
   assert.equal(attempt.attemptedItem.last_status_code, 422);
+  assert.equal(attempt.attemptedItem.last_error, "validation");
 });
 
 test("buildPendingSyncStatusMessage preserves operator-facing sync wording", () => {

--- a/apps/field-mobile/tests/submitOutcome.test.js
+++ b/apps/field-mobile/tests/submitOutcome.test.js
@@ -5,39 +5,39 @@ const test = require("node:test");
 const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
 const submitOutcome = require(path.join(buildDir, "utils/submitOutcome.js"));
 
-test("buildQueuedCapturePackageMessage preserves retryable HTTP wording", () => {
+test("buildQueuedCapturePackageMessage preserves retryable HTTP status without raw body", () => {
   assert.equal(
     submitOutcome.buildQueuedCapturePackageMessage({
       ok: false,
       statusCode: 503,
-      body: "upstream unavailable",
+      body: "upstream unavailable for patient Jane",
       retryable: true,
     }),
-    "Paired uploaded; capture package queued for retry: HTTP 503 upstream unavailable",
+    "Paired uploaded; capture package queued for retry: HTTP 503 server_or_client_response",
   );
 });
 
-test("buildRejectedCapturePackageMessage uses ERROR fallback for non-HTTP failures", () => {
+test("buildRejectedCapturePackageMessage uses ERROR fallback without raw body", () => {
   assert.equal(
     submitOutcome.buildRejectedCapturePackageMessage({
       ok: false,
       statusCode: null,
-      body: "invalid capture payload",
+      body: "invalid capture payload for subject SUBJ-001",
       retryable: false,
     }),
-    "Paired measurement uploaded, but capture package rejected: ERROR invalid capture payload",
+    "Paired measurement uploaded, but capture package rejected: ERROR validation",
   );
 });
 
-test("buildNonRetryableUploadMessage preserves validation rejection wording", () => {
+test("buildNonRetryableUploadMessage preserves validation category", () => {
   assert.equal(
     submitOutcome.buildNonRetryableUploadMessage({
       ok: false,
       statusCode: 422,
-      body: "validation error",
+      body: "validation error: patient name missing",
       retryable: false,
     }),
-    "Upload rejected and not queued. HTTP 422 validation error",
+    "Upload rejected and not queued. HTTP 422 validation",
   );
 });
 
@@ -49,6 +49,6 @@ test("buildQueuedPairedAndCaptureMessage uses NETWORK fallback for retryable net
       body: "TypeError: failed to fetch",
       retryable: true,
     }),
-    "Queued paired+capture for retry. Last paired error: NETWORK TypeError: failed to fetch",
+    "Queued paired+capture for retry. Last paired error: NETWORK network_or_timeout",
   );
 });


### PR DESCRIPTION
## What changed

- Added `formatSafeResponseProblem` so operator-facing API errors preserve HTTP status but replace raw response bodies with safe categories: `validation`, `auth_or_permission`, `network_or_timeout`, or `server_or_client_response`.
- Applied the formatter to submit outcomes, auth-context/API check failures, and comparison/coverage summary failures.
- Sanitized pending queue `last_error` both when new jobs are enqueued and when legacy queued items are normalized from storage.
- Updated mobile unit tests to assert raw response bodies such as patient/operator identifiers do not leak into displayed or stored error strings.
- Documented the behavior in the mobile README.

## Why

The mobile app previously displayed or persisted raw backend response bodies in several API failure paths. For a health-data field app, those bodies may contain identifiers or clinical context. This keeps useful operator status while reducing PHI leakage risk.

## Validation

- `.venv/bin/ruff check . && .venv/bin/pytest -q` -> `102 passed`
- `npm run typecheck && npm run test:unit` -> `63/63` mobile unit tests passed
- `npm run validate:ci` -> TypeScript, 63 unit tests, Expo Doctor 21/21, production audit, iOS export, Android export all passed
- `scripts/check_mobile_release_readiness.py` -> `ready_except_external_credentials`, `local_checks_status=pass`