### PR TITLE
[codex] Add mobile readiness redaction and live URL gates

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -127,6 +127,11 @@ jobs:
               for item in payload.get("external_items", [])
               if item.get("status") == "missing"
           ]
+          invalid = [
+              item["id"]
+              for item in payload.get("external_items", [])
+              if item.get("status") == "invalid"
+          ]
           manual = [
               item["id"]
               for item in payload.get("manual_external_items", [])
@@ -149,6 +154,7 @@ jobs:
               f"- Authenticated EAS build trigger: `{eas_trigger_status}`",
               f"- Clinical Hub live API: `{payload.get('clinical_hub_live_api_status')}`",
               f"- Missing external items: `{', '.join(missing) if missing else 'none'}`",
+              f"- Invalid external items: `{', '.join(invalid) if invalid else 'none'}`",
               f"- Manual external items: `{', '.join(manual) if manual else 'none'}`",
               f"- Next actions: `{', '.join(next_actions) if next_actions else 'none'}`",
           ]

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -135,7 +135,7 @@ secret blockers. The artifact has separate machine-readable gates:
   launch/icon assets, dependency lock alignment, and unit-test evidence that can be verified
   without external credentials.
 - `authenticated_eas_status`: whether `EXPO_TOKEN` and deterministic EAS project identity are ready for an authenticated EAS build trigger.
-- `clinical_hub_live_api_status`: whether live Clinical Hub API smoke/report-push credentials are configured.
+- `clinical_hub_live_api_status`: whether live Clinical Hub API smoke/report-push credentials are configured with an `https` non-localhost URL.
 - `external_readiness_status`: aggregate external status across Expo/EAS + Clinical Hub.
 
 When status is `ready_except_external_credentials`, use `next_actions` in the artifact as the
@@ -145,7 +145,7 @@ release handoff checklist:
 | --- | --- | --- |
 | `configure_expo_token` | `gh secret set EXPO_TOKEN --body "<expo_access_token>"` | Re-run `Mobile Build`; `external_items.expo_token` becomes `present`. |
 | `configure_eas_project_identity` | `gh variable set EAS_PROJECT_ID --body "<eas_project_uuid>"` or commit `expo.extra.eas.projectId` in `app.json` | Re-run `Mobile Build`; `external_items.eas_project_identity` becomes `present`. |
-| `configure_clinical_hub_live_api` | `gh secret set CLINICAL_HUB_URL --body "https://<clinical-hub>"` and `gh secret set CLINICAL_HUB_API_KEY --body "<api_key>"` | Re-run `Mobile Build`; `external_items.clinical_hub_live_api` becomes `present`. |
+| `configure_clinical_hub_live_api` | `gh secret set CLINICAL_HUB_URL --body "https://<clinical-hub>"` and `gh secret set CLINICAL_HUB_API_KEY --body "<api_key>"` | Re-run `Mobile Build`; `external_items.clinical_hub_live_api` becomes `present` rather than `missing`/`invalid`. |
 | `provision_apple_developer_account` | Apple Developer access, signing certificates/profiles, and TestFlight permissions | Trigger signed iOS EAS build and confirm TestFlight upload readiness. |
 | `provision_google_play_account` | Google Play Console access, Android signing, and internal testing track permissions | Trigger signed Android EAS build and confirm Play Internal Testing upload readiness. |
 

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -11,7 +11,7 @@ Scope: pilot installable builds for Uroflow Field Mobile
 4. `EAS_PROJECT_ID` configured as a GitHub repo variable or `expo.extra.eas.projectId` set in `app.json`.
 5. Expo project credentials configured for iOS and Android signing.
 6. Clinical Hub secrets configured when live API smoke/report push is part of the release:
-   - `CLINICAL_HUB_URL`
+   - `CLINICAL_HUB_URL` (`https://...`, non-localhost for live release readiness)
    - `CLINICAL_HUB_API_KEY`
 
 ## 2) Trigger preview build
@@ -27,7 +27,7 @@ From GitHub Actions:
    - `Local checks` is `pass`,
    - `Authenticated EAS readiness` is `pass` before attempting an EAS build trigger,
    - `Clinical Hub live API` is `present` before live API smoke/report push is expected,
-   - missing external items are understood and either configured or accepted as blockers for this run.
+   - missing or invalid external items are understood and either configured or accepted as blockers for this run.
    - `Next actions` maps the remaining external blockers to concrete setup tasks.
 5. Verify `eas-build` starts. If `Authenticated EAS readiness` is `blocked`, `eas-build` is skipped by design and the readiness artifact is the handoff output.
 6. Open workflow summary (`Mobile EAS Build`) and copy build links.
@@ -54,10 +54,10 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/defaults, package scripts, lockfile, pinned tooling, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/defaults, package scripts, lockfile, pinned tooling, API response redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
-- live Clinical Hub API readiness status,
+- live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
 - manual release requirements for Apple Developer and Google Play accounts,
 - machine-readable `next_actions` for configuring missing GitHub secrets/variables and manual store-account handoff.
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -84,6 +84,18 @@ def _is_localhost_url(value: str | None) -> bool:
     return bool(re.match(r"^https?://(localhost|127\.0\.0\.1|0\.0\.0\.0)([:/]|$)", value))
 
 
+def _is_https_non_localhost_url(value: str | None) -> bool:
+    if value is None:
+        return False
+    candidate = value.strip()
+    is_https_url = bool(re.match(r"^https://[^/:\s]+(?::\d+)?(?:/|$)", candidate))
+    return is_https_url and not _is_localhost_url(candidate)
+
+
+def _read_file_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.is_file() else ""
+
+
 def _has_plugin(plugins: list[Any], plugin_name: str) -> bool:
     for plugin in plugins:
         if plugin == plugin_name:
@@ -223,7 +235,7 @@ def _build_next_actions(
 
     next_actions: list[dict[str, Any]] = []
     for item in external_items:
-        if item["status"] == "missing" and item["id"] in external_action_map:
+        if item["status"] in {"missing", "invalid"} and item["id"] in external_action_map:
             next_actions.append(external_action_map[item["id"]])
     for item in manual_external_items:
         if item["status"] == "manual_required" and item["id"] in manual_action_map:
@@ -551,6 +563,13 @@ def build_readiness_report(
     validate_ci_script = scripts.get("validate:ci", "")
     test_unit_script = scripts.get("test:unit", "")
     unit_runner_path = mobile_root / "scripts" / "run-unit-tests.sh"
+    app_ts_path = mobile_root / "App.tsx"
+    app_helpers_path = mobile_root / "src" / "utils" / "appHelpers.ts"
+    connection_check_source_path = mobile_root / "src" / "api" / "connectionCheck.ts"
+    pending_sync_queue_source_path = mobile_root / "src" / "utils" / "pendingSyncQueue.ts"
+    pending_sync_hook_source_path = mobile_root / "src" / "hooks" / "usePendingSyncQueue.ts"
+    pending_storage_source_path = mobile_root / "src" / "storage" / "pendingSubmissionStorage.ts"
+    submit_outcome_source_path = mobile_root / "src" / "utils" / "submitOutcome.ts"
     helper_tests_path = mobile_root / "tests" / "appHelpers.test.js"
     app_settings_storage_tests_path = mobile_root / "tests" / "appSettingsStorage.test.js"
     clinical_hub_api_tests_path = mobile_root / "tests" / "clinicalHub.test.js"
@@ -566,6 +585,20 @@ def build_readiness_report(
     )
     summary_requests_tests_path = mobile_root / "tests" / "summaryRequests.test.js"
     submit_outcome_tests_path = mobile_root / "tests" / "submitOutcome.test.js"
+    app_ts_source = _read_file_text(app_ts_path)
+    app_helpers_source = _read_file_text(app_helpers_path)
+    connection_check_source = _read_file_text(connection_check_source_path)
+    pending_sync_queue_source = _read_file_text(pending_sync_queue_source_path)
+    pending_sync_hook_source = _read_file_text(pending_sync_hook_source_path)
+    pending_storage_source = _read_file_text(pending_storage_source_path)
+    submit_outcome_source = _read_file_text(submit_outcome_source_path)
+    helper_tests_source = _read_file_text(helper_tests_path)
+    connection_check_tests_source = _read_file_text(connection_check_tests_path)
+    pending_sync_queue_tests_source = _read_file_text(pending_sync_queue_tests_path)
+    pending_submission_storage_tests_source = _read_file_text(
+        pending_submission_storage_tests_path
+    )
+    submit_outcome_tests_source = _read_file_text(submit_outcome_tests_path)
     _check(
         checks,
         "unit_test_script",
@@ -662,6 +695,44 @@ def build_readiness_report(
         submit_outcome_tests_path.is_file(),
         f"path={submit_outcome_tests_path}",
     )
+    redaction_source_requirements = {
+        "app_helpers_formatter": "formatSafeResponseProblem" in app_helpers_source,
+        "app_summary_errors": "formatSafeResponseProblem(response.status, body)" in app_ts_source,
+        "app_network_errors": 'formatSafeResponseProblem(null, String(error), "NETWORK")'
+        in app_ts_source,
+        "connection_check": "formatSafeResponseProblem(status, body)" in connection_check_source,
+        "submit_outcome": "formatSafeResponseProblem(result.statusCode, result.body"
+        in submit_outcome_source,
+        "pending_sync_attempt": "summarizePendingError(options.result.body)"
+        in pending_sync_queue_source,
+        "pending_enqueue": "summarizePendingError(lastError)" in pending_sync_hook_source,
+        "pending_storage_migration": "summarizePendingError(rawLastError)"
+        in pending_storage_source,
+        "no_raw_summary_body": "HTTP ${response.status}: ${body}" not in app_ts_source,
+        "no_raw_summary_catch": "setSummaryError(String(error))" not in app_ts_source,
+        "no_raw_coverage_catch": "setCoverageError(String(error))" not in app_ts_source,
+    }
+    _check(
+        checks,
+        "mobile_api_response_redaction_sources",
+        all(redaction_source_requirements.values()),
+        f"requirements={redaction_source_requirements!r}",
+    )
+    redaction_test_requirements = {
+        "safe_formatter_test": "without leaking raw response bodies" in helper_tests_source,
+        "connection_check_test": "without raw body" in connection_check_tests_source,
+        "pending_sync_test": "server_or_client_response" in pending_sync_queue_tests_source
+        and "validation" in pending_sync_queue_tests_source,
+        "pending_storage_migration_test": "redacts migrated raw last errors"
+        in pending_submission_storage_tests_source,
+        "submit_outcome_test": "without raw body" in submit_outcome_tests_source,
+    }
+    _check(
+        checks,
+        "mobile_api_response_redaction_unit_tests_present",
+        all(redaction_test_requirements.values()),
+        f"requirements={redaction_test_requirements!r}",
+    )
     _check(
         checks,
         "build_scripts",
@@ -690,6 +761,28 @@ def build_readiness_report(
     eas_project_id = (
         extra.get("eas", {}).get("projectId") if isinstance(extra.get("eas"), dict) else None
     )
+    clinical_hub_url = env.get("CLINICAL_HUB_URL", "").strip()
+    clinical_hub_api_key_present = bool(env.get("CLINICAL_HUB_API_KEY"))
+    clinical_hub_live_api_present = bool(clinical_hub_url and clinical_hub_api_key_present)
+    clinical_hub_live_api_valid = (
+        clinical_hub_live_api_present and _is_https_non_localhost_url(clinical_hub_url)
+    )
+    if clinical_hub_live_api_valid:
+        clinical_hub_live_api_status = "present"
+        clinical_hub_live_api_evidence = (
+            "CLINICAL_HUB_URL uses https with a non-localhost host and CLINICAL_HUB_API_KEY is set"
+        )
+    elif clinical_hub_live_api_present:
+        clinical_hub_live_api_status = "invalid"
+        clinical_hub_live_api_evidence = (
+            "CLINICAL_HUB_URL is set but must use https with a non-localhost host for live "
+            "release readiness"
+        )
+    else:
+        clinical_hub_live_api_status = "missing"
+        clinical_hub_live_api_evidence = (
+            "CLINICAL_HUB_URL and/or CLINICAL_HUB_API_KEY are not set"
+        )
     external_items = [
         {
             "id": "expo_token",
@@ -709,13 +802,9 @@ def build_readiness_report(
         },
         {
             "id": "clinical_hub_live_api",
-            "status": "present"
-            if bool(env.get("CLINICAL_HUB_URL") and env.get("CLINICAL_HUB_API_KEY"))
-            else "missing",
+            "status": clinical_hub_live_api_status,
             "required_for": "Live Clinical Hub smoke tests and CI report push.",
-            "evidence": "CLINICAL_HUB_URL and CLINICAL_HUB_API_KEY are set"
-            if env.get("CLINICAL_HUB_URL") and env.get("CLINICAL_HUB_API_KEY")
-            else "CLINICAL_HUB_URL and/or CLINICAL_HUB_API_KEY are not set",
+            "evidence": clinical_hub_live_api_evidence,
         },
     ]
     manual_external_items = [
@@ -739,13 +828,13 @@ def build_readiness_report(
     local_failures = [
         item for item in checks if item["status"] == "fail" and item["severity"] == "error"
     ]
-    external_missing = [item for item in external_items if item["status"] == "missing"]
+    external_blocked = [item for item in external_items if item["status"] != "present"]
     authenticated_eas_item_ids = {"expo_token", "eas_project_identity"}
     authenticated_eas_blockers = [
         item["id"] for item in external_items if item["id"] in authenticated_eas_item_ids
-        and item["status"] == "missing"
+        and item["status"] != "present"
     ]
-    clinical_hub_live_api_status = next(
+    clinical_hub_live_api_status_for_report = next(
         (
             item["status"]
             for item in external_items
@@ -755,7 +844,7 @@ def build_readiness_report(
     )
     if local_failures:
         status = "not_ready"
-    elif external_missing:
+    elif external_blocked:
         status = "ready_except_external_credentials"
     else:
         status = "ready_for_authenticated_eas_preflight"
@@ -767,10 +856,10 @@ def build_readiness_report(
         "traceability": _build_traceability(env),
         "status": status,
         "local_checks_status": "pass" if not local_failures else "fail",
-        "external_readiness_status": "pass" if not external_missing else "blocked",
+        "external_readiness_status": "pass" if not external_blocked else "blocked",
         "authenticated_eas_status": "pass" if not authenticated_eas_blockers else "blocked",
         "authenticated_eas_blockers": authenticated_eas_blockers,
-        "clinical_hub_live_api_status": clinical_hub_live_api_status,
+        "clinical_hub_live_api_status": clinical_hub_live_api_status_for_report,
         "app": {
             "name": expo.get("name"),
             "slug": expo.get("slug"),

--- a/tests/test_mobile_build_workflow.py
+++ b/tests/test_mobile_build_workflow.py
@@ -38,3 +38,14 @@ def test_mobile_build_workflow_uploads_readiness_before_local_failure() -> None:
     assert build_index < upload_index < fail_index
     assert "mobile-release-readiness-exit-code" in steps[build_index]["run"]
     assert "mobile-release-readiness artifact" in steps[fail_index]["run"]
+
+
+def test_mobile_build_workflow_summary_reports_invalid_external_items() -> None:
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = payload["jobs"]["preflight"]["steps"]
+    summary_step = next(
+        step for step in steps if step.get("name") == "Publish release readiness summary"
+    )
+
+    assert 'item.get("status") == "invalid"' in summary_step["run"]
+    assert "Invalid external items" in summary_step["run"]

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -102,6 +102,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "validate_ci_runs_unit_tests",
         "unit_test_runner_script",
         "mobile_helper_unit_tests_present",
+        "mobile_api_response_redaction_sources",
+        "mobile_api_response_redaction_unit_tests_present",
         "connection_check_unit_tests_present",
         "capture_contract_unit_tests_present",
         "pending_submission_storage_unit_tests_present",
@@ -317,6 +319,36 @@ def test_mobile_release_readiness_separates_eas_from_clinical_hub(
     assert payload["authenticated_eas_status"] == "pass"
     assert payload["authenticated_eas_blockers"] == []
     assert payload["clinical_hub_live_api_status"] == "missing"
+    assert {item["id"] for item in payload["next_actions"]} == {
+        "configure_clinical_hub_live_api",
+        "provision_apple_developer_account",
+        "provision_google_play_account",
+    }
+
+
+def test_mobile_release_readiness_rejects_insecure_live_clinical_hub_url(
+    tmp_path: Path,
+) -> None:
+    payload = _run_readiness(
+        tmp_path / "readiness.json",
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "CLINICAL_HUB_API_KEY": "test-key",
+            "CLINICAL_HUB_URL": "http://127.0.0.1:8000",
+            "EAS_PROJECT_ID": "00000000-0000-0000-0000-000000000000",
+            "EXPO_TOKEN": "test-token",
+        },
+    )
+
+    clinical_hub_item = next(
+        item for item in payload["external_items"] if item["id"] == "clinical_hub_live_api"
+    )
+    assert payload["status"] == "ready_except_external_credentials"
+    assert payload["external_readiness_status"] == "blocked"
+    assert payload["authenticated_eas_status"] == "pass"
+    assert payload["clinical_hub_live_api_status"] == "invalid"
+    assert clinical_hub_item["status"] == "invalid"
+    assert "https" in clinical_hub_item["evidence"]
     assert {item["id"] for item in payload["next_actions"]} == {
         "configure_clinical_hub_live_api",
         "provision_apple_developer_account",


### PR DESCRIPTION
## What changed

- Added explicit `mobile_api_response_redaction_sources` and `mobile_api_response_redaction_unit_tests_present` local readiness checks.
- Changed live Clinical Hub external readiness from presence-only to `present` / `missing` / `invalid` based on `CLINICAL_HUB_URL` + `CLINICAL_HUB_API_KEY`.
- Require live `CLINICAL_HUB_URL` to use `https://` and a non-localhost host for release readiness.
- Updated Mobile Build summary to show invalid external items separately from missing ones.
- Updated README/runbook handoff docs and Python tests for the new readiness semantics.

## Why

The previous mobile redaction work was covered by unit tests but not surfaced as machine-readable release evidence. Also, live Clinical Hub secrets could be marked present even when the URL was unsuitable for live release, such as localhost or plain HTTP. This makes the handoff more precise: local privacy controls are explicit, and external blockers distinguish missing vs invalid configuration.

## Validation

- `.venv/bin/ruff check . && .venv/bin/pytest -q` -> `104 passed`
- `npm run validate:ci` -> TypeScript, 63 mobile unit tests, Expo Doctor 21/21, production audit, iOS export, Android export all passed
- `scripts/check_mobile_release_readiness.py` -> `ready_except_external_credentials`, `local_checks_status=pass`, redaction gates pass