### PR TITLE
[codex] Add mobile runtime privacy config

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -34,6 +34,7 @@ import {
 } from "./src/capture/runtimeCaptureSession";
 import { APP_MODEL_ID, APP_RELEASE_VERSION } from "./src/config/releaseMetadata";
 import { estimateRoiSignalFromBase64 } from "./src/capture/roiSignalEstimator";
+import { APP_DEFAULT_CAPTURE_MODE } from "./src/config/appConfig";
 import { ApiConnectionSection } from "./src/components/ApiConnectionSection";
 import { MeasurementFormSection } from "./src/components/MeasurementFormSection";
 import { ResponseAndSummarySection } from "./src/components/ResponseAndSummarySection";
@@ -97,7 +98,7 @@ export default function App() {
   const [platform, setPlatform] = useState<string>(defaultPlatform);
   const [deviceModel, setDeviceModel] = useState<string>(Platform.OS);
   const [appVersion, setAppVersion] = useState(APP_RELEASE_VERSION);
-  const [captureMode, setCaptureMode] = useState("water_impact");
+  const [captureMode, setCaptureMode] = useState(APP_DEFAULT_CAPTURE_MODE);
 
   const [appQmax, setAppQmax] = useState("");
   const [appQavg, setAppQavg] = useState("");

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -114,7 +114,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, Clinical Hub API client/connection check/summary requests + mobile helper/API + submit outcome + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, Clinical Hub API client/connection check/summary requests + mobile helper/API + runtime config + submit outcome + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` runs release preflight for mobile app/release-script changes and provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)
@@ -131,7 +131,8 @@ CI:
 secret blockers. The artifact has separate machine-readable gates:
 
 - `local_checks_status`: local app metadata, runtime release metadata, EAS profile shape,
-  runtime defaults such as non-localhost API URL defaults, store privacy declarations,
+  runtime config/defaults such as privacy-by-default switches and non-localhost API URL defaults,
+  store privacy declarations,
   launch/icon assets, dependency lock alignment, and unit-test evidence that can be verified
   without external credentials.
 - `authenticated_eas_status`: whether `EXPO_TOKEN` and deterministic EAS project identity are ready for an authenticated EAS build trigger.

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -9,6 +9,7 @@ tsc --ignoreConfig \
   src/utils/appHelpers.ts \
   src/utils/pendingSyncQueue.ts \
   src/utils/submitOutcome.ts \
+  src/config/appConfig.ts \
   src/config/releaseMetadata.ts \
   src/storage/appSettingsStorage.ts \
   src/storage/pendingSubmissionStorage.ts \

--- a/apps/field-mobile/src/capture/buildCaptureContract.ts
+++ b/apps/field-mobile/src/capture/buildCaptureContract.ts
@@ -2,6 +2,7 @@ import {
   APP_CAPTURE_SCHEMA_VERSION,
   APP_RELEASE_VERSION,
 } from "../config/releaseMetadata";
+import { APP_PRIVACY_POLICY } from "../config/appConfig";
 
 export type CaptureContractSample = {
   t_s: number;
@@ -247,6 +248,14 @@ function createSamples(input: BuildCaptureContractInput): CaptureContractSample[
   return samples;
 }
 
+function buildPrivacyNode(): CaptureContractPayload["session"]["privacy"] {
+  return {
+    store_raw_video: APP_PRIVACY_POLICY.storeRawVideo,
+    store_raw_audio: APP_PRIVACY_POLICY.storeRawAudio,
+    roi_only: APP_PRIVACY_POLICY.roiOnly,
+  };
+}
+
 export function buildCaptureContractPayload(
   input: BuildCaptureContractInput,
 ): CaptureContractPayload {
@@ -272,11 +281,7 @@ export function buildCaptureContractPayload(
         min_depth_confidence: 0.6,
         camera_distance_mm: 650,
       },
-      privacy: {
-        store_raw_video: false,
-        store_raw_audio: false,
-        roi_only: true,
-      },
+      privacy: buildPrivacyNode(),
     },
     samples: createSamples(input),
   };
@@ -340,11 +345,7 @@ export function buildCaptureContractPayloadFromSamples(
         min_depth_confidence: input.minDepthConfidence ?? 0.6,
         camera_distance_mm: input.cameraDistanceMm ?? 650,
       },
-      privacy: {
-        store_raw_video: false,
-        store_raw_audio: false,
-        roi_only: true,
-      },
+      privacy: buildPrivacyNode(),
     },
     samples: safeSamples,
   };

--- a/apps/field-mobile/src/config/appConfig.ts
+++ b/apps/field-mobile/src/config/appConfig.ts
@@ -1,0 +1,17 @@
+export const APP_RUNTIME_MODE = "pilot";
+export const APP_DEFAULT_CAPTURE_MODE = "water_impact";
+export const APP_STORE_RAW_VIDEO = false;
+export const APP_STORE_RAW_AUDIO = false;
+export const APP_ROI_ONLY = true;
+
+export const APP_PRIVACY_POLICY = Object.freeze({
+  storeRawVideo: APP_STORE_RAW_VIDEO,
+  storeRawAudio: APP_STORE_RAW_AUDIO,
+  roiOnly: APP_ROI_ONLY,
+});
+
+export const APP_RUNTIME_CONFIG = Object.freeze({
+  runtimeMode: APP_RUNTIME_MODE,
+  defaultCaptureMode: APP_DEFAULT_CAPTURE_MODE,
+  privacyPolicy: APP_PRIVACY_POLICY,
+});

--- a/apps/field-mobile/tests/appConfig.test.js
+++ b/apps/field-mobile/tests/appConfig.test.js
@@ -1,0 +1,24 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const appConfig = require(path.join(buildDir, "config/appConfig.js"));
+
+test("app runtime config defines pilot defaults and privacy-by-default switches", () => {
+  assert.equal(appConfig.APP_RUNTIME_MODE, "pilot");
+  assert.equal(appConfig.APP_DEFAULT_CAPTURE_MODE, "water_impact");
+  assert.equal(appConfig.APP_STORE_RAW_VIDEO, false);
+  assert.equal(appConfig.APP_STORE_RAW_AUDIO, false);
+  assert.equal(appConfig.APP_ROI_ONLY, true);
+  assert.deepEqual(appConfig.APP_PRIVACY_POLICY, {
+    storeRawVideo: false,
+    storeRawAudio: false,
+    roiOnly: true,
+  });
+  assert.deepEqual(appConfig.APP_RUNTIME_CONFIG, {
+    runtimeMode: "pilot",
+    defaultCaptureMode: "water_impact",
+    privacyPolicy: appConfig.APP_PRIVACY_POLICY,
+  });
+});

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -9,6 +9,7 @@ Implemented now:
 - Expo React Native field app for paired entry and sync.
 - Clinical Hub API contract for `paired-measurements` and `capture-packages`.
 - Pilot automation and release gates (`v4.2`) in repository.
+- App-level runtime config for pilot mode, default capture mode, and privacy-by-default switches.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).
@@ -46,7 +47,7 @@ Not yet implemented:
 
 ## B0: Foundation (must finish first)
 1. Split app architecture into modules: `api`, `capture`, `storage`, `sync`, `screens`.
-2. Add app-level config object (`mode`, endpoint set, privacy switches, debug gates).
+2. Add app-level config object (`mode`, endpoint set, privacy switches, debug gates). Status: partially implemented for pilot mode, default capture mode, and privacy switches.
 3. Add release manifest JSON generation (`app_version`, `git_sha`, `model_id`, `schema_version`).
 
 DoD:

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -47,6 +47,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - iOS build number and Android versionCode,
 - icon/adaptive-icon paths, `expo-splash-screen` image path, SHA-256 fingerprints, byte sizes, PNG dimensions, and splash background/resize/width config,
 - runtime release metadata from `apps/field-mobile/src/config/releaseMetadata.ts` for app version, model ID, and capture schema version,
+- runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, default capture mode, and privacy-by-default switches,
 - runtime defaults such as `DEFAULT_API_BASE_URL` to prove release builds do not point field devices at localhost,
 - git SHA/ref/run-id,
 - model_id and capture schema version.
@@ -54,7 +55,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/defaults, package scripts, lockfile, pinned tooling, API response redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, package scripts, lockfile, pinned tooling, API response redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),

--- a/scripts/build_mobile_release_manifest.py
+++ b/scripts/build_mobile_release_manifest.py
@@ -53,6 +53,14 @@ def _read_ts_string_constant(source: str, name: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _read_ts_boolean_constant(source: str, name: str) -> bool | None:
+    pattern = re.compile(rf"export\s+const\s+{re.escape(name)}\s*=\s*(true|false)")
+    match = pattern.search(source)
+    if not match:
+        return None
+    return match.group(1) == "true"
+
+
 def _release_metadata(app_json: Path) -> dict[str, str | None]:
     path = app_json.parent / "src" / "config" / "releaseMetadata.ts"
     if not path.is_file():
@@ -70,6 +78,28 @@ def _release_metadata(app_json: Path) -> dict[str, str | None]:
         "capture_schema_version": _read_ts_string_constant(
             source, "APP_CAPTURE_SCHEMA_VERSION"
         ),
+    }
+
+
+def _app_runtime_config(app_json: Path) -> dict[str, str | bool | None]:
+    path = app_json.parent / "src" / "config" / "appConfig.ts"
+    if not path.is_file():
+        return {
+            "path": str(path),
+            "runtime_mode": None,
+            "default_capture_mode": None,
+            "store_raw_video": None,
+            "store_raw_audio": None,
+            "roi_only": None,
+        }
+    source = path.read_text(encoding="utf-8")
+    return {
+        "path": str(path),
+        "runtime_mode": _read_ts_string_constant(source, "APP_RUNTIME_MODE"),
+        "default_capture_mode": _read_ts_string_constant(source, "APP_DEFAULT_CAPTURE_MODE"),
+        "store_raw_video": _read_ts_boolean_constant(source, "APP_STORE_RAW_VIDEO"),
+        "store_raw_audio": _read_ts_boolean_constant(source, "APP_STORE_RAW_AUDIO"),
+        "roi_only": _read_ts_boolean_constant(source, "APP_ROI_ONLY"),
     }
 
 
@@ -106,6 +136,7 @@ def main() -> int:
     android = expo.get("android", {})
     splash = _get_plugin_options(plugins, "expo-splash-screen")
     release_metadata = _release_metadata(args.app_json)
+    app_runtime_config = _app_runtime_config(args.app_json)
     app_settings_defaults = _app_settings_defaults(args.app_json)
     android_adaptive_icon = android.get("adaptiveIcon", {})
 
@@ -147,6 +178,7 @@ def main() -> int:
             "workflow": os.environ.get("GITHUB_WORKFLOW", "local"),
         },
         "runtime_release_metadata": release_metadata,
+        "runtime_config": app_runtime_config,
         "runtime_defaults": app_settings_defaults,
         "algorithm": {
             "model_id": args.model_id,

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -47,6 +47,14 @@ def _read_ts_string_constant(source: str, name: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _read_ts_boolean_constant(source: str, name: str) -> bool | None:
+    pattern = re.compile(rf"export\s+const\s+{re.escape(name)}\s*=\s*(true|false)")
+    match = pattern.search(source)
+    if not match:
+        return None
+    return match.group(1) == "true"
+
+
 def _load_release_metadata(app_json: Path) -> dict[str, str | None]:
     path = app_json.parent / "src" / "config" / "releaseMetadata.ts"
     if not path.is_file():
@@ -64,6 +72,28 @@ def _load_release_metadata(app_json: Path) -> dict[str, str | None]:
         "capture_schema_version": _read_ts_string_constant(
             source, "APP_CAPTURE_SCHEMA_VERSION"
         ),
+    }
+
+
+def _load_app_runtime_config(app_json: Path) -> dict[str, str | bool | None]:
+    path = app_json.parent / "src" / "config" / "appConfig.ts"
+    if not path.is_file():
+        return {
+            "path": str(path),
+            "runtime_mode": None,
+            "default_capture_mode": None,
+            "store_raw_video": None,
+            "store_raw_audio": None,
+            "roi_only": None,
+        }
+    source = path.read_text(encoding="utf-8")
+    return {
+        "path": str(path),
+        "runtime_mode": _read_ts_string_constant(source, "APP_RUNTIME_MODE"),
+        "default_capture_mode": _read_ts_string_constant(source, "APP_DEFAULT_CAPTURE_MODE"),
+        "store_raw_video": _read_ts_boolean_constant(source, "APP_STORE_RAW_VIDEO"),
+        "store_raw_audio": _read_ts_boolean_constant(source, "APP_STORE_RAW_AUDIO"),
+        "roi_only": _read_ts_boolean_constant(source, "APP_ROI_ONLY"),
     }
 
 
@@ -256,6 +286,7 @@ def build_readiness_report(
     package_payload = _load_json(package_json)
     lock_payload = _load_json(package_lock)
     release_metadata = _load_release_metadata(app_json)
+    app_runtime_config = _load_app_runtime_config(app_json)
     app_settings_defaults = _load_app_settings_defaults(app_json)
 
     expo = app_payload.get("expo", {})
@@ -318,6 +349,41 @@ def build_readiness_report(
         "release_metadata_capture_schema_version",
         release_metadata.get("capture_schema_version") == "ios_capture_v1",
         f"capture_schema_version={release_metadata.get('capture_schema_version')!r}",
+    )
+    _check(
+        checks,
+        "runtime_config_module",
+        bool(app_runtime_config.get("runtime_mode"))
+        and bool(app_runtime_config.get("default_capture_mode"))
+        and app_runtime_config.get("store_raw_video") is not None
+        and app_runtime_config.get("store_raw_audio") is not None
+        and app_runtime_config.get("roi_only") is not None,
+        (
+            f"path={app_runtime_config.get('path')}, "
+            f"runtime_mode={app_runtime_config.get('runtime_mode')!r}, "
+            f"default_capture_mode={app_runtime_config.get('default_capture_mode')!r}, "
+            f"store_raw_video={app_runtime_config.get('store_raw_video')!r}, "
+            f"store_raw_audio={app_runtime_config.get('store_raw_audio')!r}, "
+            f"roi_only={app_runtime_config.get('roi_only')!r}"
+        ),
+    )
+    _check(
+        checks,
+        "runtime_config_default_capture_mode",
+        app_runtime_config.get("default_capture_mode") == "water_impact",
+        f"default_capture_mode={app_runtime_config.get('default_capture_mode')!r}",
+    )
+    _check(
+        checks,
+        "runtime_config_privacy_by_default",
+        app_runtime_config.get("store_raw_video") is False
+        and app_runtime_config.get("store_raw_audio") is False
+        and app_runtime_config.get("roi_only") is True,
+        (
+            f"store_raw_video={app_runtime_config.get('store_raw_video')!r}, "
+            f"store_raw_audio={app_runtime_config.get('store_raw_audio')!r}, "
+            f"roi_only={app_runtime_config.get('roi_only')!r}"
+        ),
     )
     _check(
         checks,
@@ -564,6 +630,7 @@ def build_readiness_report(
     test_unit_script = scripts.get("test:unit", "")
     unit_runner_path = mobile_root / "scripts" / "run-unit-tests.sh"
     app_ts_path = mobile_root / "App.tsx"
+    app_config_tests_path = mobile_root / "tests" / "appConfig.test.js"
     app_helpers_path = mobile_root / "src" / "utils" / "appHelpers.ts"
     connection_check_source_path = mobile_root / "src" / "api" / "connectionCheck.ts"
     pending_sync_queue_source_path = mobile_root / "src" / "utils" / "pendingSyncQueue.ts"
@@ -622,6 +689,12 @@ def build_readiness_report(
         "mobile_helper_unit_tests_present",
         helper_tests_path.is_file(),
         f"path={helper_tests_path}",
+    )
+    _check(
+        checks,
+        "app_config_unit_tests_present",
+        app_config_tests_path.is_file(),
+        f"path={app_config_tests_path}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_manifest_script.py
+++ b/tests/test_mobile_release_manifest_script.py
@@ -32,6 +32,7 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     output = tmp_path / "manifest.json"
     assets = tmp_path / "assets"
     metadata_path = tmp_path / "src" / "config" / "releaseMetadata.ts"
+    app_config_path = tmp_path / "src" / "config" / "appConfig.ts"
     app_settings_path = tmp_path / "src" / "storage" / "appSettingsStorage.ts"
     assets.mkdir()
     metadata_path.parent.mkdir(parents=True)
@@ -83,6 +84,18 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
                 'export const APP_RELEASE_VERSION = "0.1.0";',
                 'export const APP_MODEL_ID = "fusion-v0.1";',
                 'export const APP_CAPTURE_SCHEMA_VERSION = "ios_capture_v1";',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    app_config_path.write_text(
+        "\n".join(
+            [
+                'export const APP_RUNTIME_MODE = "pilot";',
+                'export const APP_DEFAULT_CAPTURE_MODE = "water_impact";',
+                "export const APP_STORE_RAW_VIDEO = false;",
+                "export const APP_STORE_RAW_AUDIO = false;",
+                "export const APP_ROI_ONLY = true;",
             ]
         ),
         encoding="utf-8",
@@ -139,6 +152,11 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     assert payload["runtime_release_metadata"]["app_version"] == "0.1.0"
     assert payload["runtime_release_metadata"]["model_id"] == "fusion-v0.1"
     assert payload["runtime_release_metadata"]["capture_schema_version"] == "ios_capture_v1"
+    assert payload["runtime_config"]["runtime_mode"] == "pilot"
+    assert payload["runtime_config"]["default_capture_mode"] == "water_impact"
+    assert payload["runtime_config"]["store_raw_video"] is False
+    assert payload["runtime_config"]["store_raw_audio"] is False
+    assert payload["runtime_config"]["roi_only"] is True
     assert payload["runtime_defaults"]["default_api_base_url"] == ""
     assert payload["algorithm"]["model_id"] == "fusion-v0.1"
     assert payload["algorithm"]["capture_schema_version"] == "ios_capture_v1"

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -88,8 +88,12 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "eas_production_auto_increment",
         "eas_profile_channels",
         "ios_privacy_usage_descriptions",
+        "app_config_unit_tests_present",
         "paired_payload_unit_tests_present",
         "package_lock_matches_root",
+        "runtime_config_default_capture_mode",
+        "runtime_config_module",
+        "runtime_config_privacy_by_default",
         "secure_store_dependency_locked",
         "secure_store_plugin",
         "splash_background_color",
@@ -264,6 +268,43 @@ def test_mobile_release_readiness_fails_localhost_default_api_url(tmp_path: Path
     assert payload["local_checks_status"] == "fail"
     assert check["status"] == "fail"
     assert "http://127.0.0.1:8000" in check["evidence"]
+
+
+def test_mobile_release_readiness_fails_raw_media_runtime_config(tmp_path: Path) -> None:
+    mutated_app_json = tmp_path / "app.json"
+    app_config_path = tmp_path / "src" / "config" / "appConfig.ts"
+    app_config_path.parent.mkdir(parents=True)
+    app_payload = json.loads(APP_JSON.read_text(encoding="utf-8"))
+    mutated_app_json.write_text(json.dumps(app_payload), encoding="utf-8")
+    app_config_path.write_text(
+        "\n".join(
+            [
+                'export const APP_RUNTIME_MODE = "pilot";',
+                'export const APP_DEFAULT_CAPTURE_MODE = "water_impact";',
+                "export const APP_STORE_RAW_VIDEO = true;",
+                "export const APP_STORE_RAW_AUDIO = false;",
+                "export const APP_ROI_ONLY = true;",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = _run_readiness_with_paths(
+        tmp_path / "readiness.json",
+        env={"PATH": os.environ.get("PATH", "")},
+        app_json=mutated_app_json,
+        check=False,
+    )
+
+    check = next(
+        item
+        for item in payload["local_checks"]
+        if item["id"] == "runtime_config_privacy_by_default"
+    )
+    assert payload["status"] == "not_ready"
+    assert payload["local_checks_status"] == "fail"
+    assert check["status"] == "fail"
+    assert "store_raw_video=True" in check["evidence"]
 
 
 def test_mobile_release_readiness_passes_authenticated_preflight_env(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add a mobile app runtime config module for pilot mode, default capture mode, and privacy-by-default switches.
- Wire capture contract privacy payloads and the default capture-mode state through that config instead of hardcoded literals.
- Surface runtime config in mobile release manifest/readiness checks, including gates for default capture mode, raw media disabled by default, ROI-only enabled, and config unit-test evidence.
- Update the mobile runbook/backlog/readme to document the new release-readiness coverage.

## Validation
- `.venv/bin/ruff check scripts/check_mobile_release_readiness.py scripts/build_mobile_release_manifest.py tests/test_mobile_release_readiness_script.py tests/test_mobile_release_manifest_script.py`
- `.venv/bin/pytest -q tests/test_mobile_release_readiness_script.py tests/test_mobile_release_manifest_script.py` (`11 passed`)
- `npm run typecheck`
- `npm run test:unit` (`64 passed`)
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`105 passed`)
- `npm run validate:ci`
- `python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/readiness-runtime-config.json` (`ready_except_external_credentials`)
- `python3 scripts/build_mobile_release_manifest.py --app-json apps/field-mobile/app.json --output /tmp/manifest-runtime-config.json --profile production --model-id fusion-v0.1 --schema-version ios_capture_v1`

## Release readiness notes
- Local runtime config gates pass: `runtime_config_module`, `runtime_config_default_capture_mode`, `runtime_config_privacy_by_default`, `app_config_unit_tests_present`.
- External blockers remain explicitly separate: missing `EXPO_TOKEN`/EAS project identity and missing live Clinical Hub URL/API key in local environment.