### PR TITLE
[codex] Add mobile endpoint and debug runtime gates

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -120,7 +120,7 @@ CI:
   - `build_platform` (`all` / `ios` / `android`)
   - `wait_for_build` (`true` / `false`)
 - `mobile-build` uploads:
-  - `mobile-release-manifest` (version + runtime release metadata + git SHA + model/schema traceability)
+  - `mobile-release-manifest` (version + runtime release metadata/config + git SHA + model/schema traceability)
   - `mobile-release-readiness` (git traceability + local readiness checks + explicit external credential blockers)
   - `mobile-eas-build-result-<run_id>` (raw EAS JSON response for build IDs/URLs)
 - Workflow summary includes release readiness status and direct EAS build links for operator/release use.
@@ -131,7 +131,8 @@ CI:
 secret blockers. The artifact has separate machine-readable gates:
 
 - `local_checks_status`: local app metadata, runtime release metadata, EAS profile shape,
-  runtime config/defaults such as privacy-by-default switches and non-localhost API URL defaults,
+  runtime config/defaults such as Clinical Hub v1 endpoint set, disabled debug gates,
+  privacy-by-default switches, and non-localhost API URL defaults,
   store privacy declarations,
   launch/icon assets, dependency lock alignment, and unit-test evidence that can be verified
   without external credentials.

--- a/apps/field-mobile/src/api/clinicalHub.ts
+++ b/apps/field-mobile/src/api/clinicalHub.ts
@@ -4,6 +4,7 @@ import type {
   RequestHeaderContext,
   SubmitAttemptResult,
 } from "../types";
+import { APP_ENDPOINT_PATHS } from "../config/appConfig";
 import { clampTimeoutMs, classifyRetryable, createRequestId } from "../utils/appHelpers";
 
 export function buildBaseUrl(apiBaseUrl: string): string {
@@ -19,10 +20,7 @@ export function buildMissingApiBaseUrlMessage(): string {
 }
 
 export function endpointPath(endpoint: PendingEndpoint): string {
-  if (endpoint === "capture_packages") {
-    return "/api/v1/capture-packages";
-  }
-  return "/api/v1/paired-measurements";
+  return APP_ENDPOINT_PATHS[endpoint];
 }
 
 export function buildRequestHeaders(

--- a/apps/field-mobile/src/config/appConfig.ts
+++ b/apps/field-mobile/src/config/appConfig.ts
@@ -1,8 +1,21 @@
+import type { PendingEndpoint } from "../types";
+
 export const APP_RUNTIME_MODE = "pilot";
+export const APP_ENDPOINT_SET = "clinical_hub_v1";
 export const APP_DEFAULT_CAPTURE_MODE = "water_impact";
+export const APP_PAIRED_MEASUREMENTS_ENDPOINT_PATH = "/api/v1/paired-measurements";
+export const APP_CAPTURE_PACKAGES_ENDPOINT_PATH = "/api/v1/capture-packages";
 export const APP_STORE_RAW_VIDEO = false;
 export const APP_STORE_RAW_AUDIO = false;
 export const APP_ROI_ONLY = true;
+export const APP_ALLOW_DEBUG_CONTROLS = false;
+export const APP_ALLOW_RAW_RESPONSE_DETAILS = false;
+export const APP_ENABLE_VERBOSE_LOGGING = false;
+
+export const APP_ENDPOINT_PATHS: Readonly<Record<PendingEndpoint, string>> = Object.freeze({
+  paired_measurements: APP_PAIRED_MEASUREMENTS_ENDPOINT_PATH,
+  capture_packages: APP_CAPTURE_PACKAGES_ENDPOINT_PATH,
+});
 
 export const APP_PRIVACY_POLICY = Object.freeze({
   storeRawVideo: APP_STORE_RAW_VIDEO,
@@ -10,8 +23,17 @@ export const APP_PRIVACY_POLICY = Object.freeze({
   roiOnly: APP_ROI_ONLY,
 });
 
+export const APP_DEBUG_GATES = Object.freeze({
+  allowDebugControls: APP_ALLOW_DEBUG_CONTROLS,
+  allowRawResponseDetails: APP_ALLOW_RAW_RESPONSE_DETAILS,
+  enableVerboseLogging: APP_ENABLE_VERBOSE_LOGGING,
+});
+
 export const APP_RUNTIME_CONFIG = Object.freeze({
   runtimeMode: APP_RUNTIME_MODE,
+  endpointSet: APP_ENDPOINT_SET,
+  endpointPaths: APP_ENDPOINT_PATHS,
   defaultCaptureMode: APP_DEFAULT_CAPTURE_MODE,
   privacyPolicy: APP_PRIVACY_POLICY,
+  debugGates: APP_DEBUG_GATES,
 });

--- a/apps/field-mobile/tests/appConfig.test.js
+++ b/apps/field-mobile/tests/appConfig.test.js
@@ -5,20 +5,41 @@ const test = require("node:test");
 const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
 const appConfig = require(path.join(buildDir, "config/appConfig.js"));
 
-test("app runtime config defines pilot defaults and privacy-by-default switches", () => {
+test("app runtime config defines pilot endpoints, privacy defaults, and debug gates", () => {
   assert.equal(appConfig.APP_RUNTIME_MODE, "pilot");
+  assert.equal(appConfig.APP_ENDPOINT_SET, "clinical_hub_v1");
   assert.equal(appConfig.APP_DEFAULT_CAPTURE_MODE, "water_impact");
+  assert.equal(
+    appConfig.APP_PAIRED_MEASUREMENTS_ENDPOINT_PATH,
+    "/api/v1/paired-measurements",
+  );
+  assert.equal(appConfig.APP_CAPTURE_PACKAGES_ENDPOINT_PATH, "/api/v1/capture-packages");
   assert.equal(appConfig.APP_STORE_RAW_VIDEO, false);
   assert.equal(appConfig.APP_STORE_RAW_AUDIO, false);
   assert.equal(appConfig.APP_ROI_ONLY, true);
+  assert.equal(appConfig.APP_ALLOW_DEBUG_CONTROLS, false);
+  assert.equal(appConfig.APP_ALLOW_RAW_RESPONSE_DETAILS, false);
+  assert.equal(appConfig.APP_ENABLE_VERBOSE_LOGGING, false);
+  assert.deepEqual(appConfig.APP_ENDPOINT_PATHS, {
+    paired_measurements: "/api/v1/paired-measurements",
+    capture_packages: "/api/v1/capture-packages",
+  });
   assert.deepEqual(appConfig.APP_PRIVACY_POLICY, {
     storeRawVideo: false,
     storeRawAudio: false,
     roiOnly: true,
   });
+  assert.deepEqual(appConfig.APP_DEBUG_GATES, {
+    allowDebugControls: false,
+    allowRawResponseDetails: false,
+    enableVerboseLogging: false,
+  });
   assert.deepEqual(appConfig.APP_RUNTIME_CONFIG, {
     runtimeMode: "pilot",
+    endpointSet: "clinical_hub_v1",
+    endpointPaths: appConfig.APP_ENDPOINT_PATHS,
     defaultCaptureMode: "water_impact",
     privacyPolicy: appConfig.APP_PRIVACY_POLICY,
+    debugGates: appConfig.APP_DEBUG_GATES,
   });
 });

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -9,7 +9,7 @@ Implemented now:
 - Expo React Native field app for paired entry and sync.
 - Clinical Hub API contract for `paired-measurements` and `capture-packages`.
 - Pilot automation and release gates (`v4.2`) in repository.
-- App-level runtime config for pilot mode, default capture mode, and privacy-by-default switches.
+- App-level runtime config for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, and disabled debug gates.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).
@@ -47,7 +47,7 @@ Not yet implemented:
 
 ## B0: Foundation (must finish first)
 1. Split app architecture into modules: `api`, `capture`, `storage`, `sync`, `screens`.
-2. Add app-level config object (`mode`, endpoint set, privacy switches, debug gates). Status: partially implemented for pilot mode, default capture mode, and privacy switches.
+2. Add app-level config object (`mode`, endpoint set, privacy switches, debug gates). Status: implemented for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy switches, and disabled debug gates.
 3. Add release manifest JSON generation (`app_version`, `git_sha`, `model_id`, `schema_version`).
 
 DoD:

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -47,7 +47,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - iOS build number and Android versionCode,
 - icon/adaptive-icon paths, `expo-splash-screen` image path, SHA-256 fingerprints, byte sizes, PNG dimensions, and splash background/resize/width config,
 - runtime release metadata from `apps/field-mobile/src/config/releaseMetadata.ts` for app version, model ID, and capture schema version,
-- runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, default capture mode, and privacy-by-default switches,
+- runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, and disabled debug gates,
 - runtime defaults such as `DEFAULT_API_BASE_URL` to prove release builds do not point field devices at localhost,
 - git SHA/ref/run-id,
 - model_id and capture schema version.
@@ -55,7 +55,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, package scripts, lockfile, pinned tooling, API response redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/debug gates, package scripts, lockfile, pinned tooling, API response redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),

--- a/scripts/build_mobile_release_manifest.py
+++ b/scripts/build_mobile_release_manifest.py
@@ -87,19 +87,39 @@ def _app_runtime_config(app_json: Path) -> dict[str, str | bool | None]:
         return {
             "path": str(path),
             "runtime_mode": None,
+            "endpoint_set": None,
             "default_capture_mode": None,
+            "paired_measurements_endpoint_path": None,
+            "capture_packages_endpoint_path": None,
             "store_raw_video": None,
             "store_raw_audio": None,
             "roi_only": None,
+            "allow_debug_controls": None,
+            "allow_raw_response_details": None,
+            "enable_verbose_logging": None,
         }
     source = path.read_text(encoding="utf-8")
     return {
         "path": str(path),
         "runtime_mode": _read_ts_string_constant(source, "APP_RUNTIME_MODE"),
+        "endpoint_set": _read_ts_string_constant(source, "APP_ENDPOINT_SET"),
         "default_capture_mode": _read_ts_string_constant(source, "APP_DEFAULT_CAPTURE_MODE"),
+        "paired_measurements_endpoint_path": _read_ts_string_constant(
+            source, "APP_PAIRED_MEASUREMENTS_ENDPOINT_PATH"
+        ),
+        "capture_packages_endpoint_path": _read_ts_string_constant(
+            source, "APP_CAPTURE_PACKAGES_ENDPOINT_PATH"
+        ),
         "store_raw_video": _read_ts_boolean_constant(source, "APP_STORE_RAW_VIDEO"),
         "store_raw_audio": _read_ts_boolean_constant(source, "APP_STORE_RAW_AUDIO"),
         "roi_only": _read_ts_boolean_constant(source, "APP_ROI_ONLY"),
+        "allow_debug_controls": _read_ts_boolean_constant(source, "APP_ALLOW_DEBUG_CONTROLS"),
+        "allow_raw_response_details": _read_ts_boolean_constant(
+            source, "APP_ALLOW_RAW_RESPONSE_DETAILS"
+        ),
+        "enable_verbose_logging": _read_ts_boolean_constant(
+            source, "APP_ENABLE_VERBOSE_LOGGING"
+        ),
     }
 
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -81,19 +81,39 @@ def _load_app_runtime_config(app_json: Path) -> dict[str, str | bool | None]:
         return {
             "path": str(path),
             "runtime_mode": None,
+            "endpoint_set": None,
             "default_capture_mode": None,
+            "paired_measurements_endpoint_path": None,
+            "capture_packages_endpoint_path": None,
             "store_raw_video": None,
             "store_raw_audio": None,
             "roi_only": None,
+            "allow_debug_controls": None,
+            "allow_raw_response_details": None,
+            "enable_verbose_logging": None,
         }
     source = path.read_text(encoding="utf-8")
     return {
         "path": str(path),
         "runtime_mode": _read_ts_string_constant(source, "APP_RUNTIME_MODE"),
+        "endpoint_set": _read_ts_string_constant(source, "APP_ENDPOINT_SET"),
         "default_capture_mode": _read_ts_string_constant(source, "APP_DEFAULT_CAPTURE_MODE"),
+        "paired_measurements_endpoint_path": _read_ts_string_constant(
+            source, "APP_PAIRED_MEASUREMENTS_ENDPOINT_PATH"
+        ),
+        "capture_packages_endpoint_path": _read_ts_string_constant(
+            source, "APP_CAPTURE_PACKAGES_ENDPOINT_PATH"
+        ),
         "store_raw_video": _read_ts_boolean_constant(source, "APP_STORE_RAW_VIDEO"),
         "store_raw_audio": _read_ts_boolean_constant(source, "APP_STORE_RAW_AUDIO"),
         "roi_only": _read_ts_boolean_constant(source, "APP_ROI_ONLY"),
+        "allow_debug_controls": _read_ts_boolean_constant(source, "APP_ALLOW_DEBUG_CONTROLS"),
+        "allow_raw_response_details": _read_ts_boolean_constant(
+            source, "APP_ALLOW_RAW_RESPONSE_DETAILS"
+        ),
+        "enable_verbose_logging": _read_ts_boolean_constant(
+            source, "APP_ENABLE_VERBOSE_LOGGING"
+        ),
     }
 
 
@@ -354,17 +374,48 @@ def build_readiness_report(
         checks,
         "runtime_config_module",
         bool(app_runtime_config.get("runtime_mode"))
+        and bool(app_runtime_config.get("endpoint_set"))
         and bool(app_runtime_config.get("default_capture_mode"))
+        and bool(app_runtime_config.get("paired_measurements_endpoint_path"))
+        and bool(app_runtime_config.get("capture_packages_endpoint_path"))
         and app_runtime_config.get("store_raw_video") is not None
         and app_runtime_config.get("store_raw_audio") is not None
-        and app_runtime_config.get("roi_only") is not None,
+        and app_runtime_config.get("roi_only") is not None
+        and app_runtime_config.get("allow_debug_controls") is not None
+        and app_runtime_config.get("allow_raw_response_details") is not None
+        and app_runtime_config.get("enable_verbose_logging") is not None,
         (
             f"path={app_runtime_config.get('path')}, "
             f"runtime_mode={app_runtime_config.get('runtime_mode')!r}, "
+            f"endpoint_set={app_runtime_config.get('endpoint_set')!r}, "
             f"default_capture_mode={app_runtime_config.get('default_capture_mode')!r}, "
+            "paired_measurements_endpoint_path="
+            f"{app_runtime_config.get('paired_measurements_endpoint_path')!r}, "
+            "capture_packages_endpoint_path="
+            f"{app_runtime_config.get('capture_packages_endpoint_path')!r}, "
             f"store_raw_video={app_runtime_config.get('store_raw_video')!r}, "
             f"store_raw_audio={app_runtime_config.get('store_raw_audio')!r}, "
-            f"roi_only={app_runtime_config.get('roi_only')!r}"
+            f"roi_only={app_runtime_config.get('roi_only')!r}, "
+            f"allow_debug_controls={app_runtime_config.get('allow_debug_controls')!r}, "
+            "allow_raw_response_details="
+            f"{app_runtime_config.get('allow_raw_response_details')!r}, "
+            f"enable_verbose_logging={app_runtime_config.get('enable_verbose_logging')!r}"
+        ),
+    )
+    _check(
+        checks,
+        "runtime_config_endpoint_set",
+        app_runtime_config.get("endpoint_set") == "clinical_hub_v1"
+        and app_runtime_config.get("paired_measurements_endpoint_path")
+        == "/api/v1/paired-measurements"
+        and app_runtime_config.get("capture_packages_endpoint_path")
+        == "/api/v1/capture-packages",
+        (
+            f"endpoint_set={app_runtime_config.get('endpoint_set')!r}, "
+            "paired_measurements_endpoint_path="
+            f"{app_runtime_config.get('paired_measurements_endpoint_path')!r}, "
+            "capture_packages_endpoint_path="
+            f"{app_runtime_config.get('capture_packages_endpoint_path')!r}"
         ),
     )
     _check(
@@ -383,6 +434,19 @@ def build_readiness_report(
             f"store_raw_video={app_runtime_config.get('store_raw_video')!r}, "
             f"store_raw_audio={app_runtime_config.get('store_raw_audio')!r}, "
             f"roi_only={app_runtime_config.get('roi_only')!r}"
+        ),
+    )
+    _check(
+        checks,
+        "runtime_config_debug_gates_disabled",
+        app_runtime_config.get("allow_debug_controls") is False
+        and app_runtime_config.get("allow_raw_response_details") is False
+        and app_runtime_config.get("enable_verbose_logging") is False,
+        (
+            f"allow_debug_controls={app_runtime_config.get('allow_debug_controls')!r}, "
+            "allow_raw_response_details="
+            f"{app_runtime_config.get('allow_raw_response_details')!r}, "
+            f"enable_verbose_logging={app_runtime_config.get('enable_verbose_logging')!r}"
         ),
     )
     _check(

--- a/tests/test_mobile_release_manifest_script.py
+++ b/tests/test_mobile_release_manifest_script.py
@@ -92,10 +92,22 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
         "\n".join(
             [
                 'export const APP_RUNTIME_MODE = "pilot";',
+                'export const APP_ENDPOINT_SET = "clinical_hub_v1";',
                 'export const APP_DEFAULT_CAPTURE_MODE = "water_impact";',
+                (
+                    'export const APP_PAIRED_MEASUREMENTS_ENDPOINT_PATH = '
+                    '"/api/v1/paired-measurements";'
+                ),
+                (
+                    'export const APP_CAPTURE_PACKAGES_ENDPOINT_PATH = '
+                    '"/api/v1/capture-packages";'
+                ),
                 "export const APP_STORE_RAW_VIDEO = false;",
                 "export const APP_STORE_RAW_AUDIO = false;",
                 "export const APP_ROI_ONLY = true;",
+                "export const APP_ALLOW_DEBUG_CONTROLS = false;",
+                "export const APP_ALLOW_RAW_RESPONSE_DETAILS = false;",
+                "export const APP_ENABLE_VERBOSE_LOGGING = false;",
             ]
         ),
         encoding="utf-8",
@@ -153,10 +165,20 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     assert payload["runtime_release_metadata"]["model_id"] == "fusion-v0.1"
     assert payload["runtime_release_metadata"]["capture_schema_version"] == "ios_capture_v1"
     assert payload["runtime_config"]["runtime_mode"] == "pilot"
+    assert payload["runtime_config"]["endpoint_set"] == "clinical_hub_v1"
     assert payload["runtime_config"]["default_capture_mode"] == "water_impact"
+    assert payload["runtime_config"]["paired_measurements_endpoint_path"] == (
+        "/api/v1/paired-measurements"
+    )
+    assert payload["runtime_config"]["capture_packages_endpoint_path"] == (
+        "/api/v1/capture-packages"
+    )
     assert payload["runtime_config"]["store_raw_video"] is False
     assert payload["runtime_config"]["store_raw_audio"] is False
     assert payload["runtime_config"]["roi_only"] is True
+    assert payload["runtime_config"]["allow_debug_controls"] is False
+    assert payload["runtime_config"]["allow_raw_response_details"] is False
+    assert payload["runtime_config"]["enable_verbose_logging"] is False
     assert payload["runtime_defaults"]["default_api_base_url"] == ""
     assert payload["algorithm"]["model_id"] == "fusion-v0.1"
     assert payload["algorithm"]["capture_schema_version"] == "ios_capture_v1"

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -92,6 +92,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "paired_payload_unit_tests_present",
         "package_lock_matches_root",
         "runtime_config_default_capture_mode",
+        "runtime_config_debug_gates_disabled",
+        "runtime_config_endpoint_set",
         "runtime_config_module",
         "runtime_config_privacy_by_default",
         "secure_store_dependency_locked",
@@ -280,10 +282,22 @@ def test_mobile_release_readiness_fails_raw_media_runtime_config(tmp_path: Path)
         "\n".join(
             [
                 'export const APP_RUNTIME_MODE = "pilot";',
+                'export const APP_ENDPOINT_SET = "clinical_hub_v1";',
                 'export const APP_DEFAULT_CAPTURE_MODE = "water_impact";',
+                (
+                    'export const APP_PAIRED_MEASUREMENTS_ENDPOINT_PATH = '
+                    '"/api/v1/paired-measurements";'
+                ),
+                (
+                    'export const APP_CAPTURE_PACKAGES_ENDPOINT_PATH = '
+                    '"/api/v1/capture-packages";'
+                ),
                 "export const APP_STORE_RAW_VIDEO = true;",
                 "export const APP_STORE_RAW_AUDIO = false;",
                 "export const APP_ROI_ONLY = true;",
+                "export const APP_ALLOW_DEBUG_CONTROLS = false;",
+                "export const APP_ALLOW_RAW_RESPONSE_DETAILS = false;",
+                "export const APP_ENABLE_VERBOSE_LOGGING = false;",
             ]
         ),
         encoding="utf-8",
@@ -305,6 +319,55 @@ def test_mobile_release_readiness_fails_raw_media_runtime_config(tmp_path: Path)
     assert payload["local_checks_status"] == "fail"
     assert check["status"] == "fail"
     assert "store_raw_video=True" in check["evidence"]
+
+
+def test_mobile_release_readiness_fails_debug_runtime_config(tmp_path: Path) -> None:
+    mutated_app_json = tmp_path / "app.json"
+    app_config_path = tmp_path / "src" / "config" / "appConfig.ts"
+    app_config_path.parent.mkdir(parents=True)
+    app_payload = json.loads(APP_JSON.read_text(encoding="utf-8"))
+    mutated_app_json.write_text(json.dumps(app_payload), encoding="utf-8")
+    app_config_path.write_text(
+        "\n".join(
+            [
+                'export const APP_RUNTIME_MODE = "pilot";',
+                'export const APP_ENDPOINT_SET = "clinical_hub_v1";',
+                'export const APP_DEFAULT_CAPTURE_MODE = "water_impact";',
+                (
+                    'export const APP_PAIRED_MEASUREMENTS_ENDPOINT_PATH = '
+                    '"/api/v1/paired-measurements";'
+                ),
+                (
+                    'export const APP_CAPTURE_PACKAGES_ENDPOINT_PATH = '
+                    '"/api/v1/capture-packages";'
+                ),
+                "export const APP_STORE_RAW_VIDEO = false;",
+                "export const APP_STORE_RAW_AUDIO = false;",
+                "export const APP_ROI_ONLY = true;",
+                "export const APP_ALLOW_DEBUG_CONTROLS = true;",
+                "export const APP_ALLOW_RAW_RESPONSE_DETAILS = false;",
+                "export const APP_ENABLE_VERBOSE_LOGGING = false;",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = _run_readiness_with_paths(
+        tmp_path / "readiness.json",
+        env={"PATH": os.environ.get("PATH", "")},
+        app_json=mutated_app_json,
+        check=False,
+    )
+
+    check = next(
+        item
+        for item in payload["local_checks"]
+        if item["id"] == "runtime_config_debug_gates_disabled"
+    )
+    assert payload["status"] == "not_ready"
+    assert payload["local_checks_status"] == "fail"
+    assert check["status"] == "fail"
+    assert "allow_debug_controls=True" in check["evidence"]
 
 
 def test_mobile_release_readiness_passes_authenticated_preflight_env(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Extend mobile `appConfig` with an explicit `clinical_hub_v1` endpoint set, paired/capture endpoint paths, and disabled-by-default debug gates.
- Wire `clinicalHub.endpointPath` through the runtime config instead of hardcoded endpoint branches.
- Surface endpoint/debug settings in the mobile release manifest and readiness report.
- Add readiness gates for endpoint-set shape and disabled debug gates, plus negative coverage for debug-gate regressions.
- Update the mobile README/runbook/backlog to document endpoint/debug runtime-config coverage.

## Validation
- `.venv/bin/ruff check scripts/check_mobile_release_readiness.py scripts/build_mobile_release_manifest.py tests/test_mobile_release_readiness_script.py tests/test_mobile_release_manifest_script.py`
- `.venv/bin/pytest -q tests/test_mobile_release_readiness_script.py tests/test_mobile_release_manifest_script.py` (`12 passed`)
- `npm run typecheck`
- `npm run test:unit` (`64 passed`)
- `python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/readiness-endpoint-debug-config.json` (`ready_except_external_credentials`)
- `python3 scripts/build_mobile_release_manifest.py --app-json apps/field-mobile/app.json --output /tmp/manifest-endpoint-debug-config.json --profile production --model-id fusion-v0.1 --schema-version ios_capture_v1`
- Artifact assertions passed for `runtime_config.endpoint_set`, endpoint paths, disabled debug gates, readiness `runtime_config_endpoint_set`, and `runtime_config_debug_gates_disabled`.
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`106 passed`)
- `npm run validate:ci`

## Release readiness notes
- Local runtime config remains privacy-by-default and now also endpoint/debug-gated by readiness.
- External blockers remain explicitly separate: Expo token/EAS identity and live Clinical Hub secrets.