### PR TITLE
[codex] Add mobile runtime motion quality gate

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -137,6 +137,7 @@ export default function App() {
   const [captureStatus, setCaptureStatus] = useState("Idle");
   const [captureRoiValidRatio, setCaptureRoiValidRatio] = useState(0);
   const [captureLowConfidenceRatio, setCaptureLowConfidenceRatio] = useState(0);
+  const [captureHighMotionRatio, setCaptureHighMotionRatio] = useState(0);
   const [runtimeFlowSeries, setRuntimeFlowSeries] = useState<RuntimeFlowPoint[]>([]);
   const [cameraPreviewReady, setCameraPreviewReady] = useState(false);
   const [roiLocked, setRoiLocked] = useState(false);
@@ -413,6 +414,7 @@ export default function App() {
       setCaptureAvgMotionNorm(0);
       setCaptureRoiValidRatio(0);
       setCaptureLowConfidenceRatio(0);
+      setCaptureHighMotionRatio(0);
       setRuntimeFlowSeries([]);
       setRuntimeCaptureContractPayload(null);
       setMeasuredAt(startResult.startedAtIso);
@@ -447,6 +449,7 @@ export default function App() {
       setCaptureAvgMotionNorm(stopResult.averageMotionNorm);
       setCaptureRoiValidRatio(stopResult.quality.roiValidRatio);
       setCaptureLowConfidenceRatio(stopResult.quality.lowConfidenceRatio);
+      setCaptureHighMotionRatio(stopResult.quality.highMotionRatio);
       setRuntimeFlowSeries(stopResult.flowSeries);
       setDeviceModel(stopResult.deviceModel);
       if (!manualAppMetricsOverride) {
@@ -477,12 +480,13 @@ export default function App() {
             quality_status: stopResult.quality.qualityStatus,
             roi_valid_ratio: stopResult.quality.roiValidRatio,
             low_confidence_ratio: stopResult.quality.lowConfidenceRatio,
+            high_motion_ratio: stopResult.quality.highMotionRatio,
           },
         },
       });
       setRuntimeCaptureContractPayload(contractPayload as unknown as Record<string, unknown>);
       setCaptureStatus(
-        `Capture stopped. samples=${stopResult.sampleCount}, quality=${stopResult.quality.qualityStatus}, score=${stopResult.quality.qualityScore.toFixed(1)}`,
+        `Capture stopped. samples=${stopResult.sampleCount}, quality=${stopResult.quality.qualityStatus}, score=${stopResult.quality.qualityScore.toFixed(1)}, high_motion_ratio=${stopResult.quality.highMotionRatio.toFixed(3)}`,
       );
       if (stopResult.derived.eventStartTs != null && stopResult.derived.eventEndTs != null) {
         const runtimeNote =
@@ -639,6 +643,7 @@ export default function App() {
         setCaptureAvgMotionNorm(0);
         setCaptureRoiValidRatio(0);
         setCaptureLowConfidenceRatio(0);
+        setCaptureHighMotionRatio(0);
         setRuntimeFlowSeries([]);
         setCaptureStatus("Idle");
         setSessionId(createSessionId());
@@ -690,6 +695,7 @@ export default function App() {
       setCaptureAvgMotionNorm(0);
       setCaptureRoiValidRatio(0);
       setCaptureLowConfidenceRatio(0);
+      setCaptureHighMotionRatio(0);
       setRuntimeFlowSeries([]);
       setCaptureStatus("Idle");
       setSessionId(createSessionId());
@@ -816,6 +822,7 @@ export default function App() {
           cameraPreviewReady={cameraPreviewReady}
           cameraPreviewRef={cameraPreviewRef}
           captureAvgMotionNorm={captureAvgMotionNorm}
+          captureHighMotionRatio={captureHighMotionRatio}
           captureLowConfidenceRatio={captureLowConfidenceRatio}
           captureRoiValidRatio={captureRoiValidRatio}
           captureRunning={captureRunning}

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -86,6 +86,7 @@ Notes:
 Notes:
 - Runtime capture currently logs sampled audio metering + motion, and derives proxy level traces.
 - Camera preview + ROI lock state are included in runtime quality gating.
+- Runtime quality scoring includes `roi_valid_ratio`, `low_confidence_ratio`, and `high_motion_ratio`.
 - Raw media is not stored by default (privacy-by-default behavior).
 
 ## API URL
@@ -132,7 +133,7 @@ secret blockers. The artifact has separate machine-readable gates:
 
 - `local_checks_status`: local app metadata, runtime release metadata, EAS profile shape,
   runtime config/defaults such as Clinical Hub v1 endpoint set, disabled debug gates,
-  privacy-by-default switches, and non-localhost API URL defaults,
+  privacy-by-default switches, runtime motion quality gates, and non-localhost API URL defaults,
   store privacy declarations,
   launch/icon assets, dependency lock alignment, and unit-test evidence that can be verified
   without external credentials.

--- a/apps/field-mobile/src/capture/buildCaptureContract.ts
+++ b/apps/field-mobile/src/capture/buildCaptureContract.ts
@@ -28,6 +28,7 @@ export type CaptureContractAnalysis = {
     quality_status?: CaptureContractQualityStatus;
     roi_valid_ratio?: number;
     low_confidence_ratio?: number;
+    high_motion_ratio?: number;
   };
 };
 
@@ -198,6 +199,11 @@ function sanitizeAnalysis(
     if (Number.isFinite(runtimeQualityRaw.low_confidence_ratio)) {
       runtimeQuality.low_confidence_ratio = round4(
         clamp(runtimeQualityRaw.low_confidence_ratio as number, 0, 1),
+      );
+    }
+    if (Number.isFinite(runtimeQualityRaw.high_motion_ratio)) {
+      runtimeQuality.high_motion_ratio = round4(
+        clamp(runtimeQualityRaw.high_motion_ratio as number, 0, 1),
       );
     }
   }

--- a/apps/field-mobile/src/capture/runtimeCaptureSession.ts
+++ b/apps/field-mobile/src/capture/runtimeCaptureSession.ts
@@ -15,6 +15,7 @@ import {
   calculateAverageMotionNorm,
   clamp,
   deriveRuntimeCaptureMetrics,
+  HIGH_MOTION_SAMPLE_THRESHOLD,
   round4,
   scoreRuntimeCaptureQuality,
   type RuntimeCaptureDerivedMetrics,
@@ -332,7 +333,7 @@ export class RuntimeCaptureSession {
       this.latestPreviewReady &&
       this.latestRoiLocked &&
       this.latestRoiValidByFrame &&
-      this.latestMotionNorm < 0.35;
+      this.latestMotionNorm < HIGH_MOTION_SAMPLE_THRESHOLD;
 
     this.samples.push({
       t_s: round4(elapsedS),

--- a/apps/field-mobile/src/capture/runtimeMetrics.ts
+++ b/apps/field-mobile/src/capture/runtimeMetrics.ts
@@ -21,12 +21,17 @@ export type RuntimeCaptureQuality = {
   qualityStatus: "valid" | "repeat" | "reject";
   roiValidRatio: number;
   lowConfidenceRatio: number;
+  highMotionRatio: number;
 };
 
 export type RuntimeFlowPoint = {
   t_s: number;
   flow_ml_s: number;
 };
+
+export const HIGH_MOTION_SAMPLE_THRESHOLD = 0.35;
+const HIGH_MOTION_REPEAT_RATIO = 0.2;
+const HIGH_MOTION_REJECT_RATIO = 0.45;
 
 export function clamp(value: number, minValue: number, maxValue: number): number {
   return Math.max(minValue, Math.min(maxValue, value));
@@ -162,20 +167,30 @@ export function scoreRuntimeCaptureQuality(input: {
   const sampleCount = Math.max(1, input.samples.length);
   const roiValidCount = input.samples.filter((sample) => sample.roi_valid).length;
   const lowConfidenceCount = input.samples.filter((sample) => sample.depth_confidence < 0.6).length;
+  const highMotionCount = input.samples.filter(
+    (sample) => sample.motion_norm >= HIGH_MOTION_SAMPLE_THRESHOLD,
+  ).length;
 
   const roiValidRatio = roiValidCount / sampleCount;
   const lowConfidenceRatio = lowConfidenceCount / sampleCount;
+  const highMotionRatio = highMotionCount / sampleCount;
 
   let score = 100;
   score -= clamp(input.averageMotionNorm * 80, 0, 60);
   score -= clamp((1 - roiValidRatio) * 70, 0, 50);
   score -= clamp(lowConfidenceRatio * 40, 0, 25);
+  score -= clamp(highMotionRatio * 50, 0, 30);
   score = clamp(score, 0, 100);
 
   let qualityStatus: RuntimeCaptureQuality["qualityStatus"] = "valid";
-  if (score < 50 || roiValidRatio < 0.55) {
+  if (score < 50 || roiValidRatio < 0.55 || highMotionRatio > HIGH_MOTION_REJECT_RATIO) {
     qualityStatus = "reject";
-  } else if (score < 75 || roiValidRatio < 0.8 || lowConfidenceRatio > 0.35) {
+  } else if (
+    score < 75 ||
+    roiValidRatio < 0.8 ||
+    lowConfidenceRatio > 0.35 ||
+    highMotionRatio > HIGH_MOTION_REPEAT_RATIO
+  ) {
     qualityStatus = "repeat";
   }
 
@@ -184,5 +199,6 @@ export function scoreRuntimeCaptureQuality(input: {
     qualityStatus,
     roiValidRatio: round4(roiValidRatio),
     lowConfidenceRatio: round4(lowConfidenceRatio),
+    highMotionRatio: round4(highMotionRatio),
   };
 }

--- a/apps/field-mobile/src/components/RuntimeCaptureSection.tsx
+++ b/apps/field-mobile/src/components/RuntimeCaptureSection.tsx
@@ -11,6 +11,7 @@ type RuntimeCaptureSectionProps = {
   cameraPreviewReady: boolean;
   cameraPreviewRef: React.RefObject<CameraView | null>;
   captureAvgMotionNorm: number;
+  captureHighMotionRatio: number;
   captureLowConfidenceRatio: number;
   captureRoiValidRatio: number;
   captureRunning: boolean;
@@ -38,6 +39,7 @@ export function RuntimeCaptureSection({
   cameraPreviewReady,
   cameraPreviewRef,
   captureAvgMotionNorm,
+  captureHighMotionRatio,
   captureLowConfidenceRatio,
   captureRoiValidRatio,
   captureRunning,
@@ -72,7 +74,8 @@ export function RuntimeCaptureSection({
       </Text>
       <Text style={styles.captureStatusText}>
         quality flags: roi_valid_ratio={captureRoiValidRatio.toFixed(3)}, low_confidence_ratio=
-        {captureLowConfidenceRatio.toFixed(3)}
+        {captureLowConfidenceRatio.toFixed(3)}, high_motion_ratio=
+        {captureHighMotionRatio.toFixed(3)}
       </Text>
       <Text style={styles.captureStatusText}>
         Contract payload:{" "}

--- a/apps/field-mobile/tests/captureContract.test.js
+++ b/apps/field-mobile/tests/captureContract.test.js
@@ -196,6 +196,7 @@ test("buildCaptureContractPayloadFromSamples sanitizes runtime analysis", () => 
         quality_status: "repeat",
         roi_valid_ratio: 2,
         low_confidence_ratio: -1,
+        high_motion_ratio: 1.5,
       },
     },
   });
@@ -215,5 +216,6 @@ test("buildCaptureContractPayloadFromSamples sanitizes runtime analysis", () => 
     quality_status: "repeat",
     roi_valid_ratio: 1,
     low_confidence_ratio: 0,
+    high_motion_ratio: 1,
   });
 });

--- a/apps/field-mobile/tests/runtimeMetrics.test.js
+++ b/apps/field-mobile/tests/runtimeMetrics.test.js
@@ -90,13 +90,12 @@ test("deriveRuntimeCaptureMetrics falls back to flow-only bounds when ROI is una
 });
 
 test("scoreRuntimeCaptureQuality classifies valid, repeat, and reject captures", () => {
-  assert.equal(
-    runtime.scoreRuntimeCaptureQuality({
-      averageMotionNorm: 0.1,
-      samples: [sample(), sample(), sample(), sample()],
-    }).qualityStatus,
-    "valid",
-  );
+  const valid = runtime.scoreRuntimeCaptureQuality({
+    averageMotionNorm: 0.1,
+    samples: [sample(), sample(), sample(), sample()],
+  });
+  assert.equal(valid.qualityStatus, "valid");
+  assert.equal(valid.highMotionRatio, 0);
 
   const repeat = runtime.scoreRuntimeCaptureQuality({
     averageMotionNorm: 0.05,
@@ -123,6 +122,34 @@ test("scoreRuntimeCaptureQuality classifies valid, repeat, and reject captures",
   assert.equal(reject.roiValidRatio, 0.25);
 });
 
+test("scoreRuntimeCaptureQuality gates high-motion capture artifacts", () => {
+  const repeat = runtime.scoreRuntimeCaptureQuality({
+    averageMotionNorm: 0.17,
+    samples: [
+      sample({ motion_norm: 0.05 }),
+      sample({ motion_norm: 0.36 }),
+      sample({ motion_norm: 0.06 }),
+      sample({ motion_norm: 0.38 }),
+      sample({ motion_norm: 0.08 }),
+    ],
+  });
+  assert.equal(repeat.qualityStatus, "repeat");
+  assert.equal(repeat.highMotionRatio, 0.4);
+
+  const reject = runtime.scoreRuntimeCaptureQuality({
+    averageMotionNorm: 0.24,
+    samples: [
+      sample({ motion_norm: 0.36 }),
+      sample({ motion_norm: 0.37 }),
+      sample({ motion_norm: 0.38 }),
+      sample({ motion_norm: 0.05 }),
+      sample({ motion_norm: 0.04 }),
+    ],
+  });
+  assert.equal(reject.qualityStatus, "reject");
+  assert.equal(reject.highMotionRatio, 0.6);
+});
+
 test("scoreRuntimeCaptureQuality repeats high low-confidence captures", () => {
   const quality = runtime.scoreRuntimeCaptureQuality({
     averageMotionNorm: 0.05,
@@ -137,6 +164,7 @@ test("scoreRuntimeCaptureQuality repeats high low-confidence captures", () => {
 
   assert.equal(quality.qualityStatus, "repeat");
   assert.equal(quality.lowConfidenceRatio, 0.4);
+  assert.equal(quality.highMotionRatio, 0);
 });
 
 test("calculateAverageMotionNorm handles empty samples", () => {

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -10,6 +10,7 @@ Implemented now:
 - Clinical Hub API contract for `paired-measurements` and `capture-packages`.
 - Pilot automation and release gates (`v4.2`) in repository.
 - App-level runtime config for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, and disabled debug gates.
+- Runtime capture quality gates for ROI validity, low-confidence depth, and high-motion IMU artifacts.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).
@@ -19,13 +20,13 @@ Not yet implemented:
 ## 2) Gap analysis (what blocks real install-and-test)
 
 ### G1. Sensor capture gap
-- Missing camera/audio capture session manager.
-- Missing ROI-only processing pipeline and artifact flags.
-- Missing IMU motion gating in app runtime.
+- Native sensor capture exists as a pilot runtime path, but still needs physical-device calibration against target iPhone/Android models.
+- ROI-only processing pipeline is proxy-based and still needs native-grade ROI extraction on device.
+- IMU motion gating is implemented in runtime quality scoring, but threshold calibration needs real device smoke evidence.
 
 ### G2. Data contract gap
-- Capture contract currently scaffolded; no live sensor samples yet.
-- `capture-packages` not queued for offline retry.
+- Capture contract can use live runtime samples, with scaffold fallback still available.
+- `capture-packages` are queued for offline retry, but device-level E2E replay evidence still needs to be archived.
 - No direct upload of feature bundles/media manifests.
 
 ### G3. Security/privacy gap
@@ -59,7 +60,7 @@ DoD:
 1. Implement capture start/stop session service.
 2. Record audio envelope + ROI motion/texture + IMU jitter over unified timeline.
 3. Build live `ios_capture_v1` payload from runtime samples.
-4. Add quality pre-checks before submit (`roi_valid_ratio`, motion threshold, depth confidence ratio).
+4. Add quality pre-checks before submit (`roi_valid_ratio`, motion threshold, depth confidence ratio). Status: implemented in runtime payload scoring; needs physical-device threshold calibration.
 
 DoD:
 - Single-button record flow works on physical iPhone and Android.

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -48,6 +48,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - icon/adaptive-icon paths, `expo-splash-screen` image path, SHA-256 fingerprints, byte sizes, PNG dimensions, and splash background/resize/width config,
 - runtime release metadata from `apps/field-mobile/src/config/releaseMetadata.ts` for app version, model ID, and capture schema version,
 - runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, and disabled debug gates,
+- runtime quality evidence for ROI validity, low-confidence depth ratio, and high-motion IMU artifact ratio in `capture_payload.analysis.runtime_quality`,
 - runtime defaults such as `DEFAULT_API_BASE_URL` to prove release builds do not point field devices at localhost,
 - git SHA/ref/run-id,
 - model_id and capture schema version.
@@ -55,7 +56,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/debug gates, package scripts, lockfile, pinned tooling, API response redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/debug gates, runtime motion quality gates, package scripts, lockfile, pinned tooling, API response redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -706,9 +706,11 @@ def build_readiness_report(
     clinical_hub_api_tests_path = mobile_root / "tests" / "clinicalHub.test.js"
     connection_check_tests_path = mobile_root / "tests" / "connectionCheck.test.js"
     capture_package_payload_tests_path = mobile_root / "tests" / "capturePackagePayload.test.js"
+    capture_contract_source_path = mobile_root / "src" / "capture" / "buildCaptureContract.ts"
     capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
     paired_payload_tests_path = mobile_root / "tests" / "pairedPayload.test.js"
     roi_signal_tests_path = mobile_root / "tests" / "roiSignalEstimator.test.js"
+    runtime_metrics_source_path = mobile_root / "src" / "capture" / "runtimeMetrics.ts"
     runtime_metrics_tests_path = mobile_root / "tests" / "runtimeMetrics.test.js"
     pending_sync_queue_tests_path = mobile_root / "tests" / "pendingSyncQueue.test.js"
     pending_submission_storage_tests_path = (
@@ -730,6 +732,10 @@ def build_readiness_report(
         pending_submission_storage_tests_path
     )
     submit_outcome_tests_source = _read_file_text(submit_outcome_tests_path)
+    capture_contract_source = _read_file_text(capture_contract_source_path)
+    capture_tests_source = _read_file_text(capture_tests_path)
+    runtime_metrics_source = _read_file_text(runtime_metrics_source_path)
+    runtime_metrics_tests_source = _read_file_text(runtime_metrics_tests_path)
     _check(
         checks,
         "unit_test_script",
@@ -807,6 +813,27 @@ def build_readiness_report(
         "runtime_metrics_unit_tests_present",
         runtime_metrics_tests_path.is_file(),
         f"path={runtime_metrics_tests_path}",
+    )
+    _check(
+        checks,
+        "runtime_motion_quality_gate_sources",
+        "HIGH_MOTION_SAMPLE_THRESHOLD" in runtime_metrics_source
+        and "highMotionRatio" in runtime_metrics_source
+        and "high_motion_ratio" in capture_contract_source
+        and "captureHighMotionRatio" in app_ts_source,
+        (
+            f"runtime_metrics={runtime_metrics_source_path}, "
+            f"capture_contract={capture_contract_source_path}, "
+            f"app={app_ts_path}"
+        ),
+    )
+    _check(
+        checks,
+        "runtime_motion_quality_gate_unit_tests_present",
+        "gates high-motion capture artifacts" in runtime_metrics_tests_source
+        and "highMotionRatio" in runtime_metrics_tests_source
+        and "high_motion_ratio" in capture_tests_source,
+        f"paths={[str(runtime_metrics_tests_path), str(capture_tests_path)]}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -116,6 +116,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "pending_sync_queue_unit_tests_present",
         "roi_signal_unit_tests_present",
         "runtime_metrics_unit_tests_present",
+        "runtime_motion_quality_gate_sources",
+        "runtime_motion_quality_gate_unit_tests_present",
         "release_metadata_capture_schema_version",
         "release_metadata_model_id",
         "release_metadata_module",


### PR DESCRIPTION
## Summary
- Add `highMotionRatio` to runtime capture quality scoring and force `repeat`/`reject` when IMU artifact samples exceed release-safe thresholds.
- Reuse the exported high-motion threshold in runtime ROI validity gating.
- Persist `high_motion_ratio` in `capture_payload.analysis.runtime_quality` and show it in the runtime capture UI/status text.
- Add deterministic unit coverage for high-motion repeat/reject behavior and contract sanitization.
- Add readiness checks proving runtime motion quality gate source wiring and tests are present.
- Refresh mobile backlog/runbook/README wording to reflect current runtime capture and remaining physical-device calibration gaps.

## Validation
- `npm run typecheck`
- `npm run test:unit` (`65 passed`)
- `.venv/bin/ruff check scripts/check_mobile_release_readiness.py tests/test_mobile_release_readiness_script.py`
- `.venv/bin/pytest -q tests/test_mobile_release_readiness_script.py` (`11 passed`)
- `python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/readiness-motion-quality-gate.json` (`ready_except_external_credentials`)
- Readiness assertions passed for `runtime_motion_quality_gate_sources` and `runtime_motion_quality_gate_unit_tests_present`.
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`106 passed`)
- `npm run validate:ci`

## Release readiness notes
- Local checks pass with the new motion quality gates.
- External blockers remain explicitly separate: Expo token/EAS identity and live Clinical Hub secrets.