### PR TITLE
[codex] Add mobile feature media manifest

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -88,6 +88,8 @@ Notes:
 - Camera preview + ROI lock state are included in runtime quality gating.
 - Runtime quality scoring includes `roi_valid_ratio`, `low_confidence_ratio`, and `high_motion_ratio`.
 - Raw media is not stored by default (privacy-by-default behavior).
+- Capture contract payloads include a derivatives-only `feature_manifest` with sample count,
+  derived feature keys, and raw media storage/upload flags pinned to `false`.
 
 ## API URL
 
@@ -133,7 +135,8 @@ secret blockers. The artifact has separate machine-readable gates:
 
 - `local_checks_status`: local app metadata, runtime release metadata, EAS profile shape,
   runtime config/defaults such as Clinical Hub v1 endpoint set, disabled debug gates,
-  privacy-by-default switches, runtime motion quality gates, and non-localhost API URL defaults,
+  privacy-by-default switches, runtime motion quality gates, derivatives-only feature/media
+  manifest gates, and non-localhost API URL defaults,
   store privacy declarations,
   launch/icon assets, dependency lock alignment, and unit-test evidence that can be verified
   without external credentials.

--- a/apps/field-mobile/src/capture/buildCaptureContract.ts
+++ b/apps/field-mobile/src/capture/buildCaptureContract.ts
@@ -32,6 +32,24 @@ export type CaptureContractAnalysis = {
   };
 };
 
+export type CaptureContractFeatureManifest = {
+  version: "mobile_feature_manifest_v0.1";
+  source: string;
+  derivatives_only: true;
+  sample_count: number;
+  feature_keys: string[];
+  raw_media: {
+    store_raw_video: false;
+    store_raw_audio: false;
+    upload_raw_video: false;
+    upload_raw_audio: false;
+  };
+  privacy: {
+    roi_only: true;
+    media_scope: "roi_derivatives_only";
+  };
+};
+
 export type CaptureContractPayload = {
   schema_version: typeof APP_CAPTURE_SCHEMA_VERSION;
   session: {
@@ -57,6 +75,7 @@ export type CaptureContractPayload = {
       roi_only: true;
     };
   };
+  feature_manifest: CaptureContractFeatureManifest;
   samples: CaptureContractSample[];
   analysis?: CaptureContractAnalysis;
 };
@@ -91,6 +110,16 @@ export type BuildCaptureContractFromSamplesInput = {
 
 const DEFAULT_ML_PER_MM = 8.0;
 const DEFAULT_SAMPLE_STEP_S = 0.5;
+const FEATURE_MANIFEST_VERSION = "mobile_feature_manifest_v0.1";
+const BASE_FEATURE_KEYS = Object.freeze([
+  "t_s",
+  "depth_level_mm",
+  "rgb_level_mm",
+  "depth_confidence",
+  "audio_rms_dbfs",
+  "motion_norm",
+  "roi_valid",
+]);
 
 function clamp(value: number, minValue: number, maxValue: number): number {
   return Math.max(minValue, Math.min(maxValue, value));
@@ -262,11 +291,46 @@ function buildPrivacyNode(): CaptureContractPayload["session"]["privacy"] {
   };
 }
 
+function buildFeatureManifest(
+  source: string,
+  samples: CaptureContractSample[],
+  analysis: CaptureContractAnalysis | undefined,
+): CaptureContractFeatureManifest {
+  const featureKeys = new Set<string>(BASE_FEATURE_KEYS);
+  if (analysis?.runtime_flow_series && analysis.runtime_flow_series.length > 0) {
+    featureKeys.add("runtime_flow_series.flow_ml_s");
+  }
+  if (analysis?.runtime_quality) {
+    Object.keys(analysis.runtime_quality).forEach((key) => {
+      featureKeys.add(`runtime_quality.${key}`);
+    });
+  }
+
+  return {
+    version: FEATURE_MANIFEST_VERSION,
+    source: source.trim() || "mobile_scaffold",
+    derivatives_only: true,
+    sample_count: samples.length,
+    feature_keys: Array.from(featureKeys).sort(),
+    raw_media: {
+      store_raw_video: APP_PRIVACY_POLICY.storeRawVideo,
+      store_raw_audio: APP_PRIVACY_POLICY.storeRawAudio,
+      upload_raw_video: false,
+      upload_raw_audio: false,
+    },
+    privacy: {
+      roi_only: APP_PRIVACY_POLICY.roiOnly,
+      media_scope: "roi_derivatives_only",
+    },
+  };
+}
+
 export function buildCaptureContractPayload(
   input: BuildCaptureContractInput,
 ): CaptureContractPayload {
   const model = input.deviceModel?.trim() || "unknown-device";
   const appVersion = input.appVersion?.trim() || APP_RELEASE_VERSION;
+  const samples = createSamples(input);
 
   return {
     schema_version: APP_CAPTURE_SCHEMA_VERSION,
@@ -289,7 +353,8 @@ export function buildCaptureContractPayload(
       },
       privacy: buildPrivacyNode(),
     },
-    samples: createSamples(input),
+    feature_manifest: buildFeatureManifest("mobile_scaffold", samples, undefined),
+    samples,
   };
 }
 
@@ -353,6 +418,11 @@ export function buildCaptureContractPayloadFromSamples(
       },
       privacy: buildPrivacyNode(),
     },
+    feature_manifest: buildFeatureManifest(
+      source || "runtime-audio-imu-camera-proxy",
+      safeSamples,
+      analysis,
+    ),
     samples: safeSamples,
   };
   if (analysis) {

--- a/apps/field-mobile/tests/captureContract.test.js
+++ b/apps/field-mobile/tests/captureContract.test.js
@@ -5,6 +5,26 @@ const test = require("node:test");
 const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
 const capture = require(path.join(buildDir, "capture/buildCaptureContract.js"));
 
+function assertDerivativesOnlyFeatureManifest(payload, source) {
+  assert.equal(payload.feature_manifest.version, "mobile_feature_manifest_v0.1");
+  assert.equal(payload.feature_manifest.source, source);
+  assert.equal(payload.feature_manifest.derivatives_only, true);
+  assert.equal(payload.feature_manifest.sample_count, payload.samples.length);
+  assert.deepEqual(payload.feature_manifest.raw_media, {
+    store_raw_video: false,
+    store_raw_audio: false,
+    upload_raw_video: false,
+    upload_raw_audio: false,
+  });
+  assert.deepEqual(payload.feature_manifest.privacy, {
+    roi_only: true,
+    media_scope: "roi_derivatives_only",
+  });
+  assert.equal(payload.feature_manifest.feature_keys.includes("audio_rms_dbfs"), true);
+  assert.equal(payload.feature_manifest.feature_keys.includes("motion_norm"), true);
+  assert.equal(payload.feature_manifest.feature_keys.includes("roi_valid"), true);
+}
+
 test("buildCaptureContractPayload creates privacy-preserving scaffold payloads", () => {
   const payload = capture.buildCaptureContractPayload({
     sessionId: "SESSION-001",
@@ -34,6 +54,7 @@ test("buildCaptureContractPayload creates privacy-preserving scaffold payloads",
   assert.ok(payload.samples.length >= 8);
   assert.equal(payload.samples.every((sample) => sample.roi_valid === true), true);
   assert.equal(payload.samples.every((sample) => sample.t_s >= 0), true);
+  assertDerivativesOnlyFeatureManifest(payload, "mobile_scaffold");
 });
 
 test("buildCaptureContractPayloadFromSamples creates fallback samples for empty runtime input", () => {
@@ -61,6 +82,7 @@ test("buildCaptureContractPayloadFromSamples creates fallback samples for empty 
     [0, 0.5],
   );
   assert.equal(payload.analysis, undefined);
+  assertDerivativesOnlyFeatureManifest(payload, "runtime-audio-imu");
 });
 
 test("buildCaptureContractPayloadFromSamples duplicates one-sample runtime captures safely", () => {
@@ -218,4 +240,13 @@ test("buildCaptureContractPayloadFromSamples sanitizes runtime analysis", () => 
     low_confidence_ratio: 0,
     high_motion_ratio: 1,
   });
+  assertDerivativesOnlyFeatureManifest(payload, "runtime-audio-imu-camera-proxy");
+  assert.equal(
+    payload.feature_manifest.feature_keys.includes("runtime_flow_series.flow_ml_s"),
+    true,
+  );
+  assert.equal(
+    payload.feature_manifest.feature_keys.includes("runtime_quality.high_motion_ratio"),
+    true,
+  );
 });

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -11,6 +11,7 @@ Implemented now:
 - Pilot automation and release gates (`v4.2`) in repository.
 - App-level runtime config for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, and disabled debug gates.
 - Runtime capture quality gates for ROI validity, low-confidence depth, and high-motion IMU artifacts.
+- Derivatives-only feature/media manifest in mobile `ios_capture_v1` payloads, with backend validation that raw media storage/upload flags remain disabled.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).
@@ -27,7 +28,7 @@ Not yet implemented:
 ### G2. Data contract gap
 - Capture contract can use live runtime samples, with scaffold fallback still available.
 - `capture-packages` are queued for offline retry, but device-level E2E replay evidence still needs to be archived.
-- No direct upload of feature bundles/media manifests.
+- Mobile payloads include a derivatives-only feature/media manifest; native-grade feature bundles and device-level media-manifest replay evidence still need physical-device archival.
 
 ### G3. Security/privacy gap
 - Secure storage introduced for API key, but no media encryption path yet.
@@ -61,6 +62,7 @@ DoD:
 2. Record audio envelope + ROI motion/texture + IMU jitter over unified timeline.
 3. Build live `ios_capture_v1` payload from runtime samples.
 4. Add quality pre-checks before submit (`roi_valid_ratio`, motion threshold, depth confidence ratio). Status: implemented in runtime payload scoring; needs physical-device threshold calibration.
+5. Add feature/media manifest for derived mobile capture features. Status: implemented as derivatives-only manifest with raw media disabled in payload and backend validator.
 
 DoD:
 - Single-button record flow works on physical iPhone and Android.

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -49,6 +49,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - runtime release metadata from `apps/field-mobile/src/config/releaseMetadata.ts` for app version, model ID, and capture schema version,
 - runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, and disabled debug gates,
 - runtime quality evidence for ROI validity, low-confidence depth ratio, and high-motion IMU artifact ratio in `capture_payload.analysis.runtime_quality`,
+- derivatives-only feature/media manifest evidence in `capture_payload.feature_manifest`, including `sample_count`, `feature_keys`, `raw_media.*=false`, and `privacy.media_scope=roi_derivatives_only`,
 - runtime defaults such as `DEFAULT_API_BASE_URL` to prove release builds do not point field devices at localhost,
 - git SHA/ref/run-id,
 - model_id and capture schema version.
@@ -56,7 +57,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/debug gates, runtime motion quality gates, package scripts, lockfile, pinned tooling, API response redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/debug gates, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
@@ -123,4 +124,5 @@ Android:
 3. Build links (iOS + Android).
 4. Smoke test log with device model and OS version.
 5. Clinical Hub sample export (paired + capture package rows).
+   - For `capture-packages`, archive `capture_payload.feature_manifest` and confirm `derivatives_only=true`, `raw_media.store_raw_video=false`, `raw_media.store_raw_audio=false`, `raw_media.upload_raw_video=false`, and `raw_media.upload_raw_audio=false`.
 6. Go/No-Go note for pilot usage.

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -708,6 +708,9 @@ def build_readiness_report(
     capture_package_payload_tests_path = mobile_root / "tests" / "capturePackagePayload.test.js"
     capture_contract_source_path = mobile_root / "src" / "capture" / "buildCaptureContract.ts"
     capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
+    repo_root = mobile_root.parent.parent
+    backend_capture_contract_path = repo_root / "src" / "uroflow_mobile" / "capture_contract.py"
+    backend_capture_tests_path = repo_root / "tests" / "test_capture_contract.py"
     paired_payload_tests_path = mobile_root / "tests" / "pairedPayload.test.js"
     roi_signal_tests_path = mobile_root / "tests" / "roiSignalEstimator.test.js"
     runtime_metrics_source_path = mobile_root / "src" / "capture" / "runtimeMetrics.ts"
@@ -734,6 +737,8 @@ def build_readiness_report(
     submit_outcome_tests_source = _read_file_text(submit_outcome_tests_path)
     capture_contract_source = _read_file_text(capture_contract_source_path)
     capture_tests_source = _read_file_text(capture_tests_path)
+    backend_capture_contract_source = _read_file_text(backend_capture_contract_path)
+    backend_capture_tests_source = _read_file_text(backend_capture_tests_path)
     runtime_metrics_source = _read_file_text(runtime_metrics_source_path)
     runtime_metrics_tests_source = _read_file_text(runtime_metrics_tests_path)
     _check(
@@ -834,6 +839,33 @@ def build_readiness_report(
         and "highMotionRatio" in runtime_metrics_tests_source
         and "high_motion_ratio" in capture_tests_source,
         f"paths={[str(runtime_metrics_tests_path), str(capture_tests_path)]}",
+    )
+    _check(
+        checks,
+        "mobile_feature_media_manifest_sources",
+        "feature_manifest" in capture_contract_source
+        and "mobile_feature_manifest_v0.1" in capture_contract_source
+        and "derivatives_only" in capture_contract_source
+        and "raw_media" in capture_contract_source
+        and "upload_raw_audio" in capture_contract_source
+        and "feature_manifest" in backend_capture_contract_source
+        and "FEATURE_MANIFEST_VERSION" in backend_capture_contract_source
+        and "derivatives_only must be true" in backend_capture_contract_source
+        and "upload_raw_audio" in backend_capture_contract_source
+        and "raw_media.{flag} must be false" in backend_capture_contract_source,
+        (
+            f"mobile_capture_contract={capture_contract_source_path}, "
+            f"backend_capture_contract={backend_capture_contract_path}"
+        ),
+    )
+    _check(
+        checks,
+        "mobile_feature_media_manifest_unit_tests_present",
+        "assertDerivativesOnlyFeatureManifest" in capture_tests_source
+        and "runtime_quality.high_motion_ratio" in capture_tests_source
+        and "allows_derivatives_only_feature_manifest" in backend_capture_tests_source
+        and "rejects_feature_manifest_raw_media_upload" in backend_capture_tests_source,
+        f"paths={[str(capture_tests_path), str(backend_capture_tests_path)]}",
     )
     _check(
         checks,

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -708,7 +708,7 @@ def build_readiness_report(
     capture_package_payload_tests_path = mobile_root / "tests" / "capturePackagePayload.test.js"
     capture_contract_source_path = mobile_root / "src" / "capture" / "buildCaptureContract.ts"
     capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
-    repo_root = mobile_root.parent.parent
+    repo_root = package_json.resolve().parent.parent.parent
     backend_capture_contract_path = repo_root / "src" / "uroflow_mobile" / "capture_contract.py"
     backend_capture_tests_path = repo_root / "tests" / "test_capture_contract.py"
     paired_payload_tests_path = mobile_root / "tests" / "pairedPayload.test.js"

--- a/src/uroflow_mobile/capture_contract.py
+++ b/src/uroflow_mobile/capture_contract.py
@@ -7,6 +7,7 @@ from typing import Any
 
 SUPPORTED_CAPTURE_MODES = {"water_impact", "jet_in_air", "porcelain_wall"}
 SCHEMA_VERSION = "ios_capture_v1"
+FEATURE_MANIFEST_VERSION = "mobile_feature_manifest_v0.1"
 
 
 @dataclass(frozen=True)
@@ -41,6 +42,71 @@ def _parse_started_at(value: Any) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _validate_feature_manifest(
+    manifest: Any,
+    *,
+    sample_count: int,
+    errors: list[str],
+) -> None:
+    if manifest is None:
+        return
+    if not isinstance(manifest, dict):
+        errors.append("feature_manifest must be an object when provided")
+        return
+
+    if manifest.get("version") != FEATURE_MANIFEST_VERSION:
+        errors.append(f"feature_manifest.version must be '{FEATURE_MANIFEST_VERSION}'")
+
+    source = manifest.get("source")
+    if not isinstance(source, str) or not source.strip():
+        errors.append("feature_manifest.source must be a non-empty string")
+
+    if manifest.get("derivatives_only") is not True:
+        errors.append("feature_manifest.derivatives_only must be true")
+
+    manifest_sample_count = manifest.get("sample_count")
+    if not isinstance(manifest_sample_count, int) or isinstance(
+        manifest_sample_count, bool
+    ):
+        errors.append("feature_manifest.sample_count must be an integer")
+    elif manifest_sample_count != sample_count:
+        errors.append("feature_manifest.sample_count must match samples length")
+
+    feature_keys = manifest.get("feature_keys")
+    if not isinstance(feature_keys, list) or not feature_keys:
+        errors.append("feature_manifest.feature_keys must be a non-empty array")
+    else:
+        for index, feature_key in enumerate(feature_keys):
+            if not isinstance(feature_key, str) or not feature_key.strip():
+                errors.append(
+                    f"feature_manifest.feature_keys[{index}] must be a non-empty string"
+                )
+
+    raw_media = manifest.get("raw_media")
+    if not isinstance(raw_media, dict):
+        errors.append("feature_manifest.raw_media must be an object")
+    else:
+        for flag in (
+            "store_raw_video",
+            "store_raw_audio",
+            "upload_raw_video",
+            "upload_raw_audio",
+        ):
+            if raw_media.get(flag) is not False:
+                errors.append(f"feature_manifest.raw_media.{flag} must be false")
+
+    privacy = manifest.get("privacy")
+    if not isinstance(privacy, dict):
+        errors.append("feature_manifest.privacy must be an object")
+    else:
+        if privacy.get("roi_only") is not True:
+            errors.append("feature_manifest.privacy.roi_only must be true")
+        if privacy.get("media_scope") != "roi_derivatives_only":
+            errors.append(
+                "feature_manifest.privacy.media_scope must be 'roi_derivatives_only'"
+            )
 
 
 def validate_capture_payload(payload: dict[str, Any]) -> CaptureValidationReport:
@@ -158,6 +224,12 @@ def validate_capture_payload(payload: dict[str, Any]) -> CaptureValidationReport
         warnings.append("ROI valid ratio < 0.85; likely repeat measurement")
     if sample_count and low_conf_ratio > 0.25:
         warnings.append("Low depth confidence ratio > 0.25; fallback reliance expected")
+
+    _validate_feature_manifest(
+        payload.get("feature_manifest"),
+        sample_count=sample_count,
+        errors=errors,
+    )
 
     return CaptureValidationReport(
         valid=not errors,

--- a/tests/test_capture_contract.py
+++ b/tests/test_capture_contract.py
@@ -41,6 +41,35 @@ def _valid_payload() -> dict[str, object]:
     }
 
 
+def _valid_feature_manifest(sample_count: int = 3) -> dict[str, object]:
+    return {
+        "version": "mobile_feature_manifest_v0.1",
+        "source": "runtime-audio-imu",
+        "derivatives_only": True,
+        "sample_count": sample_count,
+        "feature_keys": [
+            "audio_rms_dbfs",
+            "depth_confidence",
+            "depth_level_mm",
+            "motion_norm",
+            "rgb_level_mm",
+            "roi_valid",
+            "runtime_quality.high_motion_ratio",
+            "t_s",
+        ],
+        "raw_media": {
+            "store_raw_video": False,
+            "store_raw_audio": False,
+            "upload_raw_video": False,
+            "upload_raw_audio": False,
+        },
+        "privacy": {
+            "roi_only": True,
+            "media_scope": "roi_derivatives_only",
+        },
+    }
+
+
 def test_validate_capture_payload_accepts_valid_shape() -> None:
     report = validate_capture_payload(_valid_payload())
 
@@ -105,3 +134,28 @@ def test_validate_capture_payload_allows_optional_analysis_block() -> None:
 
     assert report.valid is True
     assert report.errors == []
+
+
+def test_validate_capture_payload_allows_derivatives_only_feature_manifest() -> None:
+    payload = _valid_payload()
+    payload["feature_manifest"] = _valid_feature_manifest()
+
+    report = validate_capture_payload(payload)
+
+    assert report.valid is True
+    assert report.errors == []
+
+
+def test_validate_capture_payload_rejects_feature_manifest_raw_media_upload() -> None:
+    payload = _valid_payload()
+    manifest = _valid_feature_manifest(sample_count=2)
+    manifest["derivatives_only"] = False
+    manifest["raw_media"]["upload_raw_audio"] = True  # type: ignore[index]
+    payload["feature_manifest"] = manifest
+
+    report = validate_capture_payload(payload)
+
+    assert report.valid is False
+    assert "feature_manifest.derivatives_only must be true" in report.errors
+    assert "feature_manifest.sample_count must match samples length" in report.errors
+    assert "feature_manifest.raw_media.upload_raw_audio must be false" in report.errors

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -110,6 +110,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "mobile_helper_unit_tests_present",
         "mobile_api_response_redaction_sources",
         "mobile_api_response_redaction_unit_tests_present",
+        "mobile_feature_media_manifest_sources",
+        "mobile_feature_media_manifest_unit_tests_present",
         "connection_check_unit_tests_present",
         "capture_contract_unit_tests_present",
         "pending_submission_storage_unit_tests_present",


### PR DESCRIPTION
## What changed
- Added a derivatives-only `feature_manifest` to generated mobile `ios_capture_v1` payloads for scaffold and runtime capture paths.
- Added backend validation for optional `feature_manifest`, including strict rejection of raw video/audio storage or upload flags.
- Added mobile/backend unit coverage plus release-readiness gates for feature/media manifest source and test evidence.
- Updated mobile README, release runbook, and productization backlog to reflect the implemented manifest and remaining physical-device evidence gap.

## Why
Clinical Hub can now archive a compact manifest of derived mobile capture features without raw media. This closes the contract-level media manifest gap while preserving privacy-by-default behavior and compatibility with legacy payloads that do not include the optional manifest.

## Validation
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`108 passed`)
- `cd apps/field-mobile && npm run validate:ci` (`65` mobile unit tests, Expo Doctor, npm audit, iOS/Android Expo export)
- `python3 scripts/check_mobile_release_readiness.py ... --output /tmp/mobile-release-readiness-feature-media-manifest.json`
  - `status=ready_except_external_credentials`
  - `local_checks_status=pass`
  - `mobile_feature_media_manifest_sources=pass`
  - `mobile_feature_media_manifest_unit_tests_present=pass`

## External blockers unchanged
- `EXPO_TOKEN`
- `EAS_PROJECT_ID`
- live Clinical Hub credentials
- Apple Developer / Google Play account setup for signed distribution
