### PR TITLE
[codex] Add feature manifest evidence to release manifest

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -123,7 +123,7 @@ CI:
   - `build_platform` (`all` / `ios` / `android`)
   - `wait_for_build` (`true` / `false`)
 - `mobile-build` uploads:
-  - `mobile-release-manifest` (version + runtime release metadata/config + git SHA + model/schema traceability)
+  - `mobile-release-manifest` (version + runtime release metadata/config + capture contract feature-manifest evidence + git SHA + model/schema traceability)
   - `mobile-release-readiness` (git traceability + local readiness checks + explicit external credential blockers)
   - `mobile-eas-build-result-<run_id>` (raw EAS JSON response for build IDs/URLs)
 - Workflow summary includes release readiness status and direct EAS build links for operator/release use.

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -49,7 +49,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - runtime release metadata from `apps/field-mobile/src/config/releaseMetadata.ts` for app version, model ID, and capture schema version,
 - runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, and disabled debug gates,
 - runtime quality evidence for ROI validity, low-confidence depth ratio, and high-motion IMU artifact ratio in `capture_payload.analysis.runtime_quality`,
-- derivatives-only feature/media manifest evidence in `capture_payload.feature_manifest`, including `sample_count`, `feature_keys`, `raw_media.*=false`, and `privacy.media_scope=roi_derivatives_only`,
+- source-backed derivatives-only feature/media manifest evidence in `capture_contract.feature_manifest`, including manifest version, feature keys, `sample_count` source, `raw_media.*=false`, and `privacy.media_scope=roi_derivatives_only`,
 - runtime defaults such as `DEFAULT_API_BASE_URL` to prove release builds do not point field devices at localhost,
 - git SHA/ref/run-id,
 - model_id and capture schema version.

--- a/scripts/build_mobile_release_manifest.py
+++ b/scripts/build_mobile_release_manifest.py
@@ -61,6 +61,12 @@ def _read_ts_boolean_constant(source: str, name: str) -> bool | None:
     return match.group(1) == "true"
 
 
+def _read_ts_string_assignment(source: str, name: str) -> str | None:
+    pattern = re.compile(rf"{re.escape(name)}\s*=\s*[\"']([^\"']*)[\"']")
+    match = pattern.search(source)
+    return match.group(1) if match else None
+
+
 def _release_metadata(app_json: Path) -> dict[str, str | None]:
     path = app_json.parent / "src" / "config" / "releaseMetadata.ts"
     if not path.is_file():
@@ -134,6 +140,81 @@ def _app_settings_defaults(app_json: Path) -> dict[str, str | None]:
     }
 
 
+def _capture_contract_evidence(
+    app_json: Path,
+    app_runtime_config: dict[str, str | bool | None],
+) -> dict[str, Any]:
+    path = app_json.parent / "src" / "capture" / "buildCaptureContract.ts"
+    if not path.is_file():
+        return {
+            "path": str(path),
+            "feature_manifest": {
+                "version": None,
+                "derivatives_only": None,
+                "sample_count_source": None,
+                "feature_keys": [],
+                "raw_media": {
+                    "store_raw_video": app_runtime_config.get("store_raw_video"),
+                    "store_raw_audio": app_runtime_config.get("store_raw_audio"),
+                    "upload_raw_video": None,
+                    "upload_raw_audio": None,
+                },
+                "privacy": {
+                    "roi_only": app_runtime_config.get("roi_only"),
+                    "media_scope": None,
+                },
+            },
+        }
+
+    source = path.read_text(encoding="utf-8")
+    feature_keys = [
+        key
+        for key in (
+            "audio_rms_dbfs",
+            "depth_confidence",
+            "depth_level_mm",
+            "motion_norm",
+            "rgb_level_mm",
+            "roi_valid",
+            "runtime_flow_series.flow_ml_s",
+            "runtime_quality.high_motion_ratio",
+            "t_s",
+        )
+        if key in source
+    ]
+    if (
+        "runtime_quality" in source
+        and "high_motion_ratio" in source
+        and "runtime_quality.high_motion_ratio" not in feature_keys
+    ):
+        feature_keys.append("runtime_quality.high_motion_ratio")
+    return {
+        "path": str(path),
+        "feature_manifest": {
+            "version": _read_ts_string_assignment(source, "FEATURE_MANIFEST_VERSION"),
+            "derivatives_only": "derivatives_only: true" in source,
+            "sample_count_source": (
+                "samples.length" if "sample_count: samples.length" in source else None
+            ),
+            "feature_keys": feature_keys,
+            "raw_media": {
+                "store_raw_video": app_runtime_config.get("store_raw_video"),
+                "store_raw_audio": app_runtime_config.get("store_raw_audio"),
+                "upload_raw_video": False if "upload_raw_video: false" in source else None,
+                "upload_raw_audio": False if "upload_raw_audio: false" in source else None,
+            },
+            "privacy": {
+                "roi_only": app_runtime_config.get("roi_only"),
+                "media_scope": (
+                    "roi_derivatives_only"
+                    if 'media_scope: "roi_derivatives_only"' in source
+                    else None
+                ),
+            },
+        },
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Build mobile release manifest for pilot traceability."
@@ -200,6 +281,7 @@ def main() -> int:
         "runtime_release_metadata": release_metadata,
         "runtime_config": app_runtime_config,
         "runtime_defaults": app_settings_defaults,
+        "capture_contract": _capture_contract_evidence(args.app_json, app_runtime_config),
         "algorithm": {
             "model_id": args.model_id,
             "capture_schema_version": args.schema_version,

--- a/tests/test_mobile_release_manifest_script.py
+++ b/tests/test_mobile_release_manifest_script.py
@@ -33,9 +33,11 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     assets = tmp_path / "assets"
     metadata_path = tmp_path / "src" / "config" / "releaseMetadata.ts"
     app_config_path = tmp_path / "src" / "config" / "appConfig.ts"
+    capture_contract_path = tmp_path / "src" / "capture" / "buildCaptureContract.ts"
     app_settings_path = tmp_path / "src" / "storage" / "appSettingsStorage.ts"
     assets.mkdir()
     metadata_path.parent.mkdir(parents=True)
+    capture_contract_path.parent.mkdir(parents=True)
     app_settings_path.parent.mkdir(parents=True)
     _write_png(assets / "icon.png", 1024, 1024)
     _write_png(assets / "adaptive-icon.png", 1024, 1024)
@@ -116,6 +118,25 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
         'export const DEFAULT_API_BASE_URL = "";\n',
         encoding="utf-8",
     )
+    capture_contract_path.write_text(
+        "\n".join(
+            [
+                'const FEATURE_MANIFEST_VERSION = "mobile_feature_manifest_v0.1";',
+                'const BASE_FEATURE_KEYS = ["t_s", "depth_level_mm", "rgb_level_mm",',
+                '  "depth_confidence", "audio_rms_dbfs", "motion_norm", "roi_valid"];',
+                'featureKeys.add("runtime_flow_series.flow_ml_s");',
+                'featureKeys.add("runtime_quality.high_motion_ratio");',
+                "const featureManifest = {",
+                "  derivatives_only: true,",
+                "  sample_count: samples.length,",
+                "  upload_raw_video: false,",
+                "  upload_raw_audio: false,",
+                '  media_scope: "roi_derivatives_only",',
+                "};",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
     script_path = Path("scripts/build_mobile_release_manifest.py")
     subprocess.run(
@@ -180,5 +201,22 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     assert payload["runtime_config"]["allow_raw_response_details"] is False
     assert payload["runtime_config"]["enable_verbose_logging"] is False
     assert payload["runtime_defaults"]["default_api_base_url"] == ""
+    assert payload["capture_contract"]["path"] == str(capture_contract_path)
+    feature_manifest = payload["capture_contract"]["feature_manifest"]
+    assert feature_manifest["version"] == "mobile_feature_manifest_v0.1"
+    assert feature_manifest["derivatives_only"] is True
+    assert feature_manifest["sample_count_source"] == "samples.length"
+    assert feature_manifest["raw_media"] == {
+        "store_raw_video": False,
+        "store_raw_audio": False,
+        "upload_raw_video": False,
+        "upload_raw_audio": False,
+    }
+    assert feature_manifest["privacy"] == {
+        "roi_only": True,
+        "media_scope": "roi_derivatives_only",
+    }
+    assert "audio_rms_dbfs" in feature_manifest["feature_keys"]
+    assert "runtime_quality.high_motion_ratio" in feature_manifest["feature_keys"]
     assert payload["algorithm"]["model_id"] == "fusion-v0.1"
     assert payload["algorithm"]["capture_schema_version"] == "ios_capture_v1"


### PR DESCRIPTION
## What changed
- Added `capture_contract.feature_manifest` evidence to `mobile-release-manifest`.
- The evidence records manifest version, derivatives-only state, sample-count source, feature keys, raw media storage/upload flags, and ROI-only media scope.
- Updated release manifest tests and docs so the runbook matches the actual artifact shape.

## Why
PR #83 added derivatives-only feature/media manifests to mobile capture payloads and readiness gates. This follow-up keeps the release manifest artifact aligned with the runbook so operators can verify feature-manifest evidence directly from CI artifacts.

## Validation
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`108 passed`)
- `cd apps/field-mobile && npm run validate:ci` (`65` mobile unit tests, Expo Doctor, npm audit, iOS/Android Expo export)
- `python3 scripts/build_mobile_release_manifest.py ...` verified `capture_contract.feature_manifest` includes `mobile_feature_manifest_v0.1`, `derivatives_only=true`, `raw_media.*=false`, `media_scope=roi_derivatives_only`, and `runtime_quality.high_motion_ratio`.
