### PR TITLE
[codex] Embed readiness summary in mobile release manifest

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -176,6 +176,7 @@ jobs:
           python3 ../../scripts/build_mobile_release_manifest.py \
             --app-json app.json \
             --output /tmp/mobile-release-manifest.json \
+            --readiness-json /tmp/mobile-release-readiness.json \
             --profile "$profile" \
             --channel "$channel" \
             --model-id fusion-v0.1 \

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -123,7 +123,7 @@ CI:
   - `build_platform` (`all` / `ios` / `android`)
   - `wait_for_build` (`true` / `false`)
 - `mobile-build` uploads:
-  - `mobile-release-manifest` (version + runtime release metadata/config + capture contract feature-manifest evidence + git SHA + model/schema traceability)
+  - `mobile-release-manifest` (version + runtime release metadata/config + capture contract feature-manifest evidence + readiness gate summary + git SHA + model/schema traceability)
   - `mobile-release-readiness` (git traceability + local readiness checks + explicit external credential blockers)
   - `mobile-eas-build-result-<run_id>` (raw EAS JSON response for build IDs/URLs)
 - Workflow summary includes release readiness status and direct EAS build links for operator/release use.

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -12,6 +12,7 @@ Implemented now:
 - App-level runtime config for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, and disabled debug gates.
 - Runtime capture quality gates for ROI validity, low-confidence depth, and high-motion IMU artifacts.
 - Derivatives-only feature/media manifest in mobile `ios_capture_v1` payloads, with backend validation that raw media storage/upload flags remain disabled.
+- Release manifest traceability for app version, git SHA, model/schema, runtime config, capture contract feature-manifest evidence, and readiness gate summary.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).
@@ -38,7 +39,7 @@ Not yet implemented:
 ### G4. Build/release gap
 - EAS profiles are added but CI does not yet publish artifacts to testers automatically.
 - TestFlight and Play Internal release SOPs are not codified in repo.
-- No immutable release manifest (version -> git sha -> model id -> gate summary).
+- Release manifest is generated with version -> git SHA -> model/schema -> gate summary traceability; signed store distribution remains externally blocked until Apple/Google/Expo credentials are configured.
 
 ### G5. Verification gap
 - Mobile tests are only typecheck-level.
@@ -50,7 +51,7 @@ Not yet implemented:
 ## B0: Foundation (must finish first)
 1. Split app architecture into modules: `api`, `capture`, `storage`, `sync`, `screens`.
 2. Add app-level config object (`mode`, endpoint set, privacy switches, debug gates). Status: implemented for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy switches, and disabled debug gates.
-3. Add release manifest JSON generation (`app_version`, `git_sha`, `model_id`, `schema_version`).
+3. Add release manifest JSON generation (`app_version`, `git_sha`, `model_id`, `schema_version`, readiness gate summary). Status: implemented in Mobile Build artifacts.
 
 DoD:
 - App builds locally for iOS and Android.

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -50,6 +50,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, and disabled debug gates,
 - runtime quality evidence for ROI validity, low-confidence depth ratio, and high-motion IMU artifact ratio in `capture_payload.analysis.runtime_quality`,
 - source-backed derivatives-only feature/media manifest evidence in `capture_contract.feature_manifest`, including manifest version, feature keys, `sample_count` source, `raw_media.*=false`, and `privacy.media_scope=roi_derivatives_only`,
+- readiness gate summary in `readiness`, including local/external/EAS/Clinical Hub statuses, local check counts, failed check IDs, external blocker statuses, and next-action IDs without secret values or detailed evidence strings,
 - runtime defaults such as `DEFAULT_API_BASE_URL` to prove release builds do not point field devices at localhost,
 - git SHA/ref/run-id,
 - model_id and capture schema version.

--- a/scripts/build_mobile_release_manifest.py
+++ b/scripts/build_mobile_release_manifest.py
@@ -215,12 +215,99 @@ def _capture_contract_evidence(
     }
 
 
+def _readiness_summary(readiness_json: Path | None) -> dict[str, Any]:
+    if readiness_json is None:
+        return {
+            "source_path": None,
+            "status": "not_provided",
+            "local_checks_status": None,
+            "external_readiness_status": None,
+            "authenticated_eas_status": None,
+            "authenticated_eas_blockers": [],
+            "clinical_hub_live_api_status": None,
+            "local_check_counts": {},
+            "failed_local_checks": [],
+            "warning_local_checks": [],
+            "external_items": [],
+            "manual_external_items": [],
+            "next_action_ids": [],
+        }
+    if not readiness_json.is_file():
+        return {
+            "source_path": str(readiness_json),
+            "status": "missing",
+            "local_checks_status": None,
+            "external_readiness_status": None,
+            "authenticated_eas_status": None,
+            "authenticated_eas_blockers": [],
+            "clinical_hub_live_api_status": None,
+            "local_check_counts": {},
+            "failed_local_checks": [],
+            "warning_local_checks": [],
+            "external_items": [],
+            "manual_external_items": [],
+            "next_action_ids": [],
+        }
+
+    payload = json.loads(readiness_json.read_text(encoding="utf-8"))
+    local_checks = payload.get("local_checks", [])
+    local_check_counts: dict[str, int] = {}
+    failed_local_checks: list[str] = []
+    warning_local_checks: list[str] = []
+    for check in local_checks:
+        if not isinstance(check, dict):
+            continue
+        status = str(check.get("status", "unknown"))
+        local_check_counts[status] = local_check_counts.get(status, 0) + 1
+        check_id = check.get("id")
+        if isinstance(check_id, str) and status != "pass":
+            failed_local_checks.append(check_id)
+        if isinstance(check_id, str) and check.get("severity") == "warning":
+            warning_local_checks.append(check_id)
+
+    def item_statuses(items: Any) -> list[dict[str, str]]:
+        if not isinstance(items, list):
+            return []
+        result: list[dict[str, str]] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            item_id = item.get("id")
+            status = item.get("status")
+            if isinstance(item_id, str) and isinstance(status, str):
+                result.append({"id": item_id, "status": status})
+        return result
+
+    next_action_ids = [
+        item["id"]
+        for item in payload.get("next_actions", [])
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    ]
+
+    return {
+        "source_path": str(readiness_json),
+        "status": payload.get("status"),
+        "local_checks_status": payload.get("local_checks_status"),
+        "external_readiness_status": payload.get("external_readiness_status"),
+        "authenticated_eas_status": payload.get("authenticated_eas_status"),
+        "authenticated_eas_blockers": payload.get("authenticated_eas_blockers", []),
+        "clinical_hub_live_api_status": payload.get("clinical_hub_live_api_status"),
+        "local_check_counts": local_check_counts,
+        "failed_local_checks": failed_local_checks,
+        "warning_local_checks": warning_local_checks,
+        "external_items": item_statuses(payload.get("external_items")),
+        "manual_external_items": item_statuses(payload.get("manual_external_items")),
+        "next_action_ids": next_action_ids,
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Build mobile release manifest for pilot traceability."
     )
     parser.add_argument("--app-json", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--readiness-json", type=Path)
     parser.add_argument("--profile", default="preview")
     parser.add_argument("--channel", default="preview")
     parser.add_argument("--model-id", default="fusion-v0.1")
@@ -282,6 +369,7 @@ def main() -> int:
         "runtime_config": app_runtime_config,
         "runtime_defaults": app_settings_defaults,
         "capture_contract": _capture_contract_evidence(args.app_json, app_runtime_config),
+        "readiness": _readiness_summary(args.readiness_json),
         "algorithm": {
             "model_id": args.model_id,
             "capture_schema_version": args.schema_version,

--- a/tests/test_mobile_build_workflow.py
+++ b/tests/test_mobile_build_workflow.py
@@ -40,6 +40,14 @@ def test_mobile_build_workflow_uploads_readiness_before_local_failure() -> None:
     assert "mobile-release-readiness artifact" in steps[fail_index]["run"]
 
 
+def test_mobile_build_workflow_embeds_readiness_summary_in_release_manifest() -> None:
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = payload["jobs"]["preflight"]["steps"]
+    manifest_step = next(step for step in steps if step.get("name") == "Build release manifest")
+
+    assert "--readiness-json /tmp/mobile-release-readiness.json" in manifest_step["run"]
+
+
 def test_mobile_build_workflow_summary_reports_invalid_external_items() -> None:
     payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     steps = payload["jobs"]["preflight"]["steps"]

--- a/tests/test_mobile_release_manifest_script.py
+++ b/tests/test_mobile_release_manifest_script.py
@@ -30,6 +30,7 @@ def _write_png(path: Path, width: int, height: int) -> None:
 def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     app_json = tmp_path / "app.json"
     output = tmp_path / "manifest.json"
+    readiness_json = tmp_path / "readiness.json"
     assets = tmp_path / "assets"
     metadata_path = tmp_path / "src" / "config" / "releaseMetadata.ts"
     app_config_path = tmp_path / "src" / "config" / "appConfig.ts"
@@ -137,6 +138,65 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
         ),
         encoding="utf-8",
     )
+    readiness_json.write_text(
+        json.dumps(
+            {
+                "status": "ready_except_external_credentials",
+                "local_checks_status": "pass",
+                "external_readiness_status": "blocked",
+                "authenticated_eas_status": "blocked",
+                "authenticated_eas_blockers": ["expo_token", "eas_project_identity"],
+                "clinical_hub_live_api_status": "missing",
+                "local_checks": [
+                    {
+                        "id": "runtime_config_privacy_by_default",
+                        "status": "pass",
+                        "severity": "error",
+                        "evidence": "secret-free evidence",
+                    },
+                    {
+                        "id": "preview_android_apk",
+                        "status": "pass",
+                        "severity": "warning",
+                        "evidence": "warning evidence",
+                    },
+                ],
+                "external_items": [
+                    {
+                        "id": "expo_token",
+                        "status": "missing",
+                        "evidence": "EXPO_TOKEN environment variable is not set",
+                    },
+                    {
+                        "id": "eas_project_identity",
+                        "status": "missing",
+                        "evidence": "EAS_PROJECT_ID is not set",
+                    },
+                    {
+                        "id": "clinical_hub_live_api",
+                        "status": "missing",
+                        "evidence": "CLINICAL_HUB_URL and/or CLINICAL_HUB_API_KEY are not set",
+                    },
+                ],
+                "manual_external_items": [
+                    {
+                        "id": "apple_developer_account",
+                        "status": "manual_required",
+                    },
+                    {
+                        "id": "google_play_account",
+                        "status": "manual_required",
+                    },
+                ],
+                "next_actions": [
+                    {"id": "configure_expo_token"},
+                    {"id": "configure_eas_project_identity"},
+                    {"id": "configure_clinical_hub_live_api"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
 
     script_path = Path("scripts/build_mobile_release_manifest.py")
     subprocess.run(
@@ -147,6 +207,8 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
             str(app_json),
             "--output",
             str(output),
+            "--readiness-json",
+            str(readiness_json),
             "--profile",
             "preview",
             "--channel",
@@ -218,5 +280,34 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     }
     assert "audio_rms_dbfs" in feature_manifest["feature_keys"]
     assert "runtime_quality.high_motion_ratio" in feature_manifest["feature_keys"]
+    assert payload["readiness"] == {
+        "source_path": str(readiness_json),
+        "status": "ready_except_external_credentials",
+        "local_checks_status": "pass",
+        "external_readiness_status": "blocked",
+        "authenticated_eas_status": "blocked",
+        "authenticated_eas_blockers": ["expo_token", "eas_project_identity"],
+        "clinical_hub_live_api_status": "missing",
+        "local_check_counts": {"pass": 2},
+        "failed_local_checks": [],
+        "warning_local_checks": ["preview_android_apk"],
+        "external_items": [
+            {"id": "expo_token", "status": "missing"},
+            {"id": "eas_project_identity", "status": "missing"},
+            {"id": "clinical_hub_live_api", "status": "missing"},
+        ],
+        "manual_external_items": [
+            {"id": "apple_developer_account", "status": "manual_required"},
+            {"id": "google_play_account", "status": "manual_required"},
+        ],
+        "next_action_ids": [
+            "configure_expo_token",
+            "configure_eas_project_identity",
+            "configure_clinical_hub_live_api",
+        ],
+    }
+    serialized_manifest = json.dumps(payload)
+    assert "secret-free evidence" not in serialized_manifest
+    assert "EXPO_TOKEN environment variable is not set" not in serialized_manifest
     assert payload["algorithm"]["model_id"] == "fusion-v0.1"
     assert payload["algorithm"]["capture_schema_version"] == "ios_capture_v1"


### PR DESCRIPTION
## What changed
- Added optional `--readiness-json` support to `scripts/build_mobile_release_manifest.py`.
- Embedded a compact `readiness` gate summary in `mobile-release-manifest`: statuses, local check counts, failed check IDs, external blocker statuses, manual blocker statuses, and next-action IDs.
- Wired `Mobile Build` to pass `/tmp/mobile-release-readiness.json` into release manifest generation.
- Updated tests and docs/backlog so release manifest traceability now covers app version -> git SHA -> model/schema -> readiness gate summary.

## Why
The release manifest already carried version/git/model/runtime/capture-contract evidence, but the backlog still had a real gap: no immutable gate summary in the release manifest itself. This makes the manifest a stronger handoff artifact while keeping detailed readiness evidence in the separate readiness JSON and avoiding secret/evidence-string leakage.

## Validation
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (`109 passed`)
- `cd apps/field-mobile && npm run validate:ci` (`65` mobile unit tests, Expo Doctor, npm audit, iOS/Android Expo export)
- Local manifest smoke with `--readiness-json` confirmed `readiness.status=ready_except_external_credentials`, `local_check_counts={'pass': 71}`, no failed local checks, and external blockers represented as IDs/statuses only.
