### PR TITLE
Redact mobile capture exceptions

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -75,6 +75,7 @@ import {
   createSessionId,
   createSyncId,
   extractCreatedRecordId,
+  formatSafeExceptionMessage,
   formatSafeResponseProblem,
 } from "./src/utils/appHelpers";
 
@@ -431,8 +432,9 @@ export default function App() {
       }
     } catch (error) {
       setCaptureRunning(false);
-      setCaptureStatus(`Capture start failed: ${String(error)}`);
-      Alert.alert("Capture start failed", String(error));
+      const message = formatSafeExceptionMessage(error);
+      setCaptureStatus(`Capture start failed: ${message}`);
+      Alert.alert("Capture start failed", message);
     }
   }
 
@@ -496,8 +498,9 @@ export default function App() {
       }
     } catch (error) {
       setCaptureRunning(false);
-      setCaptureStatus(`Capture stop failed: ${String(error)}`);
-      Alert.alert("Capture stop failed", String(error));
+      const message = formatSafeExceptionMessage(error);
+      setCaptureStatus(`Capture stop failed: ${message}`);
+      Alert.alert("Capture stop failed", message);
     }
   }
 

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -136,7 +136,7 @@ secret blockers. The artifact has separate machine-readable gates:
 - `local_checks_status`: local app metadata, runtime release metadata, EAS profile shape,
   runtime config/defaults such as Clinical Hub v1 endpoint set, disabled debug gates,
   privacy-by-default switches, runtime motion quality gates, derivatives-only feature/media
-  manifest gates, and non-localhost API URL defaults,
+  manifest gates, API response + runtime exception PHI redaction, and non-localhost API URL defaults,
   store privacy declarations,
   launch/icon assets, dependency lock alignment, and unit-test evidence that can be verified
   without external credentials.

--- a/apps/field-mobile/src/utils/appHelpers.ts
+++ b/apps/field-mobile/src/utils/appHelpers.ts
@@ -94,7 +94,11 @@ export function summarizePendingError(error: string | null): string | null {
   if (
     normalized.includes("unauthorized") ||
     normalized.includes("forbidden") ||
-    normalized.includes("api key")
+    normalized.includes("api key") ||
+    normalized.includes("api_key") ||
+    normalized.includes("apikey") ||
+    normalized.includes("bearer") ||
+    normalized.includes("token")
   ) {
     return "auth_or_permission";
   }
@@ -116,6 +120,13 @@ export function formatSafeResponseProblem(
 ): string {
   const statusLabel = statusCode ? `HTTP ${statusCode}` : fallbackStatusLabel;
   return `${statusLabel} ${summarizePendingError(responseBody) ?? "server_or_client_response"}`;
+}
+
+export function formatSafeExceptionMessage(
+  error: unknown,
+  fallbackStatusLabel: "ERROR" | "NETWORK" = "ERROR",
+): string {
+  return formatSafeResponseProblem(null, String(error), fallbackStatusLabel);
 }
 
 export function normalizeActorRoleInput(rawValue: string | null | undefined): string {

--- a/apps/field-mobile/tests/appHelpers.test.js
+++ b/apps/field-mobile/tests/appHelpers.test.js
@@ -74,6 +74,27 @@ test("formatSafeResponseProblem preserves status without leaking raw response bo
   );
 });
 
+test("formatSafeExceptionMessage redacts mobile PHI and secret-like details", () => {
+  const message = helpers.formatSafeExceptionMessage(
+    new Error(
+      "Runtime failure for subject_id=SUBJ-001 site_id=SITE-001 operator_id=OP-01 api_key=secret-token",
+    ),
+  );
+
+  assert.equal(message, "ERROR auth_or_permission");
+  assert.equal(message.includes("SUBJ-001"), false);
+  assert.equal(message.includes("SITE-001"), false);
+  assert.equal(message.includes("OP-01"), false);
+  assert.equal(message.includes("secret-token"), false);
+});
+
+test("formatSafeExceptionMessage preserves network category without raw exception text", () => {
+  assert.equal(
+    helpers.formatSafeExceptionMessage("TypeError: failed to fetch subject_id=SUBJ-002", "NETWORK"),
+    "NETWORK network_or_timeout",
+  );
+});
+
 test("buildHeaderContextFromValues normalizes operator context and preserves request id", () => {
   assert.deepEqual(
     helpers.buildHeaderContextFromValues(

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -13,6 +13,7 @@ Implemented now:
 - Runtime capture quality gates for ROI validity, low-confidence depth, and high-motion IMU artifacts.
 - Derivatives-only feature/media manifest in mobile `ios_capture_v1` payloads, with backend validation that raw media storage/upload flags remain disabled.
 - Release manifest traceability for app version, git SHA, model/schema, runtime config, capture contract feature-manifest evidence, and readiness gate summary.
+- Mobile API response and runtime exception redaction gates for raw body, PHI-like subject/site/operator IDs, and secret-like error details.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).
@@ -33,7 +34,7 @@ Not yet implemented:
 
 ### G3. Security/privacy gap
 - Secure storage introduced for API key, but no media encryption path yet.
-- No log redaction tests for accidental PHI leakage on mobile.
+- Mobile response/exception redaction tests are present; broader device log collection review still needs physical-device evidence.
 - No policy controls for region-specific data residency in mobile config.
 
 ### G4. Build/release gap

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -58,7 +58,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/debug gates, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/debug gates, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -929,6 +929,38 @@ def build_readiness_report(
         all(redaction_test_requirements.values()),
         f"requirements={redaction_test_requirements!r}",
     )
+    phi_exception_redaction_requirements = {
+        "safe_exception_formatter": "formatSafeExceptionMessage" in app_helpers_source,
+        "capture_start_status_safe": "Capture start failed: ${message}" in app_ts_source,
+        "capture_start_alert_safe": 'Alert.alert("Capture start failed", message)'
+        in app_ts_source,
+        "capture_stop_status_safe": "Capture stop failed: ${message}" in app_ts_source,
+        "capture_stop_alert_safe": 'Alert.alert("Capture stop failed", message)'
+        in app_ts_source,
+        "no_raw_capture_start_status": "Capture start failed: ${String(error)}"
+        not in app_ts_source,
+        "no_raw_capture_start_alert": 'Alert.alert("Capture start failed", String(error))'
+        not in app_ts_source,
+        "no_raw_capture_stop_status": "Capture stop failed: ${String(error)}"
+        not in app_ts_source,
+        "no_raw_capture_stop_alert": 'Alert.alert("Capture stop failed", String(error))'
+        not in app_ts_source,
+    }
+    _check(
+        checks,
+        "mobile_phi_exception_redaction_sources",
+        all(phi_exception_redaction_requirements.values()),
+        f"requirements={phi_exception_redaction_requirements!r}",
+    )
+    _check(
+        checks,
+        "mobile_phi_exception_redaction_unit_tests_present",
+        "formatSafeExceptionMessage redacts mobile PHI and secret-like details"
+        in helper_tests_source
+        and "formatSafeExceptionMessage preserves network category without raw exception text"
+        in helper_tests_source,
+        f"path={helper_tests_path}",
+    )
     _check(
         checks,
         "build_scripts",

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -110,6 +110,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "mobile_helper_unit_tests_present",
         "mobile_api_response_redaction_sources",
         "mobile_api_response_redaction_unit_tests_present",
+        "mobile_phi_exception_redaction_sources",
+        "mobile_phi_exception_redaction_unit_tests_present",
         "mobile_feature_media_manifest_sources",
         "mobile_feature_media_manifest_unit_tests_present",
         "connection_check_unit_tests_present",


### PR DESCRIPTION
## Summary
- route capture start/stop exception alerts through a safe formatter instead of raw String(error)
- extend safe error categorization for api_key/token/bearer-style failures
- add readiness gates and unit coverage for mobile PHI/secret exception redaction
- update mobile release docs/backlog to reflect response + exception redaction evidence

## Validation
- .venv/bin/ruff check .
- .venv/bin/pytest -q
- cd apps/field-mobile && npm run validate:ci
- readiness script status: ready_except_external_credentials; local_checks_status: pass

## Notes
- External release blockers remain Expo/EAS credentials and live Clinical Hub API secrets; no secret values are introduced.