### PR TITLE
Redact submit exception bodies

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -136,7 +136,7 @@ secret blockers. The artifact has separate machine-readable gates:
 - `local_checks_status`: local app metadata, runtime release metadata, EAS profile shape,
   runtime config/defaults such as Clinical Hub v1 endpoint set, disabled debug gates,
   privacy-by-default switches, runtime motion quality gates, derivatives-only feature/media
-  manifest gates, API response + runtime exception PHI redaction, and non-localhost API URL defaults,
+  manifest gates, API response + submit exception + runtime exception PHI redaction, and non-localhost API URL defaults,
   store privacy declarations,
   launch/icon assets, dependency lock alignment, and unit-test evidence that can be verified
   without external credentials.

--- a/apps/field-mobile/src/api/clinicalHub.ts
+++ b/apps/field-mobile/src/api/clinicalHub.ts
@@ -5,7 +5,12 @@ import type {
   SubmitAttemptResult,
 } from "../types";
 import { APP_ENDPOINT_PATHS } from "../config/appConfig";
-import { clampTimeoutMs, classifyRetryable, createRequestId } from "../utils/appHelpers";
+import {
+  clampTimeoutMs,
+  classifyRetryable,
+  createRequestId,
+  summarizeSafeExceptionCategory,
+} from "../utils/appHelpers";
 
 export function buildBaseUrl(apiBaseUrl: string): string {
   return apiBaseUrl.trim().replace(/\/+$/, "");
@@ -91,7 +96,7 @@ export async function attemptSubmitEndpoint(options: {
     return {
       ok: false,
       statusCode: null,
-      body: String(error),
+      body: summarizeSafeExceptionCategory(error, "network_or_timeout"),
       retryable: true,
     };
   }

--- a/apps/field-mobile/src/utils/appHelpers.ts
+++ b/apps/field-mobile/src/utils/appHelpers.ts
@@ -122,11 +122,21 @@ export function formatSafeResponseProblem(
   return `${statusLabel} ${summarizePendingError(responseBody) ?? "server_or_client_response"}`;
 }
 
+export function summarizeSafeExceptionCategory(
+  error: unknown,
+  fallbackCategory: "network_or_timeout" | "server_or_client_response" = "server_or_client_response",
+): string {
+  const category = summarizePendingError(String(error)) ?? fallbackCategory;
+  return category === "server_or_client_response" ? fallbackCategory : category;
+}
+
 export function formatSafeExceptionMessage(
   error: unknown,
   fallbackStatusLabel: "ERROR" | "NETWORK" = "ERROR",
 ): string {
-  return formatSafeResponseProblem(null, String(error), fallbackStatusLabel);
+  const fallbackCategory =
+    fallbackStatusLabel === "NETWORK" ? "network_or_timeout" : "server_or_client_response";
+  return `${fallbackStatusLabel} ${summarizeSafeExceptionCategory(error, fallbackCategory)}`;
 }
 
 export function normalizeActorRoleInput(rawValue: string | null | undefined): string {

--- a/apps/field-mobile/tests/appHelpers.test.js
+++ b/apps/field-mobile/tests/appHelpers.test.js
@@ -88,6 +88,20 @@ test("formatSafeExceptionMessage redacts mobile PHI and secret-like details", ()
   assert.equal(message.includes("secret-token"), false);
 });
 
+test("summarizeSafeExceptionCategory returns safe categories without raw exception text", () => {
+  assert.equal(
+    helpers.summarizeSafeExceptionCategory(
+      "Runtime failure subject_id=SUBJ-001 api_key=secret-token",
+      "network_or_timeout",
+    ),
+    "auth_or_permission",
+  );
+  assert.equal(
+    helpers.summarizeSafeExceptionCategory("Unexpected native bridge failure", "network_or_timeout"),
+    "network_or_timeout",
+  );
+});
+
 test("formatSafeExceptionMessage preserves network category without raw exception text", () => {
   assert.equal(
     helpers.formatSafeExceptionMessage("TypeError: failed to fetch subject_id=SUBJ-002", "NETWORK"),

--- a/apps/field-mobile/tests/clinicalHub.test.js
+++ b/apps/field-mobile/tests/clinicalHub.test.js
@@ -119,7 +119,7 @@ test("attemptSubmitEndpoint keeps network failures retryable", async () => {
   const originalFetch = global.fetch;
   try {
     global.fetch = async () => {
-      throw new Error("failed to fetch");
+      throw new Error("failed to fetch subject_id=SUBJ-001 api_key=secret-token");
     };
 
     const result = await clinicalHub.attemptSubmitEndpoint({
@@ -139,7 +139,9 @@ test("attemptSubmitEndpoint keeps network failures retryable", async () => {
     assert.equal(result.ok, false);
     assert.equal(result.statusCode, null);
     assert.equal(result.retryable, true);
-    assert.match(result.body, /failed to fetch/);
+    assert.equal(result.body, "network_or_timeout");
+    assert.equal(result.body.includes("SUBJ-001"), false);
+    assert.equal(result.body.includes("secret-token"), false);
   } finally {
     global.fetch = originalFetch;
   }

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -13,7 +13,7 @@ Implemented now:
 - Runtime capture quality gates for ROI validity, low-confidence depth, and high-motion IMU artifacts.
 - Derivatives-only feature/media manifest in mobile `ios_capture_v1` payloads, with backend validation that raw media storage/upload flags remain disabled.
 - Release manifest traceability for app version, git SHA, model/schema, runtime config, capture contract feature-manifest evidence, and readiness gate summary.
-- Mobile API response and runtime exception redaction gates for raw body, PHI-like subject/site/operator IDs, and secret-like error details.
+- Mobile API response, submit exception outcome, and runtime exception redaction gates for raw body, PHI-like subject/site/operator IDs, and secret-like error details.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).
@@ -34,7 +34,7 @@ Not yet implemented:
 
 ### G3. Security/privacy gap
 - Secure storage introduced for API key, but no media encryption path yet.
-- Mobile response/exception redaction tests are present; broader device log collection review still needs physical-device evidence.
+- Mobile response/submit-exception/runtime-exception redaction tests are present; broader device log collection review still needs physical-device evidence.
 - No policy controls for region-specific data residency in mobile config.
 
 ### G4. Build/release gap

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -58,7 +58,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/debug gates, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/debug gates, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -696,6 +696,7 @@ def build_readiness_report(
     app_ts_path = mobile_root / "App.tsx"
     app_config_tests_path = mobile_root / "tests" / "appConfig.test.js"
     app_helpers_path = mobile_root / "src" / "utils" / "appHelpers.ts"
+    clinical_hub_source_path = mobile_root / "src" / "api" / "clinicalHub.ts"
     connection_check_source_path = mobile_root / "src" / "api" / "connectionCheck.ts"
     pending_sync_queue_source_path = mobile_root / "src" / "utils" / "pendingSyncQueue.ts"
     pending_sync_hook_source_path = mobile_root / "src" / "hooks" / "usePendingSyncQueue.ts"
@@ -723,12 +724,14 @@ def build_readiness_report(
     submit_outcome_tests_path = mobile_root / "tests" / "submitOutcome.test.js"
     app_ts_source = _read_file_text(app_ts_path)
     app_helpers_source = _read_file_text(app_helpers_path)
+    clinical_hub_source = _read_file_text(clinical_hub_source_path)
     connection_check_source = _read_file_text(connection_check_source_path)
     pending_sync_queue_source = _read_file_text(pending_sync_queue_source_path)
     pending_sync_hook_source = _read_file_text(pending_sync_hook_source_path)
     pending_storage_source = _read_file_text(pending_storage_source_path)
     submit_outcome_source = _read_file_text(submit_outcome_source_path)
     helper_tests_source = _read_file_text(helper_tests_path)
+    clinical_hub_tests_source = _read_file_text(clinical_hub_api_tests_path)
     connection_check_tests_source = _read_file_text(connection_check_tests_path)
     pending_sync_queue_tests_source = _read_file_text(pending_sync_queue_tests_path)
     pending_submission_storage_tests_source = _read_file_text(
@@ -897,6 +900,8 @@ def build_readiness_report(
         "app_network_errors": 'formatSafeResponseProblem(null, String(error), "NETWORK")'
         in app_ts_source,
         "connection_check": "formatSafeResponseProblem(status, body)" in connection_check_source,
+        "submit_exception_body_redaction": "summarizeSafeExceptionCategory(error, "
+        in clinical_hub_source,
         "submit_outcome": "formatSafeResponseProblem(result.statusCode, result.body"
         in submit_outcome_source,
         "pending_sync_attempt": "summarizePendingError(options.result.body)"
@@ -904,6 +909,7 @@ def build_readiness_report(
         "pending_enqueue": "summarizePendingError(lastError)" in pending_sync_hook_source,
         "pending_storage_migration": "summarizePendingError(rawLastError)"
         in pending_storage_source,
+        "no_raw_submit_exception_body": "body: String(error)" not in clinical_hub_source,
         "no_raw_summary_body": "HTTP ${response.status}: ${body}" not in app_ts_source,
         "no_raw_summary_catch": "setSummaryError(String(error))" not in app_ts_source,
         "no_raw_coverage_catch": "setCoverageError(String(error))" not in app_ts_source,
@@ -922,6 +928,9 @@ def build_readiness_report(
         "pending_storage_migration_test": "redacts migrated raw last errors"
         in pending_submission_storage_tests_source,
         "submit_outcome_test": "without raw body" in submit_outcome_tests_source,
+        "submit_exception_body_test": "network failures retryable" in clinical_hub_tests_source
+        and "secret-token" in clinical_hub_tests_source
+        and '"network_or_timeout"' in clinical_hub_tests_source,
     }
     _check(
         checks,


### PR DESCRIPTION
## Summary
- stop returning raw thrown exception text from Clinical Hub submit failures
- add a safe exception category helper for API outcome bodies and UI messages
- extend unit coverage for secret/PHI-like submit exception text
- extend mobile readiness gates to fail on raw submit exception bodies
- update mobile release docs/backlog wording for API response + submit exception + runtime exception redaction

## Validation
- .venv/bin/ruff check .
- .venv/bin/pytest -q
- cd apps/field-mobile && npm run validate:ci
- readiness script status: ready_except_external_credentials; local_checks_status: pass

## Notes
- External release blockers remain Expo/EAS credentials, live Clinical Hub secrets, and manual Apple/Google account provisioning.