### PR TITLE
Add mobile data residency policy

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -135,7 +135,8 @@ secret blockers. The artifact has separate machine-readable gates:
 
 - `local_checks_status`: local app metadata, runtime release metadata, EAS profile shape,
   runtime config/defaults such as Clinical Hub v1 endpoint set, disabled debug gates,
-  privacy-by-default switches, runtime motion quality gates, derivatives-only feature/media
+  privacy-by-default switches, single-region data residency policy,
+  runtime motion quality gates, derivatives-only feature/media
   manifest gates, API response + submit exception + runtime exception PHI redaction, and non-localhost API URL defaults,
   store privacy declarations,
   launch/icon assets, dependency lock alignment, and unit-test evidence that can be verified

--- a/apps/field-mobile/src/config/appConfig.ts
+++ b/apps/field-mobile/src/config/appConfig.ts
@@ -8,6 +8,10 @@ export const APP_CAPTURE_PACKAGES_ENDPOINT_PATH = "/api/v1/capture-packages";
 export const APP_STORE_RAW_VIDEO = false;
 export const APP_STORE_RAW_AUDIO = false;
 export const APP_ROI_ONLY = true;
+export const APP_DATA_RESIDENCY_REGION = "us";
+export const APP_DATA_RESIDENCY_BOUNDARY = "single_region";
+export const APP_ALLOW_CROSS_REGION_SYNC = false;
+export const APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB = true;
 export const APP_ALLOW_DEBUG_CONTROLS = false;
 export const APP_ALLOW_RAW_RESPONSE_DETAILS = false;
 export const APP_ENABLE_VERBOSE_LOGGING = false;
@@ -23,6 +27,13 @@ export const APP_PRIVACY_POLICY = Object.freeze({
   roiOnly: APP_ROI_ONLY,
 });
 
+export const APP_DATA_RESIDENCY_POLICY = Object.freeze({
+  region: APP_DATA_RESIDENCY_REGION,
+  boundary: APP_DATA_RESIDENCY_BOUNDARY,
+  allowCrossRegionSync: APP_ALLOW_CROSS_REGION_SYNC,
+  requireRegionMatchedClinicalHub: APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB,
+});
+
 export const APP_DEBUG_GATES = Object.freeze({
   allowDebugControls: APP_ALLOW_DEBUG_CONTROLS,
   allowRawResponseDetails: APP_ALLOW_RAW_RESPONSE_DETAILS,
@@ -35,5 +46,6 @@ export const APP_RUNTIME_CONFIG = Object.freeze({
   endpointPaths: APP_ENDPOINT_PATHS,
   defaultCaptureMode: APP_DEFAULT_CAPTURE_MODE,
   privacyPolicy: APP_PRIVACY_POLICY,
+  dataResidencyPolicy: APP_DATA_RESIDENCY_POLICY,
   debugGates: APP_DEBUG_GATES,
 });

--- a/apps/field-mobile/tests/appConfig.test.js
+++ b/apps/field-mobile/tests/appConfig.test.js
@@ -17,6 +17,10 @@ test("app runtime config defines pilot endpoints, privacy defaults, and debug ga
   assert.equal(appConfig.APP_STORE_RAW_VIDEO, false);
   assert.equal(appConfig.APP_STORE_RAW_AUDIO, false);
   assert.equal(appConfig.APP_ROI_ONLY, true);
+  assert.equal(appConfig.APP_DATA_RESIDENCY_REGION, "us");
+  assert.equal(appConfig.APP_DATA_RESIDENCY_BOUNDARY, "single_region");
+  assert.equal(appConfig.APP_ALLOW_CROSS_REGION_SYNC, false);
+  assert.equal(appConfig.APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB, true);
   assert.equal(appConfig.APP_ALLOW_DEBUG_CONTROLS, false);
   assert.equal(appConfig.APP_ALLOW_RAW_RESPONSE_DETAILS, false);
   assert.equal(appConfig.APP_ENABLE_VERBOSE_LOGGING, false);
@@ -29,6 +33,12 @@ test("app runtime config defines pilot endpoints, privacy defaults, and debug ga
     storeRawAudio: false,
     roiOnly: true,
   });
+  assert.deepEqual(appConfig.APP_DATA_RESIDENCY_POLICY, {
+    region: "us",
+    boundary: "single_region",
+    allowCrossRegionSync: false,
+    requireRegionMatchedClinicalHub: true,
+  });
   assert.deepEqual(appConfig.APP_DEBUG_GATES, {
     allowDebugControls: false,
     allowRawResponseDetails: false,
@@ -40,6 +50,7 @@ test("app runtime config defines pilot endpoints, privacy defaults, and debug ga
     endpointPaths: appConfig.APP_ENDPOINT_PATHS,
     defaultCaptureMode: "water_impact",
     privacyPolicy: appConfig.APP_PRIVACY_POLICY,
+    dataResidencyPolicy: appConfig.APP_DATA_RESIDENCY_POLICY,
     debugGates: appConfig.APP_DEBUG_GATES,
   });
 });

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -9,11 +9,12 @@ Implemented now:
 - Expo React Native field app for paired entry and sync.
 - Clinical Hub API contract for `paired-measurements` and `capture-packages`.
 - Pilot automation and release gates (`v4.2`) in repository.
-- App-level runtime config for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, and disabled debug gates.
+- App-level runtime config for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, single-region data residency policy, and disabled debug gates.
 - Runtime capture quality gates for ROI validity, low-confidence depth, and high-motion IMU artifacts.
 - Derivatives-only feature/media manifest in mobile `ios_capture_v1` payloads, with backend validation that raw media storage/upload flags remain disabled.
 - Release manifest traceability for app version, git SHA, model/schema, runtime config, capture contract feature-manifest evidence, and readiness gate summary.
 - Mobile API response, submit exception outcome, and runtime exception redaction gates for raw body, PHI-like subject/site/operator IDs, and secret-like error details.
+- Mobile release readiness gate for single-region data residency policy (`us`, no cross-region sync, region-matched Clinical Hub required).
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).
@@ -35,7 +36,7 @@ Not yet implemented:
 ### G3. Security/privacy gap
 - Secure storage introduced for API key, but no media encryption path yet.
 - Mobile response/submit-exception/runtime-exception redaction tests are present; broader device log collection review still needs physical-device evidence.
-- No policy controls for region-specific data residency in mobile config.
+- Mobile data residency policy controls are present; live Clinical Hub region mapping still needs deployment/account evidence.
 
 ### G4. Build/release gap
 - EAS profiles are added but CI does not yet publish artifacts to testers automatically.
@@ -51,7 +52,7 @@ Not yet implemented:
 
 ## B0: Foundation (must finish first)
 1. Split app architecture into modules: `api`, `capture`, `storage`, `sync`, `screens`.
-2. Add app-level config object (`mode`, endpoint set, privacy switches, debug gates). Status: implemented for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy switches, and disabled debug gates.
+2. Add app-level config object (`mode`, endpoint set, privacy switches, data residency policy, debug gates). Status: implemented for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy switches, single-region data residency policy, and disabled debug gates.
 3. Add release manifest JSON generation (`app_version`, `git_sha`, `model_id`, `schema_version`, readiness gate summary). Status: implemented in Mobile Build artifacts.
 
 DoD:

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -47,7 +47,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - iOS build number and Android versionCode,
 - icon/adaptive-icon paths, `expo-splash-screen` image path, SHA-256 fingerprints, byte sizes, PNG dimensions, and splash background/resize/width config,
 - runtime release metadata from `apps/field-mobile/src/config/releaseMetadata.ts` for app version, model ID, and capture schema version,
-- runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, and disabled debug gates,
+- runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, single-region data residency policy, and disabled debug gates,
 - runtime quality evidence for ROI validity, low-confidence depth ratio, and high-motion IMU artifact ratio in `capture_payload.analysis.runtime_quality`,
 - source-backed derivatives-only feature/media manifest evidence in `capture_contract.feature_manifest`, including manifest version, feature keys, `sample_count` source, `raw_media.*=false`, and `privacy.media_scope=roi_derivatives_only`,
 - readiness gate summary in `readiness`, including local/external/EAS/Clinical Hub statuses, local check counts, failed check IDs, external blocker statuses, and next-action IDs without secret values or detailed evidence strings,
@@ -58,7 +58,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/debug gates, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),

--- a/scripts/build_mobile_release_manifest.py
+++ b/scripts/build_mobile_release_manifest.py
@@ -100,6 +100,10 @@ def _app_runtime_config(app_json: Path) -> dict[str, str | bool | None]:
             "store_raw_video": None,
             "store_raw_audio": None,
             "roi_only": None,
+            "data_residency_region": None,
+            "data_residency_boundary": None,
+            "allow_cross_region_sync": None,
+            "require_region_matched_clinical_hub": None,
             "allow_debug_controls": None,
             "allow_raw_response_details": None,
             "enable_verbose_logging": None,
@@ -119,6 +123,16 @@ def _app_runtime_config(app_json: Path) -> dict[str, str | bool | None]:
         "store_raw_video": _read_ts_boolean_constant(source, "APP_STORE_RAW_VIDEO"),
         "store_raw_audio": _read_ts_boolean_constant(source, "APP_STORE_RAW_AUDIO"),
         "roi_only": _read_ts_boolean_constant(source, "APP_ROI_ONLY"),
+        "data_residency_region": _read_ts_string_constant(source, "APP_DATA_RESIDENCY_REGION"),
+        "data_residency_boundary": _read_ts_string_constant(
+            source, "APP_DATA_RESIDENCY_BOUNDARY"
+        ),
+        "allow_cross_region_sync": _read_ts_boolean_constant(
+            source, "APP_ALLOW_CROSS_REGION_SYNC"
+        ),
+        "require_region_matched_clinical_hub": _read_ts_boolean_constant(
+            source, "APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB"
+        ),
         "allow_debug_controls": _read_ts_boolean_constant(source, "APP_ALLOW_DEBUG_CONTROLS"),
         "allow_raw_response_details": _read_ts_boolean_constant(
             source, "APP_ALLOW_RAW_RESPONSE_DETAILS"

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -88,6 +88,10 @@ def _load_app_runtime_config(app_json: Path) -> dict[str, str | bool | None]:
             "store_raw_video": None,
             "store_raw_audio": None,
             "roi_only": None,
+            "data_residency_region": None,
+            "data_residency_boundary": None,
+            "allow_cross_region_sync": None,
+            "require_region_matched_clinical_hub": None,
             "allow_debug_controls": None,
             "allow_raw_response_details": None,
             "enable_verbose_logging": None,
@@ -107,6 +111,16 @@ def _load_app_runtime_config(app_json: Path) -> dict[str, str | bool | None]:
         "store_raw_video": _read_ts_boolean_constant(source, "APP_STORE_RAW_VIDEO"),
         "store_raw_audio": _read_ts_boolean_constant(source, "APP_STORE_RAW_AUDIO"),
         "roi_only": _read_ts_boolean_constant(source, "APP_ROI_ONLY"),
+        "data_residency_region": _read_ts_string_constant(source, "APP_DATA_RESIDENCY_REGION"),
+        "data_residency_boundary": _read_ts_string_constant(
+            source, "APP_DATA_RESIDENCY_BOUNDARY"
+        ),
+        "allow_cross_region_sync": _read_ts_boolean_constant(
+            source, "APP_ALLOW_CROSS_REGION_SYNC"
+        ),
+        "require_region_matched_clinical_hub": _read_ts_boolean_constant(
+            source, "APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB"
+        ),
         "allow_debug_controls": _read_ts_boolean_constant(source, "APP_ALLOW_DEBUG_CONTROLS"),
         "allow_raw_response_details": _read_ts_boolean_constant(
             source, "APP_ALLOW_RAW_RESPONSE_DETAILS"
@@ -381,6 +395,10 @@ def build_readiness_report(
         and app_runtime_config.get("store_raw_video") is not None
         and app_runtime_config.get("store_raw_audio") is not None
         and app_runtime_config.get("roi_only") is not None
+        and bool(app_runtime_config.get("data_residency_region"))
+        and bool(app_runtime_config.get("data_residency_boundary"))
+        and app_runtime_config.get("allow_cross_region_sync") is not None
+        and app_runtime_config.get("require_region_matched_clinical_hub") is not None
         and app_runtime_config.get("allow_debug_controls") is not None
         and app_runtime_config.get("allow_raw_response_details") is not None
         and app_runtime_config.get("enable_verbose_logging") is not None,
@@ -396,6 +414,14 @@ def build_readiness_report(
             f"store_raw_video={app_runtime_config.get('store_raw_video')!r}, "
             f"store_raw_audio={app_runtime_config.get('store_raw_audio')!r}, "
             f"roi_only={app_runtime_config.get('roi_only')!r}, "
+            "data_residency_region="
+            f"{app_runtime_config.get('data_residency_region')!r}, "
+            "data_residency_boundary="
+            f"{app_runtime_config.get('data_residency_boundary')!r}, "
+            "allow_cross_region_sync="
+            f"{app_runtime_config.get('allow_cross_region_sync')!r}, "
+            "require_region_matched_clinical_hub="
+            f"{app_runtime_config.get('require_region_matched_clinical_hub')!r}, "
             f"allow_debug_controls={app_runtime_config.get('allow_debug_controls')!r}, "
             "allow_raw_response_details="
             f"{app_runtime_config.get('allow_raw_response_details')!r}, "
@@ -434,6 +460,24 @@ def build_readiness_report(
             f"store_raw_video={app_runtime_config.get('store_raw_video')!r}, "
             f"store_raw_audio={app_runtime_config.get('store_raw_audio')!r}, "
             f"roi_only={app_runtime_config.get('roi_only')!r}"
+        ),
+    )
+    _check(
+        checks,
+        "runtime_config_data_residency_policy",
+        app_runtime_config.get("data_residency_region") == "us"
+        and app_runtime_config.get("data_residency_boundary") == "single_region"
+        and app_runtime_config.get("allow_cross_region_sync") is False
+        and app_runtime_config.get("require_region_matched_clinical_hub") is True,
+        (
+            "data_residency_region="
+            f"{app_runtime_config.get('data_residency_region')!r}, "
+            "data_residency_boundary="
+            f"{app_runtime_config.get('data_residency_boundary')!r}, "
+            "allow_cross_region_sync="
+            f"{app_runtime_config.get('allow_cross_region_sync')!r}, "
+            "require_region_matched_clinical_hub="
+            f"{app_runtime_config.get('require_region_matched_clinical_hub')!r}"
         ),
     )
     _check(

--- a/tests/test_mobile_release_manifest_script.py
+++ b/tests/test_mobile_release_manifest_script.py
@@ -108,6 +108,10 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
                 "export const APP_STORE_RAW_VIDEO = false;",
                 "export const APP_STORE_RAW_AUDIO = false;",
                 "export const APP_ROI_ONLY = true;",
+                'export const APP_DATA_RESIDENCY_REGION = "us";',
+                'export const APP_DATA_RESIDENCY_BOUNDARY = "single_region";',
+                "export const APP_ALLOW_CROSS_REGION_SYNC = false;",
+                "export const APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB = true;",
                 "export const APP_ALLOW_DEBUG_CONTROLS = false;",
                 "export const APP_ALLOW_RAW_RESPONSE_DETAILS = false;",
                 "export const APP_ENABLE_VERBOSE_LOGGING = false;",
@@ -259,6 +263,10 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     assert payload["runtime_config"]["store_raw_video"] is False
     assert payload["runtime_config"]["store_raw_audio"] is False
     assert payload["runtime_config"]["roi_only"] is True
+    assert payload["runtime_config"]["data_residency_region"] == "us"
+    assert payload["runtime_config"]["data_residency_boundary"] == "single_region"
+    assert payload["runtime_config"]["allow_cross_region_sync"] is False
+    assert payload["runtime_config"]["require_region_matched_clinical_hub"] is True
     assert payload["runtime_config"]["allow_debug_controls"] is False
     assert payload["runtime_config"]["allow_raw_response_details"] is False
     assert payload["runtime_config"]["enable_verbose_logging"] is False

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -91,6 +91,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "app_config_unit_tests_present",
         "paired_payload_unit_tests_present",
         "package_lock_matches_root",
+        "runtime_config_data_residency_policy",
         "runtime_config_default_capture_mode",
         "runtime_config_debug_gates_disabled",
         "runtime_config_endpoint_set",
@@ -301,6 +302,10 @@ def test_mobile_release_readiness_fails_raw_media_runtime_config(tmp_path: Path)
                 "export const APP_STORE_RAW_VIDEO = true;",
                 "export const APP_STORE_RAW_AUDIO = false;",
                 "export const APP_ROI_ONLY = true;",
+                'export const APP_DATA_RESIDENCY_REGION = "us";',
+                'export const APP_DATA_RESIDENCY_BOUNDARY = "single_region";',
+                "export const APP_ALLOW_CROSS_REGION_SYNC = false;",
+                "export const APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB = true;",
                 "export const APP_ALLOW_DEBUG_CONTROLS = false;",
                 "export const APP_ALLOW_RAW_RESPONSE_DETAILS = false;",
                 "export const APP_ENABLE_VERBOSE_LOGGING = false;",
@@ -327,6 +332,59 @@ def test_mobile_release_readiness_fails_raw_media_runtime_config(tmp_path: Path)
     assert "store_raw_video=True" in check["evidence"]
 
 
+def test_mobile_release_readiness_fails_cross_region_runtime_config(tmp_path: Path) -> None:
+    mutated_app_json = tmp_path / "app.json"
+    app_config_path = tmp_path / "src" / "config" / "appConfig.ts"
+    app_config_path.parent.mkdir(parents=True)
+    app_payload = json.loads(APP_JSON.read_text(encoding="utf-8"))
+    mutated_app_json.write_text(json.dumps(app_payload), encoding="utf-8")
+    app_config_path.write_text(
+        "\n".join(
+            [
+                'export const APP_RUNTIME_MODE = "pilot";',
+                'export const APP_ENDPOINT_SET = "clinical_hub_v1";',
+                'export const APP_DEFAULT_CAPTURE_MODE = "water_impact";',
+                (
+                    'export const APP_PAIRED_MEASUREMENTS_ENDPOINT_PATH = '
+                    '"/api/v1/paired-measurements";'
+                ),
+                (
+                    'export const APP_CAPTURE_PACKAGES_ENDPOINT_PATH = '
+                    '"/api/v1/capture-packages";'
+                ),
+                "export const APP_STORE_RAW_VIDEO = false;",
+                "export const APP_STORE_RAW_AUDIO = false;",
+                "export const APP_ROI_ONLY = true;",
+                'export const APP_DATA_RESIDENCY_REGION = "us";',
+                'export const APP_DATA_RESIDENCY_BOUNDARY = "multi_region";',
+                "export const APP_ALLOW_CROSS_REGION_SYNC = true;",
+                "export const APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB = false;",
+                "export const APP_ALLOW_DEBUG_CONTROLS = false;",
+                "export const APP_ALLOW_RAW_RESPONSE_DETAILS = false;",
+                "export const APP_ENABLE_VERBOSE_LOGGING = false;",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = _run_readiness_with_paths(
+        tmp_path / "readiness.json",
+        env={"PATH": os.environ.get("PATH", "")},
+        app_json=mutated_app_json,
+        check=False,
+    )
+
+    check = next(
+        item
+        for item in payload["local_checks"]
+        if item["id"] == "runtime_config_data_residency_policy"
+    )
+    assert payload["status"] == "not_ready"
+    assert payload["local_checks_status"] == "fail"
+    assert check["status"] == "fail"
+    assert "allow_cross_region_sync=True" in check["evidence"]
+
+
 def test_mobile_release_readiness_fails_debug_runtime_config(tmp_path: Path) -> None:
     mutated_app_json = tmp_path / "app.json"
     app_config_path = tmp_path / "src" / "config" / "appConfig.ts"
@@ -350,6 +408,10 @@ def test_mobile_release_readiness_fails_debug_runtime_config(tmp_path: Path) -> 
                 "export const APP_STORE_RAW_VIDEO = false;",
                 "export const APP_STORE_RAW_AUDIO = false;",
                 "export const APP_ROI_ONLY = true;",
+                'export const APP_DATA_RESIDENCY_REGION = "us";',
+                'export const APP_DATA_RESIDENCY_BOUNDARY = "single_region";',
+                "export const APP_ALLOW_CROSS_REGION_SYNC = false;",
+                "export const APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB = true;",
                 "export const APP_ALLOW_DEBUG_CONTROLS = true;",
                 "export const APP_ALLOW_RAW_RESPONSE_DETAILS = false;",
                 "export const APP_ENABLE_VERBOSE_LOGGING = false;",


### PR DESCRIPTION
## Summary
- add explicit mobile data residency runtime policy: us, single_region, no cross-region sync, region-matched Clinical Hub required
- include the policy in APP_RUNTIME_CONFIG and mobile unit coverage
- add release readiness gate runtime_config_data_residency_policy plus negative coverage
- include data residency fields in mobile release manifest runtime_config
- update mobile release docs/backlog to reflect policy controls and remaining live-region evidence

## Validation
- .venv/bin/ruff check .
- .venv/bin/pytest -q
- cd apps/field-mobile && npm run validate:ci
- readiness script status: ready_except_external_credentials; local_checks_status: pass; runtime_config_data_residency_policy: pass
- release manifest runtime_config includes us/single_region/allow_cross_region_sync=false/require_region_matched_clinical_hub=true

## Notes
- This is policy/readiness traceability, not backend geo-routing enforcement. Live Clinical Hub region mapping remains deployment/account evidence.