### PR TITLE
[codex] Sync pending queue on connectivity restore

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -137,7 +137,7 @@ secret blockers. The artifact has separate machine-readable gates:
   runtime config/defaults such as Clinical Hub v1 endpoint set, disabled debug gates,
   privacy-by-default switches, single-region data residency policy,
   runtime motion quality gates, derivatives-only feature/media
-  manifest gates, API response + submit exception + runtime exception PHI redaction, and non-localhost API URL defaults,
+  manifest gates, pending sync connectivity-restore trigger, API response + submit exception + runtime exception PHI redaction, and non-localhost API URL defaults,
   store privacy declarations,
   launch/icon assets, dependency lock alignment, and unit-test evidence that can be verified
   without external credentials.

--- a/apps/field-mobile/package-lock.json
+++ b/apps/field-mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-community/netinfo": "12.0.1",
         "expo": "56.0.8",
         "expo-asset": "~56.0.15",
         "expo-audio": "~56.0.11",
@@ -1663,6 +1664,16 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/netinfo": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-12.0.1.tgz",
+      "integrity": "sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.59"
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/apps/field-mobile/package.json
+++ b/apps/field-mobile/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/netinfo": "12.0.1",
     "expo": "56.0.8",
     "expo-asset": "~56.0.15",
     "expo-audio": "~56.0.11",

--- a/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
+++ b/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Alert, AppState } from "react-native";
+import NetInfo from "@react-native-community/netinfo";
 
 import {
   attemptSubmitEndpoint,
@@ -24,7 +25,9 @@ import {
 import {
   buildPendingSyncAttempt,
   buildPendingSyncStatusMessage,
+  isNetworkReachableForSync,
   shouldAutoSyncPendingQueue,
+  shouldAutoSyncOnConnectivityRestore,
   splitPendingSyncBatch,
 } from "../utils/pendingSyncQueue";
 
@@ -48,6 +51,7 @@ export function usePendingSyncQueue({
   const [syncStatusMessage, setSyncStatusMessage] = useState("");
   const syncInFlightRef = useRef(false);
   const autoSyncIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const networkReachableRef = useRef<boolean | null>(null);
   const apiConfigured = isConfiguredApiBaseUrl(apiBaseUrl);
 
   const persistPendingQueue = useCallback(async (queue: PendingSubmission[]): Promise<void> => {
@@ -235,6 +239,33 @@ export function usePendingSyncQueue({
         clearInterval(autoSyncIntervalRef.current);
         autoSyncIntervalRef.current = null;
       }
+    };
+  }, [apiConfigured, pendingQueue.length, settingsHydrated, syncPendingSubmissions]);
+
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      const isNetworkReachable = isNetworkReachableForSync(
+        state.isConnected,
+        state.isInternetReachable,
+      );
+      const wasNetworkReachable = networkReachableRef.current;
+      networkReachableRef.current = isNetworkReachable;
+
+      if (
+        shouldAutoSyncOnConnectivityRestore({
+          settingsHydrated,
+          pendingCount: pendingQueue.length,
+          apiConfigured,
+          wasNetworkReachable,
+          isNetworkReachable,
+        })
+      ) {
+        void syncPendingSubmissions(false);
+      }
+    });
+
+    return () => {
+      unsubscribe();
     };
   }, [apiConfigured, pendingQueue.length, settingsHydrated, syncPendingSubmissions]);
 

--- a/apps/field-mobile/src/utils/pendingSyncQueue.ts
+++ b/apps/field-mobile/src/utils/pendingSyncQueue.ts
@@ -34,6 +34,11 @@ export type PendingAutoSyncGate = {
   apiConfigured: boolean;
 };
 
+export type PendingConnectivityRestoreGate = PendingAutoSyncGate & {
+  wasNetworkReachable: boolean | null;
+  isNetworkReachable: boolean;
+};
+
 export function splitPendingSyncBatch(
   queue: PendingSubmission[],
   maxBatchSize = MAX_PENDING_SYNC_BATCH_SIZE,
@@ -49,6 +54,23 @@ export function splitPendingSyncBatch(
 
 export function shouldAutoSyncPendingQueue(gate: PendingAutoSyncGate): boolean {
   return gate.settingsHydrated && gate.pendingCount > 0 && gate.apiConfigured;
+}
+
+export function isNetworkReachableForSync(
+  isConnected: boolean | null,
+  isInternetReachable: boolean | null,
+): boolean {
+  return isConnected === true && isInternetReachable !== false;
+}
+
+export function shouldAutoSyncOnConnectivityRestore(
+  gate: PendingConnectivityRestoreGate,
+): boolean {
+  return (
+    shouldAutoSyncPendingQueue(gate) &&
+    gate.wasNetworkReachable === false &&
+    gate.isNetworkReachable
+  );
 }
 
 export function buildPendingSyncAttempt(options: {

--- a/apps/field-mobile/tests/pendingSyncQueue.test.js
+++ b/apps/field-mobile/tests/pendingSyncQueue.test.js
@@ -96,6 +96,56 @@ test("shouldAutoSyncPendingQueue requires hydrated settings, pending work, and c
   );
 });
 
+test("isNetworkReachableForSync treats connected unknown internet as usable", () => {
+  assert.equal(pending.isNetworkReachableForSync(true, true), true);
+  assert.equal(pending.isNetworkReachableForSync(true, null), true);
+  assert.equal(pending.isNetworkReachableForSync(true, false), false);
+  assert.equal(pending.isNetworkReachableForSync(false, true), false);
+  assert.equal(pending.isNetworkReachableForSync(null, true), false);
+});
+
+test("shouldAutoSyncOnConnectivityRestore requires unreachable to reachable transition", () => {
+  const baseGate = {
+    settingsHydrated: true,
+    pendingCount: 1,
+    apiConfigured: true,
+  };
+
+  assert.equal(
+    pending.shouldAutoSyncOnConnectivityRestore({
+      ...baseGate,
+      wasNetworkReachable: false,
+      isNetworkReachable: true,
+    }),
+    true,
+  );
+  assert.equal(
+    pending.shouldAutoSyncOnConnectivityRestore({
+      ...baseGate,
+      wasNetworkReachable: null,
+      isNetworkReachable: true,
+    }),
+    false,
+  );
+  assert.equal(
+    pending.shouldAutoSyncOnConnectivityRestore({
+      ...baseGate,
+      wasNetworkReachable: false,
+      isNetworkReachable: false,
+    }),
+    false,
+  );
+  assert.equal(
+    pending.shouldAutoSyncOnConnectivityRestore({
+      ...baseGate,
+      pendingCount: 0,
+      wasNetworkReachable: false,
+      isNetworkReachable: true,
+    }),
+    false,
+  );
+});
+
 test("buildPendingSyncAttempt records successful capture package submissions", () => {
   const headerContext = {
     api_key: "current-key",

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -15,6 +15,7 @@ Implemented now:
 - Release manifest traceability for app version, git SHA, model/schema, runtime config, capture contract feature-manifest evidence, and readiness gate summary.
 - Mobile API response, submit exception outcome, and runtime exception redaction gates for raw body, PHI-like subject/site/operator IDs, and secret-like error details.
 - Mobile release readiness gate for single-region data residency policy (`us`, no cross-region sync, region-matched Clinical Hub required).
+- Pending queue auto-sync on connectivity restore via NetInfo, with interval/AppState fallback.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).
@@ -30,7 +31,7 @@ Not yet implemented:
 
 ### G2. Data contract gap
 - Capture contract can use live runtime samples, with scaffold fallback still available.
-- `capture-packages` are queued for offline retry, but device-level E2E replay evidence still needs to be archived.
+- `capture-packages` are queued for offline retry, with app-level connectivity-restore sync; device-level E2E replay evidence still needs to be archived.
 - Mobile payloads include a derivatives-only feature/media manifest; native-grade feature bundles and device-level media-manifest replay evidence still need physical-device archival.
 
 ### G3. Security/privacy gap
@@ -75,7 +76,7 @@ DoD:
 ## B2: Sync and resilience
 1. Extend offline queue to support both `paired-measurements` and `capture-packages` as independent jobs.
 2. Add idempotent retry policies per endpoint and per status code.
-3. Add background sync trigger on connectivity restore.
+3. Add background sync trigger on connectivity restore. Status: implemented for foreground app connectivity restore via NetInfo, plus interval and AppState fallback; OS background task scheduling remains out of scope until native/background execution policy is chosen.
 
 DoD:
 - Airplane-mode scenario retains both payload types.

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -58,7 +58,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, pending sync connectivity restore, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
@@ -116,7 +116,7 @@ Android:
 3. `Contract payload: ready` after stop.
 4. Submit produces `paired-measurements` and `capture-packages` records.
 5. Offline mode queues both endpoint jobs.
-6. Returning online triggers successful auto-sync.
+6. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
 
 ## 6) Evidence to archive per build
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -920,6 +920,35 @@ def build_readiness_report(
         pending_sync_queue_tests_path.is_file(),
         f"path={pending_sync_queue_tests_path}",
     )
+    connectivity_restore_requirements = {
+        "netinfo_dependency": "@react-native-community/netinfo" in package_dependencies,
+        "netinfo_listener": "NetInfo.addEventListener" in pending_sync_hook_source,
+        "network_reachable_helper": "isNetworkReachableForSync" in pending_sync_queue_source,
+        "restore_gate_helper": "shouldAutoSyncOnConnectivityRestore"
+        in pending_sync_queue_source,
+        "restore_gate_used_by_hook": "shouldAutoSyncOnConnectivityRestore"
+        in pending_sync_hook_source,
+    }
+    _check(
+        checks,
+        "pending_sync_connectivity_restore_sources",
+        all(connectivity_restore_requirements.values()),
+        f"requirements={connectivity_restore_requirements!r}",
+    )
+    connectivity_restore_test_requirements = {
+        "reachability_helper_test": (
+            "isNetworkReachableForSync treats connected unknown internet as usable"
+        )
+        in pending_sync_queue_tests_source,
+        "restore_gate_test": "requires unreachable to reachable transition"
+        in pending_sync_queue_tests_source,
+    }
+    _check(
+        checks,
+        "pending_sync_connectivity_restore_unit_tests_present",
+        all(connectivity_restore_test_requirements.values()),
+        f"requirements={connectivity_restore_test_requirements!r}",
+    )
     _check(
         checks,
         "pending_submission_storage_unit_tests_present",

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -118,6 +118,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "connection_check_unit_tests_present",
         "capture_contract_unit_tests_present",
         "pending_submission_storage_unit_tests_present",
+        "pending_sync_connectivity_restore_sources",
+        "pending_sync_connectivity_restore_unit_tests_present",
         "pending_sync_queue_unit_tests_present",
         "roi_signal_unit_tests_present",
         "runtime_metrics_unit_tests_present",


### PR DESCRIPTION
## What changed

- Added `@react-native-community/netinfo` to the Expo mobile app.
- Wired the pending submission queue to trigger auto-sync when foreground connectivity transitions from unreachable to reachable.
- Kept the existing interval and AppState fallbacks in place.
- Added helper-level unit tests for reachability and restore-gate behavior.
- Added release-readiness checks and documentation evidence for the connectivity-restore sync path.

## Why

The app already queued failed capture package submissions and retried via interval/AppState paths. This closes the foreground connectivity-restore gap so queued work can replay promptly when a device regains network access.

## Validation

- `cd apps/field-mobile && npm run typecheck`
- `cd apps/field-mobile && npm run test:unit`
- `.venv/bin/pytest -q tests/test_mobile_release_readiness_script.py`
- `python scripts/check_mobile_release_readiness.py --output /tmp/mobile-readiness-connectivity-restore.json`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q`
- `cd apps/field-mobile && npm run validate:ci`

Readiness status remained `ready_except_external_credentials`; local checks passed.