### PR TITLE
[codex] Add mobile sync smoke replay test

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -117,7 +117,7 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
-- `validate:ci` covers TypeScript, Clinical Hub API client/connection check/summary requests + mobile helper/API + runtime config + submit outcome + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
+- `validate:ci` covers TypeScript, Clinical Hub API client/connection check/summary requests + mobile helper/API + runtime config + submit outcome + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + deterministic sync smoke + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
 - `.github/workflows/mobile-build.yml` runs release preflight for mobile app/release-script changes and provides manual EAS build trigger (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)

--- a/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
+++ b/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
@@ -17,18 +17,12 @@ import type {
   PendingSubmission,
   RequestHeaderContext,
 } from "../types";
+import { createPendingId, summarizePendingError } from "../utils/appHelpers";
 import {
-  createPendingId,
-  resolvePendingHeaderContext,
-  summarizePendingError,
-} from "../utils/appHelpers";
-import {
-  buildPendingSyncAttempt,
-  buildPendingSyncStatusMessage,
   isNetworkReachableForSync,
+  runPendingSyncBatch,
   shouldAutoSyncPendingQueue,
   shouldAutoSyncOnConnectivityRestore,
-  splitPendingSyncBatch,
 } from "../utils/pendingSyncQueue";
 
 type UsePendingSyncQueueOptions = {
@@ -116,58 +110,24 @@ export function usePendingSyncQueue({
           return;
         }
 
-        const { batch, deferred } = splitPendingSyncBatch(queue);
-        const retryableBatchItems: PendingSubmission[] = [];
-        let syncedPaired = 0;
-        let syncedCapture = 0;
-        let droppedNonRetryable = 0;
-
-        for (const item of batch) {
-          const headerContext = resolvePendingHeaderContext(item, requestHeaderContext);
-          const result = await attemptSubmitEndpoint({
-            apiBaseUrl,
-            requestTimeoutMs,
-            endpoint: item.endpoint,
-            endpointPayload: item.payload,
-            headerContext,
-          });
-          const attempt = buildPendingSyncAttempt({
-            item,
-            headerContext,
-            result,
-            attemptedAtIso: new Date().toISOString(),
-          });
-          if (attempt.outcome === "synced_capture") {
-            syncedCapture += 1;
-            continue;
-          }
-          if (attempt.outcome === "synced_paired") {
-            syncedPaired += 1;
-            continue;
-          }
-          if (attempt.outcome === "retryable") {
-            retryableBatchItems.push(attempt.attemptedItem);
-            continue;
-          }
-          droppedNonRetryable += 1;
-        }
-
-        const remaining = [...retryableBatchItems, ...deferred];
-        await persistPendingQueue(remaining);
-
-        const statusMessage = buildPendingSyncStatusMessage({
-          batchCount: batch.length,
-          totalCount: queue.length,
-          syncedPaired,
-          syncedCapture,
-          remainingQueued: remaining.length,
-          deferred: deferred.length,
-          droppedNonRetryable,
+        const syncResult = await runPendingSyncBatch({
+          queue,
+          requestHeaderContext,
+          submitEndpoint: ({ endpoint, endpointPayload, headerContext }) =>
+            attemptSubmitEndpoint({
+              apiBaseUrl,
+              requestTimeoutMs,
+              endpoint,
+              endpointPayload,
+              headerContext,
+            }),
         });
-        setSyncStatusMessage(statusMessage);
-        onLastResponse(statusMessage);
+        await persistPendingQueue(syncResult.remaining);
+
+        setSyncStatusMessage(syncResult.statusMessage);
+        onLastResponse(syncResult.statusMessage);
         if (showAlert) {
-          Alert.alert("Sync completed", statusMessage);
+          Alert.alert("Sync completed", syncResult.statusMessage);
         }
       } finally {
         syncInFlightRef.current = false;

--- a/apps/field-mobile/src/utils/pendingSyncQueue.ts
+++ b/apps/field-mobile/src/utils/pendingSyncQueue.ts
@@ -1,9 +1,11 @@
 import type {
+  EndpointPayload,
+  PendingEndpoint,
   PendingSubmission,
   RequestHeaderContext,
   SubmitAttemptResult,
 } from "../types";
-import { summarizePendingError } from "./appHelpers";
+import { resolvePendingHeaderContext, summarizePendingError } from "./appHelpers";
 
 export const MAX_PENDING_SYNC_BATCH_SIZE = 10;
 
@@ -37,6 +39,19 @@ export type PendingAutoSyncGate = {
 export type PendingConnectivityRestoreGate = PendingAutoSyncGate & {
   wasNetworkReachable: boolean | null;
   isNetworkReachable: boolean;
+};
+
+export type SubmitPendingEndpoint = (options: {
+  endpoint: PendingEndpoint;
+  endpointPayload: EndpointPayload;
+  headerContext: RequestHeaderContext;
+}) => Promise<SubmitAttemptResult>;
+
+export type PendingSyncBatchResult = {
+  remaining: PendingSubmission[];
+  attempts: PendingSyncAttempt[];
+  summary: PendingSyncStatusSummary;
+  statusMessage: string;
 };
 
 export function splitPendingSyncBatch(
@@ -104,6 +119,70 @@ export function buildPendingSyncAttempt(options: {
   return {
     attemptedItem,
     outcome: options.result.retryable ? "retryable" : "dropped_non_retryable",
+  };
+}
+
+export async function runPendingSyncBatch(options: {
+  queue: PendingSubmission[];
+  requestHeaderContext: RequestHeaderContext;
+  submitEndpoint: SubmitPendingEndpoint;
+  attemptedAtIso?: string;
+  maxBatchSize?: number;
+}): Promise<PendingSyncBatchResult> {
+  const { batch, deferred } = splitPendingSyncBatch(options.queue, options.maxBatchSize);
+  const retryableBatchItems: PendingSubmission[] = [];
+  const attempts: PendingSyncAttempt[] = [];
+  let syncedPaired = 0;
+  let syncedCapture = 0;
+  let droppedNonRetryable = 0;
+  const attemptedAtIso = options.attemptedAtIso ?? new Date().toISOString();
+
+  for (const item of batch) {
+    const headerContext = resolvePendingHeaderContext(item, options.requestHeaderContext);
+    const result = await options.submitEndpoint({
+      endpoint: item.endpoint,
+      endpointPayload: item.payload,
+      headerContext,
+    });
+    const attempt = buildPendingSyncAttempt({
+      item,
+      headerContext,
+      result,
+      attemptedAtIso,
+    });
+    attempts.push(attempt);
+
+    if (attempt.outcome === "synced_capture") {
+      syncedCapture += 1;
+      continue;
+    }
+    if (attempt.outcome === "synced_paired") {
+      syncedPaired += 1;
+      continue;
+    }
+    if (attempt.outcome === "retryable") {
+      retryableBatchItems.push(attempt.attemptedItem);
+      continue;
+    }
+    droppedNonRetryable += 1;
+  }
+
+  const remaining = [...retryableBatchItems, ...deferred];
+  const summary = {
+    batchCount: batch.length,
+    totalCount: options.queue.length,
+    syncedPaired,
+    syncedCapture,
+    remainingQueued: remaining.length,
+    deferred: deferred.length,
+    droppedNonRetryable,
+  };
+
+  return {
+    remaining,
+    attempts,
+    summary,
+    statusMessage: buildPendingSyncStatusMessage(summary),
   };
 }
 

--- a/apps/field-mobile/tests/pendingSyncQueue.test.js
+++ b/apps/field-mobile/tests/pendingSyncQueue.test.js
@@ -23,6 +23,24 @@ function buildPayload(syncId = "SYNC-001") {
   };
 }
 
+function buildCapturePackagePayload(syncId = "SYNC-001") {
+  const pairedPayload = buildPayload(syncId);
+  return {
+    session: pairedPayload.session,
+    package_type: "capture_contract_json",
+    capture_payload: {
+      schema_version: "ios_capture_v1",
+      session: {
+        session_id: pairedPayload.session.session_id,
+        sync_id: pairedPayload.session.sync_id,
+      },
+      samples: [],
+    },
+    paired_measurement_id: null,
+    notes: "mobile_runtime_capture_contract_audio_imu_v0.1",
+  };
+}
+
 function buildPendingSubmission(overrides = {}) {
   return {
     id: "PENDING-001",
@@ -143,6 +161,123 @@ test("shouldAutoSyncOnConnectivityRestore requires unreachable to reachable tran
       isNetworkReachable: true,
     }),
     false,
+  );
+});
+
+test("mobile E2E smoke replays queued paired and capture submissions after network restore", async () => {
+  const queue = [
+    buildPendingSubmission({
+      id: "PENDING-PAIR",
+      endpoint: "paired_measurements",
+      payload: buildPayload("SYNC-E2E-001"),
+    }),
+    buildPendingSubmission({
+      id: "PENDING-CAPTURE",
+      endpoint: "capture_packages",
+      payload: buildCapturePackagePayload("SYNC-E2E-001"),
+      request_headers: {
+        api_key: "",
+        actor_role: "",
+        site_id: "",
+        operator_id: "",
+        request_id: "",
+      },
+    }),
+  ];
+  const currentHeaders = {
+    api_key: "current-key",
+    actor_role: "operator",
+    site_id: "SITE-CURRENT",
+    operator_id: "OP-CURRENT",
+    request_id: "REQ-CURRENT",
+  };
+
+  const offlineCalls = [];
+  const offlineResult = await pending.runPendingSyncBatch({
+    queue,
+    requestHeaderContext: currentHeaders,
+    attemptedAtIso: "2026-06-04T01:02:03.000Z",
+    submitEndpoint: async ({ endpoint, endpointPayload, headerContext }) => {
+      offlineCalls.push({
+        endpoint,
+        requestId: headerContext.request_id,
+        sessionId: endpointPayload.session.session_id,
+        syncId: endpointPayload.session.sync_id,
+      });
+      return {
+        ok: false,
+        statusCode: null,
+        body: "TypeError: failed to fetch subject_id=SUBJ-001 api_key=secret-token",
+        retryable: true,
+      };
+    },
+  });
+
+  assert.deepEqual(
+    offlineCalls.map((call) => `${call.endpoint}:${call.sessionId}:${call.syncId}`),
+    [
+      "paired_measurements:SESSION-001:SYNC-E2E-001",
+      "capture_packages:SESSION-001:SYNC-E2E-001",
+    ],
+  );
+  assert.deepEqual(
+    offlineCalls.map((call) => call.requestId),
+    ["REQ-QUEUED", "PENDING-CAPTURE"],
+  );
+  assert.equal(offlineResult.remaining.length, 2);
+  assert.deepEqual(
+    offlineResult.remaining.map((item) => item.id),
+    ["PENDING-PAIR", "PENDING-CAPTURE"],
+  );
+  assert.equal(offlineResult.remaining.every((item) => item.attempt_count === 1), true);
+  assert.equal(offlineResult.remaining.every((item) => item.last_error === "network_or_timeout"), true);
+  assert.deepEqual(offlineResult.summary, {
+    batchCount: 2,
+    totalCount: 2,
+    syncedPaired: 0,
+    syncedCapture: 0,
+    remainingQueued: 2,
+    deferred: 0,
+    droppedNonRetryable: 0,
+  });
+
+  const restoredCalls = [];
+  const restoredResult = await pending.runPendingSyncBatch({
+    queue: offlineResult.remaining,
+    requestHeaderContext: currentHeaders,
+    attemptedAtIso: "2026-06-04T01:03:03.000Z",
+    submitEndpoint: async ({ endpoint, endpointPayload }) => {
+      restoredCalls.push(`${endpoint}:${endpointPayload.session.session_id}`);
+      return {
+        ok: true,
+        statusCode: endpoint === "capture_packages" ? 201 : 200,
+        body: endpoint === "capture_packages" ? '{"id": 102}' : '{"id": 101}',
+        retryable: false,
+      };
+    },
+  });
+
+  assert.deepEqual(restoredCalls, [
+    "paired_measurements:SESSION-001",
+    "capture_packages:SESSION-001",
+  ]);
+  assert.deepEqual(
+    restoredResult.attempts.map((attempt) => attempt.outcome),
+    ["synced_paired", "synced_capture"],
+  );
+  assert.deepEqual(restoredResult.remaining, []);
+  assert.deepEqual(restoredResult.summary, {
+    batchCount: 2,
+    totalCount: 2,
+    syncedPaired: 1,
+    syncedCapture: 1,
+    remainingQueued: 0,
+    deferred: 0,
+    droppedNonRetryable: 0,
+  });
+  assert.equal(
+    restoredResult.statusMessage,
+    "Sync batch completed (2/2). Synced paired: 1, synced capture: 1, remaining queued: 0, deferred: 0, dropped non-retryable: 0.",
   );
 });
 

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -16,6 +16,7 @@ Implemented now:
 - Mobile API response, submit exception outcome, and runtime exception redaction gates for raw body, PHI-like subject/site/operator IDs, and secret-like error details.
 - Mobile release readiness gate for single-region data residency policy (`us`, no cross-region sync, region-matched Clinical Hub required).
 - Pending queue auto-sync on connectivity restore via NetInfo, with interval/AppState fallback.
+- Deterministic mobile sync smoke covering queued paired+capture replay after network restore.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).
@@ -45,8 +46,8 @@ Not yet implemented:
 - Release manifest is generated with version -> git SHA -> model/schema -> gate summary traceability; signed store distribution remains externally blocked until Apple/Google/Expo credentials are configured.
 
 ### G5. Verification gap
-- Mobile tests are only typecheck-level.
-- No deterministic replay tests for capture contract generation on device.
+- Mobile tests include TypeScript, unit, export, and deterministic sync replay coverage.
+- Deterministic replay tests cover capture contract generation and queued paired+capture sync; physical-device evidence still needs archival.
 - No device-matrix smoke checks (iPhone/Android model spread).
 
 ## 3) Backlog (implementation order)
@@ -95,8 +96,8 @@ DoD:
 - Every build has linked commit SHA and changelog.
 
 ## B4: Quality and validation readiness
-1. Add unit tests for capture payload generation and local validation.
-2. Add E2E mobile smoke tests (session create -> submit -> queue -> sync).
+1. Add unit tests for capture payload generation and local validation. Status: implemented for paired payload, capture package payload, capture contract generation, ROI signal, runtime metrics, and backend capture contract validation.
+2. Add E2E mobile smoke tests (session create -> submit -> queue -> sync). Status: implemented as deterministic repository-level paired+capture queue replay after network restore; physical-device/live Clinical Hub smoke evidence still required.
 3. Export nightly comparison summary and gate snapshot to Clinical Hub.
 
 DoD:

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -58,7 +58,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, pending sync connectivity restore, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, pending sync connectivity restore, deterministic mobile E2E sync smoke, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
@@ -117,6 +117,7 @@ Android:
 4. Submit produces `paired-measurements` and `capture-packages` records.
 5. Offline mode queues both endpoint jobs.
 6. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
+7. Repository-level deterministic smoke confirms queued paired+capture replay drains after network restore.
 
 ## 6) Evidence to archive per build
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -949,6 +949,44 @@ def build_readiness_report(
         all(connectivity_restore_test_requirements.values()),
         f"requirements={connectivity_restore_test_requirements!r}",
     )
+    mobile_e2e_sync_smoke_requirements = {
+        "batch_replay_helper": "runPendingSyncBatch" in pending_sync_queue_source,
+        "submitter_injection": "submitEndpoint" in pending_sync_queue_source,
+        "hook_uses_batch_replay_helper": "runPendingSyncBatch" in pending_sync_hook_source,
+        "paired_and_capture_counts": (
+            "syncedPaired" in pending_sync_queue_source
+            and "syncedCapture" in pending_sync_queue_source
+        ),
+    }
+    _check(
+        checks,
+        "mobile_e2e_sync_smoke_sources",
+        all(mobile_e2e_sync_smoke_requirements.values()),
+        f"requirements={mobile_e2e_sync_smoke_requirements!r}",
+    )
+    mobile_e2e_sync_smoke_test_requirements = {
+        "restore_smoke_test": (
+            "mobile E2E smoke replays queued paired and capture submissions "
+            "after network restore"
+        )
+        in pending_sync_queue_tests_source,
+        "paired_capture_queue": (
+            '"paired_measurements:SESSION-001:SYNC-E2E-001"'
+            in pending_sync_queue_tests_source
+            and '"capture_packages:SESSION-001:SYNC-E2E-001"'
+            in pending_sync_queue_tests_source
+        ),
+        "synced_outcomes": (
+            '"synced_paired"' in pending_sync_queue_tests_source
+            and '"synced_capture"' in pending_sync_queue_tests_source
+        ),
+    }
+    _check(
+        checks,
+        "mobile_e2e_sync_smoke_unit_tests_present",
+        all(mobile_e2e_sync_smoke_test_requirements.values()),
+        f"requirements={mobile_e2e_sync_smoke_test_requirements!r}",
+    )
     _check(
         checks,
         "pending_submission_storage_unit_tests_present",

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -117,6 +117,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "mobile_feature_media_manifest_unit_tests_present",
         "connection_check_unit_tests_present",
         "capture_contract_unit_tests_present",
+        "mobile_e2e_sync_smoke_sources",
+        "mobile_e2e_sync_smoke_unit_tests_present",
         "pending_submission_storage_unit_tests_present",
         "pending_sync_connectivity_restore_sources",
         "pending_sync_connectivity_restore_unit_tests_present",


### PR DESCRIPTION
## What changed

- Extracted pending queue batch replay into a pure `runPendingSyncBatch` helper with an injected submitter.
- Updated `usePendingSyncQueue` to use the shared replay helper while keeping hook-owned storage, status, and alert behavior intact.
- Added a deterministic mobile E2E-style smoke test for queued paired + capture submissions: network failure keeps both jobs queued, network restore replays both and drains the queue.
- Added release-readiness gates for the replay helper and smoke test evidence.
- Updated mobile productization docs/runbook/README to reflect repository-level sync smoke coverage.

## Why

B4 called for mobile smoke coverage around submit -> queue -> sync. The live physical-device and Clinical Hub run is still external/manual, but the replay semantics can be protected in CI without credentials.

## Validation

- `cd apps/field-mobile && npm run typecheck`
- `cd apps/field-mobile && npm run test:unit` (71 tests)
- `.venv/bin/ruff check scripts/check_mobile_release_readiness.py tests/test_mobile_release_readiness_script.py`
- `.venv/bin/pytest -q tests/test_mobile_release_readiness_script.py`
- `.venv/bin/python scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-e2e-sync-smoke.json`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q`
- `cd apps/field-mobile && npm run validate:ci`

Readiness status stayed `ready_except_external_credentials`; local checks passed with 78 pass checks including `mobile_e2e_sync_smoke_sources` and `mobile_e2e_sync_smoke_unit_tests_present`.