### PR TITLE
[codex] Add mobile release notes artifact

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -26,6 +26,10 @@ on:
         required: false
         type: boolean
         default: false
+      release_notes:
+        description: "Operator-facing release notes for this mobile build"
+        required: false
+        type: string
   push:
     branches:
       - main
@@ -162,6 +166,51 @@ jobs:
               handle.write("\n".join(lines) + "\n")
           PY
 
+      - name: Build release notes artifact
+        env:
+          WORKFLOW_BUILD_PROFILE: ${{ github.event.inputs.build_profile || 'preview' }}
+          WORKFLOW_BUILD_PLATFORM: ${{ github.event.inputs.build_platform || 'all' }}
+          WORKFLOW_RELEASE_NOTES: ${{ github.event.inputs.release_notes || '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          notes = os.environ.get("WORKFLOW_RELEASE_NOTES", "").strip()
+          if not notes:
+              notes = (
+                  "No operator-facing release notes were supplied for this run. "
+                  "Use the workflow_dispatch release_notes input for clinic handoff notes."
+              )
+
+          lines = [
+              "# Uroflow Field Mobile Release Notes",
+              "",
+              f"- Git SHA: `{os.environ.get('GITHUB_SHA', 'local')}`",
+              f"- Git ref: `{os.environ.get('GITHUB_REF', 'local')}`",
+              f"- GitHub run: `{os.environ.get('GITHUB_RUN_ID', 'local')}`",
+              f"- Build profile: `{os.environ.get('WORKFLOW_BUILD_PROFILE', 'preview')}`",
+              f"- Build platform: `{os.environ.get('WORKFLOW_BUILD_PLATFORM', 'all')}`",
+              "",
+              "## Operator Notes",
+              "",
+              notes,
+              "",
+              "## Required Evidence",
+              "",
+              "- Download `mobile-release-manifest`.",
+              "- Download `mobile-release-readiness`.",
+              "- Archive iOS/Android EAS build links when authenticated EAS build runs.",
+              "- Archive physical-device smoke log with device model and OS version.",
+          ]
+          Path("/tmp/mobile-release-notes.md").write_text(
+              "\n".join(lines) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
       - name: Build release manifest
         env:
           WORKFLOW_BUILD_PROFILE: ${{ github.event.inputs.build_profile || 'preview' }}
@@ -177,10 +226,17 @@ jobs:
             --app-json app.json \
             --output /tmp/mobile-release-manifest.json \
             --readiness-json /tmp/mobile-release-readiness.json \
+            --release-notes /tmp/mobile-release-notes.md \
             --profile "$profile" \
             --channel "$channel" \
             --model-id fusion-v0.1 \
             --schema-version ios_capture_v1
+
+      - name: Upload release notes
+        uses: actions/upload-artifact@v7
+        with:
+          name: mobile-release-notes
+          path: /tmp/mobile-release-notes.md
 
       - name: Upload release manifest
         uses: actions/upload-artifact@v7

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -122,9 +122,11 @@ CI:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)
   - `wait_for_build` (`true` / `false`)
+  - `release_notes` (operator-facing handoff notes archived as `mobile-release-notes`)
 - `mobile-build` uploads:
-  - `mobile-release-manifest` (version + runtime release metadata/config + capture contract feature-manifest evidence + readiness gate summary + git SHA + model/schema traceability)
+  - `mobile-release-manifest` (version + runtime release metadata/config + release notes digest + capture contract feature-manifest evidence + readiness gate summary + git SHA + model/schema traceability)
   - `mobile-release-readiness` (git traceability + local readiness checks + explicit external credential blockers)
+  - `mobile-release-notes` (operator-facing release notes and required evidence reminders)
   - `mobile-eas-build-result-<run_id>` (raw EAS JSON response for build IDs/URLs)
 - Workflow summary includes release readiness status and direct EAS build links for operator/release use.
 

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -17,6 +17,7 @@ Implemented now:
 - Mobile release readiness gate for single-region data residency policy (`us`, no cross-region sync, region-matched Clinical Hub required).
 - Pending queue auto-sync on connectivity restore via NetInfo, with interval/AppState fallback.
 - Deterministic mobile sync smoke covering queued paired+capture replay after network restore.
+- Mobile Build release notes artifact and manifest traceability for operator-facing build handoff.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).
@@ -85,7 +86,7 @@ DoD:
 
 ## B3: Release and tester delivery
 1. Configure Expo project credentials and EAS secrets.
-2. Wire CI dispatch for preview builds with release notes.
+2. Wire CI dispatch for preview builds with release notes. Status: release notes input/artifact and manifest digest traceability implemented; authenticated EAS trigger still waits for Expo/EAS credentials.
 3. Set distribution channels:
 - iOS TestFlight (internal group)
 - Android Internal Testing (Play)

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -21,7 +21,8 @@ From GitHub Actions:
 2. Run `workflow_dispatch` and set:
    - `build_profile` (`preview` for pilot by default),
    - `build_platform` (`all`/`ios`/`android`),
-   - `wait_for_build` (`false` for fast trigger, `true` for full wait mode).
+   - `wait_for_build` (`false` for fast trigger, `true` for full wait mode),
+   - `release_notes` for operator-facing clinic handoff notes.
 3. Verify `preflight` passes.
 4. Open workflow summary (`Mobile Release Readiness`) and confirm:
    - `Local checks` is `pass`,
@@ -44,6 +45,7 @@ npm run build:preview
 
 Workflow generates artifact `mobile-release-manifest` containing:
 - app version and package IDs,
+- release notes metadata (`present`, byte size, SHA-256, title) without embedding the full notes body,
 - iOS build number and Android versionCode,
 - icon/adaptive-icon paths, `expo-splash-screen` image path, SHA-256 fingerprints, byte sizes, PNG dimensions, and splash background/resize/width config,
 - runtime release metadata from `apps/field-mobile/src/config/releaseMetadata.ts` for app version, model ID, and capture schema version,
@@ -64,6 +66,12 @@ Workflow also generates artifact `mobile-release-readiness` containing:
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
 - manual release requirements for Apple Developer and Google Play accounts,
 - machine-readable `next_actions` for configuring missing GitHub secrets/variables and manual store-account handoff.
+
+Workflow also generates artifact `mobile-release-notes` containing:
+- git SHA/ref/run-id,
+- selected build profile/platform,
+- operator-facing release notes from workflow input or an explicit placeholder when not supplied,
+- required evidence reminders for manifest, readiness, EAS build links, and physical-device smoke logs.
 
 Manifest script:
 

--- a/scripts/build_mobile_release_manifest.py
+++ b/scripts/build_mobile_release_manifest.py
@@ -315,6 +315,41 @@ def _readiness_summary(readiness_json: Path | None) -> dict[str, Any]:
     }
 
 
+def _release_notes_summary(release_notes: Path | None) -> dict[str, Any]:
+    if release_notes is None:
+        return {
+            "source_path": None,
+            "present": False,
+            "bytes": 0,
+            "sha256": None,
+            "title": None,
+        }
+    if not release_notes.is_file():
+        return {
+            "source_path": str(release_notes),
+            "present": False,
+            "bytes": 0,
+            "sha256": None,
+            "title": None,
+        }
+
+    data = release_notes.read_bytes()
+    title = None
+    for line in release_notes.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            title = stripped.lstrip("#").strip() or None
+            break
+
+    return {
+        "source_path": str(release_notes),
+        "present": True,
+        "bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "title": title,
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Build mobile release manifest for pilot traceability."
@@ -322,6 +357,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--app-json", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--readiness-json", type=Path)
+    parser.add_argument("--release-notes", type=Path)
     parser.add_argument("--profile", default="preview")
     parser.add_argument("--channel", default="preview")
     parser.add_argument("--model-id", default="fusion-v0.1")
@@ -384,6 +420,7 @@ def main() -> int:
         "runtime_defaults": app_settings_defaults,
         "capture_contract": _capture_contract_evidence(args.app_json, app_runtime_config),
         "readiness": _readiness_summary(args.readiness_json),
+        "release_notes": _release_notes_summary(args.release_notes),
         "algorithm": {
             "model_id": args.model_id,
             "capture_schema_version": args.schema_version,

--- a/tests/test_mobile_build_workflow.py
+++ b/tests/test_mobile_build_workflow.py
@@ -24,6 +24,7 @@ def test_mobile_build_workflow_runs_for_release_script_changes() -> None:
 
     assert required_paths.issubset(set(triggers["push"]["paths"]))
     assert required_paths.issubset(set(triggers["pull_request"]["paths"]))
+    assert "release_notes" in triggers["workflow_dispatch"]["inputs"]
 
 
 def test_mobile_build_workflow_uploads_readiness_before_local_failure() -> None:
@@ -46,6 +47,23 @@ def test_mobile_build_workflow_embeds_readiness_summary_in_release_manifest() ->
     manifest_step = next(step for step in steps if step.get("name") == "Build release manifest")
 
     assert "--readiness-json /tmp/mobile-release-readiness.json" in manifest_step["run"]
+    assert "--release-notes /tmp/mobile-release-notes.md" in manifest_step["run"]
+
+
+def test_mobile_build_workflow_uploads_release_notes_artifact() -> None:
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = payload["jobs"]["preflight"]["steps"]
+    step_names = [step.get("name") for step in steps]
+
+    notes_index = step_names.index("Build release notes artifact")
+    manifest_index = step_names.index("Build release manifest")
+    upload_index = step_names.index("Upload release notes")
+    notes_upload_step = steps[upload_index]
+
+    assert notes_index < manifest_index < upload_index
+    assert "WORKFLOW_RELEASE_NOTES" in steps[notes_index]["env"]
+    assert notes_upload_step["with"]["name"] == "mobile-release-notes"
+    assert notes_upload_step["with"]["path"] == "/tmp/mobile-release-notes.md"
 
 
 def test_mobile_build_workflow_summary_reports_invalid_external_items() -> None:

--- a/tests/test_mobile_release_manifest_script.py
+++ b/tests/test_mobile_release_manifest_script.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
@@ -31,6 +32,7 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     app_json = tmp_path / "app.json"
     output = tmp_path / "manifest.json"
     readiness_json = tmp_path / "readiness.json"
+    release_notes = tmp_path / "mobile-release-notes.md"
     assets = tmp_path / "assets"
     metadata_path = tmp_path / "src" / "config" / "releaseMetadata.ts"
     app_config_path = tmp_path / "src" / "config" / "appConfig.ts"
@@ -201,6 +203,17 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
         ),
         encoding="utf-8",
     )
+    release_notes.write_text(
+        "\n".join(
+            [
+                "# Uroflow Field Mobile Release Notes",
+                "",
+                "Pilot operator note: verify offline queue before first subject.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
     script_path = Path("scripts/build_mobile_release_manifest.py")
     subprocess.run(
@@ -213,6 +226,8 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
             str(output),
             "--readiness-json",
             str(readiness_json),
+            "--release-notes",
+            str(release_notes),
             "--profile",
             "preview",
             "--channel",
@@ -313,6 +328,14 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
             "configure_eas_project_identity",
             "configure_clinical_hub_live_api",
         ],
+    }
+    release_notes_bytes = release_notes.read_bytes()
+    assert payload["release_notes"] == {
+        "source_path": str(release_notes),
+        "present": True,
+        "bytes": len(release_notes_bytes),
+        "sha256": hashlib.sha256(release_notes_bytes).hexdigest(),
+        "title": "Uroflow Field Mobile Release Notes",
     }
     serialized_manifest = json.dumps(payload)
     assert "secret-free evidence" not in serialized_manifest


### PR DESCRIPTION
## What changed

- Added a `release_notes` input to the `Mobile Build` workflow dispatch.
- Generate a `mobile-release-notes` artifact during preflight with git/run/profile/platform metadata, operator notes, and required evidence reminders.
- Pass the notes file into `build_mobile_release_manifest.py` and include digest metadata (`present`, bytes, SHA-256, title) in `mobile-release-manifest` without embedding the full notes body.
- Updated workflow/manifest tests and mobile release docs/README/backlog.

## Why

B3 calls for preview build CI dispatch with release notes. This makes release handoff traceable even while authenticated EAS/TestFlight/Play delivery remains blocked by external credentials.

## Validation

- `.venv/bin/ruff check scripts/build_mobile_release_manifest.py tests/test_mobile_release_manifest_script.py tests/test_mobile_build_workflow.py`
- `.venv/bin/pytest -q tests/test_mobile_release_manifest_script.py tests/test_mobile_build_workflow.py`
- local manifest smoke with `--release-notes`, verifying digest metadata
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (111 passed)
- `cd apps/field-mobile && npm run doctor` (21/21)
- `cd apps/field-mobile && npm run validate:ci` (rerun passed; first attempt hit a transient Expo package-check exit 7, then `expo-doctor` and full `validate:ci` both passed)

External blockers remain unchanged: Expo token, EAS project identity, Clinical Hub live API secrets, Apple Developer, Google Play.