### PR TITLE
Add mobile release bundle verifier

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -41,7 +41,9 @@ on:
       - "scripts/check_mobile_release_readiness.py"
       - "scripts/validate_mobile_device_smoke_log.py"
       - "scripts/validate_mobile_store_rollout_handoff.py"
+      - "scripts/verify_mobile_release_bundle.py"
       - "tests/test_mobile_device_smoke_log.py"
+      - "tests/test_mobile_release_bundle_verifier.py"
       - "tests/test_mobile_store_rollout_handoff.py"
       - ".github/workflows/mobile-build.yml"
   pull_request:
@@ -53,7 +55,9 @@ on:
       - "scripts/check_mobile_release_readiness.py"
       - "scripts/validate_mobile_device_smoke_log.py"
       - "scripts/validate_mobile_store_rollout_handoff.py"
+      - "scripts/verify_mobile_release_bundle.py"
       - "tests/test_mobile_device_smoke_log.py"
+      - "tests/test_mobile_release_bundle_verifier.py"
       - "tests/test_mobile_store_rollout_handoff.py"
       - ".github/workflows/mobile-build.yml"
 
@@ -214,6 +218,7 @@ jobs:
               "",
               "- Download `mobile-release-manifest`.",
               "- Download `mobile-release-readiness`.",
+              "- Download `mobile-release-bundle-verification`.",
               "- Download `mobile-store-rollout-handoff` and fill in TestFlight/Play evidence after external account setup.",
               "- Archive iOS/Android EAS build links when authenticated EAS build runs.",
               "- Archive physical-device smoke log with device model and OS version.",
@@ -304,6 +309,20 @@ jobs:
             /tmp/mobile-store-rollout-handoff.json \
             --output /tmp/mobile-store-rollout-handoff-summary.json
 
+      - name: Verify release artifact bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 ../../scripts/verify_mobile_release_bundle.py \
+            --manifest-json /tmp/mobile-release-manifest.json \
+            --readiness-json /tmp/mobile-release-readiness.json \
+            --release-notes /tmp/mobile-release-notes.md \
+            --store-rollout-handoff-json /tmp/mobile-store-rollout-handoff.json \
+            --store-rollout-summary-json /tmp/mobile-store-rollout-handoff-summary.json \
+            --expect-git-sha "$GITHUB_SHA" \
+            --expect-run-id "$GITHUB_RUN_ID" \
+            --output /tmp/mobile-release-bundle-verification.json
+
       - name: Upload release notes
         uses: actions/upload-artifact@v7
         with:
@@ -321,6 +340,12 @@ jobs:
         with:
           name: mobile-release-readiness
           path: /tmp/mobile-release-readiness.json
+
+      - name: Upload release bundle verification
+        uses: actions/upload-artifact@v7
+        with:
+          name: mobile-release-bundle-verification
+          path: /tmp/mobile-release-bundle-verification.json
 
       - name: Upload store rollout handoff
         uses: actions/upload-artifact@v7

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -127,6 +127,7 @@ CI:
   - `mobile-release-manifest` (version + runtime release metadata/config + release notes digest + capture contract feature-manifest evidence + readiness gate summary + git SHA + model/schema traceability)
   - `mobile-release-readiness` (git traceability + local readiness checks + explicit external credential blockers)
   - `mobile-release-notes` (operator-facing release notes and required evidence reminders)
+  - `mobile-release-bundle-verification` (manifest/readiness/notes/store-handoff digest and traceability consistency summary)
   - `mobile-store-rollout-handoff` (per-run TestFlight/Play Internal handoff template + validation summary with current external blockers)
   - `mobile-eas-build-result-<run_id>` (raw EAS JSON response for build IDs/URLs)
 - Workflow summary includes release readiness status and direct EAS build links for operator/release use.
@@ -141,7 +142,7 @@ secret blockers. The artifact has separate machine-readable gates:
   privacy-by-default switches, single-region data residency policy,
   runtime motion quality gates, derivatives-only feature/media
   manifest gates, pending sync connectivity-restore trigger, device-smoke evidence template/validator,
-  store rollout handoff template/validator,
+  store rollout handoff template/validator, release bundle verifier,
   API response + submit exception + runtime exception PHI redaction, and non-localhost API URL defaults,
   store privacy declarations,
   launch/icon assets, dependency lock alignment, and unit-test evidence that can be verified
@@ -192,3 +193,4 @@ Detailed release SOP:
 - `docs/mobile-release-runbook-v0.1.md`
 - `docs/mobile-install-and-field-test-runbook-v0.1.md`
 - `docs/mobile-store-rollout-handoff-template-v0.1.json`
+- `scripts/verify_mobile_release_bundle.py`

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -20,6 +20,7 @@ Implemented now:
 - Mobile Build release notes artifact and manifest traceability for operator-facing build handoff.
 - Physical-device smoke evidence JSON template and validator for iOS+Android release handoff.
 - Store rollout handoff JSON template, validator, and Mobile Build artifact for TestFlight/Play Internal traceability.
+- Mobile release bundle verifier for manifest/readiness/notes/store-handoff artifact consistency.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -60,7 +60,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
@@ -78,6 +78,12 @@ Workflow also generates artifact `mobile-store-rollout-handoff` containing:
 - iOS TestFlight internal handoff checklist and current external blockers,
 - Android Play Internal Testing handoff checklist and current external blockers,
 - validation summary from `scripts/validate_mobile_store_rollout_handoff.py`.
+
+Workflow also generates artifact `mobile-release-bundle-verification` containing:
+- git/run traceability shared by manifest, readiness, and store rollout handoff,
+- SHA-256 fingerprints for manifest, readiness, release notes, store rollout handoff, and store rollout summary,
+- consistency checks proving the manifest readiness summary matches raw readiness JSON,
+- digest checks proving the store rollout handoff references the exact manifest/readiness/notes files from the same run.
 
 Manifest script:
 
@@ -118,6 +124,18 @@ cp docs/mobile-store-rollout-handoff-template-v0.1.json /tmp/mobile-store-rollou
 python3 scripts/validate_mobile_store_rollout_handoff.py \
   /tmp/mobile-store-rollout-handoff.json \
   --output /tmp/mobile-store-rollout-summary.json
+```
+
+Release bundle verification:
+
+```bash
+python3 scripts/verify_mobile_release_bundle.py \
+  --manifest-json /tmp/mobile-release-manifest.json \
+  --readiness-json /tmp/mobile-release-readiness.json \
+  --release-notes /tmp/mobile-release-notes.md \
+  --store-rollout-handoff-json /tmp/mobile-store-rollout-handoff.json \
+  --store-rollout-summary-json /tmp/mobile-store-rollout-summary.json \
+  --output /tmp/mobile-release-bundle-verification.json
 ```
 
 External handoff commands, using placeholders only:
@@ -171,10 +189,11 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 
 1. Mobile release manifest JSON.
 2. Mobile release readiness JSON.
-3. Mobile store rollout handoff JSON and validation summary.
-4. Build links (iOS + Android).
-5. Smoke test log with device model and OS version.
-6. Validated smoke summary JSON from `scripts/validate_mobile_device_smoke_log.py`.
-7. Clinical Hub sample export (paired + capture package rows).
+3. Mobile release bundle verification JSON.
+4. Mobile store rollout handoff JSON and validation summary.
+5. Build links (iOS + Android).
+6. Smoke test log with device model and OS version.
+7. Validated smoke summary JSON from `scripts/validate_mobile_device_smoke_log.py`.
+8. Clinical Hub sample export (paired + capture package rows).
    - For `capture-packages`, archive `capture_payload.feature_manifest` and confirm `derivatives_only=true`, `raw_media.store_raw_video=false`, `raw_media.store_raw_audio=false`, `raw_media.upload_raw_video=false`, and `raw_media.upload_raw_audio=false`.
-8. Go/No-Go note for pilot usage.
+9. Go/No-Go note for pilot usage.

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -774,6 +774,12 @@ def build_readiness_report(
     mobile_store_rollout_validator_tests_path = (
         repo_root / "tests" / "test_mobile_store_rollout_handoff.py"
     )
+    mobile_release_bundle_verifier_path = (
+        repo_root / "scripts" / "verify_mobile_release_bundle.py"
+    )
+    mobile_release_bundle_verifier_tests_path = (
+        repo_root / "tests" / "test_mobile_release_bundle_verifier.py"
+    )
     paired_payload_tests_path = mobile_root / "tests" / "pairedPayload.test.js"
     roi_signal_tests_path = mobile_root / "tests" / "roiSignalEstimator.test.js"
     runtime_metrics_source_path = mobile_root / "src" / "capture" / "runtimeMetrics.ts"
@@ -817,6 +823,12 @@ def build_readiness_report(
     )
     mobile_store_rollout_validator_tests_source = _read_file_text(
         mobile_store_rollout_validator_tests_path
+    )
+    mobile_release_bundle_verifier_source = _read_file_text(
+        mobile_release_bundle_verifier_path
+    )
+    mobile_release_bundle_verifier_tests_source = _read_file_text(
+        mobile_release_bundle_verifier_tests_path
     )
     _check(
         checks,
@@ -1111,6 +1123,38 @@ def build_readiness_report(
         "mobile_store_rollout_handoff_validator_unit_tests_present",
         all(mobile_store_rollout_validator_test_requirements.values()),
         f"requirements={mobile_store_rollout_validator_test_requirements!r}",
+    )
+    mobile_release_bundle_verifier_requirements = {
+        "verifier_file": mobile_release_bundle_verifier_path.is_file(),
+        "traceability_validation": "TRACEABILITY_FIELDS"
+        in mobile_release_bundle_verifier_source,
+        "readiness_count_validation": "local_check_counts"
+        in mobile_release_bundle_verifier_source,
+        "store_handoff_digest_validation": "mobile_release_manifest_sha256"
+        in mobile_release_bundle_verifier_source,
+        "expected_run_validation": "expect_run_id" in mobile_release_bundle_verifier_source,
+    }
+    _check(
+        checks,
+        "mobile_release_bundle_verifier_sources",
+        all(mobile_release_bundle_verifier_requirements.values()),
+        f"requirements={mobile_release_bundle_verifier_requirements!r}",
+    )
+    mobile_release_bundle_verifier_test_requirements = {
+        "valid_bundle_test": "test_mobile_release_bundle_verifier_accepts_consistent_bundle"
+        in mobile_release_bundle_verifier_tests_source,
+        "handoff_digest_mismatch_test": "rejects_handoff_digest_mismatch"
+        in mobile_release_bundle_verifier_tests_source,
+        "readiness_count_mismatch_test": "rejects_readiness_count_mismatch"
+        in mobile_release_bundle_verifier_tests_source,
+        "expected_git_sha_mismatch_test": "rejects_expected_git_sha_mismatch"
+        in mobile_release_bundle_verifier_tests_source,
+    }
+    _check(
+        checks,
+        "mobile_release_bundle_verifier_unit_tests_present",
+        all(mobile_release_bundle_verifier_test_requirements.values()),
+        f"requirements={mobile_release_bundle_verifier_test_requirements!r}",
     )
     _check(
         checks,

--- a/scripts/verify_mobile_release_bundle.py
+++ b/scripts/verify_mobile_release_bundle.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+TRACEABILITY_FIELDS = ("git_sha", "git_ref", "git_run_id", "workflow")
+READINESS_SUMMARY_FIELDS = (
+    "status",
+    "local_checks_status",
+    "external_readiness_status",
+    "authenticated_eas_status",
+    "clinical_hub_live_api_status",
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _local_check_counts(readiness: dict[str, Any]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for check in _as_list(readiness.get("local_checks")):
+        if isinstance(check, dict):
+            counts[str(check.get("status", "unknown"))] += 1
+    return dict(counts)
+
+
+def _failed_local_checks(readiness: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    for check in _as_list(readiness.get("local_checks")):
+        if not isinstance(check, dict):
+            continue
+        check_id = check.get("id")
+        if isinstance(check_id, str) and check.get("status") != "pass":
+            failures.append(check_id)
+    return failures
+
+
+def _warning_local_checks(readiness: dict[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    for check in _as_list(readiness.get("local_checks")):
+        if not isinstance(check, dict):
+            continue
+        check_id = check.get("id")
+        if isinstance(check_id, str) and check.get("severity") == "warning":
+            warnings.append(check_id)
+    return warnings
+
+
+def _item_statuses(items: Any) -> list[dict[str, str]]:
+    result: list[dict[str, str]] = []
+    for item in _as_list(items):
+        if not isinstance(item, dict):
+            continue
+        item_id = item.get("id")
+        status = item.get("status")
+        if isinstance(item_id, str) and isinstance(status, str):
+            result.append({"id": item_id, "status": status})
+    return result
+
+
+def _next_action_ids(readiness: dict[str, Any]) -> list[str]:
+    return [
+        item["id"]
+        for item in _as_list(readiness.get("next_actions"))
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    ]
+
+
+def _compare_field(
+    errors: list[str], prefix: str, field: str, actual: Any, expected: Any
+) -> None:
+    if actual != expected:
+        errors.append(f"{prefix}.{field} mismatch: actual={actual!r}, expected={expected!r}")
+
+
+def _validate_traceability(
+    manifest: dict[str, Any],
+    readiness: dict[str, Any],
+    handoff: dict[str, Any],
+    errors: list[str],
+    *,
+    expect_git_sha: str | None,
+    expect_run_id: str | None,
+) -> dict[str, Any]:
+    manifest_traceability = _as_dict(manifest.get("traceability"))
+    readiness_traceability = _as_dict(readiness.get("traceability"))
+    handoff_release = _as_dict(handoff.get("release"))
+
+    for field in TRACEABILITY_FIELDS:
+        _compare_field(
+            errors,
+            "traceability",
+            field,
+            manifest_traceability.get(field),
+            readiness_traceability.get(field),
+        )
+
+    _compare_field(
+        errors,
+        "store_rollout_handoff.release",
+        "git_sha",
+        handoff_release.get("git_sha"),
+        manifest_traceability.get("git_sha"),
+    )
+
+    if expect_git_sha:
+        _compare_field(
+            errors,
+            "expected",
+            "git_sha",
+            manifest_traceability.get("git_sha"),
+            expect_git_sha,
+        )
+    if expect_run_id:
+        _compare_field(
+            errors,
+            "expected",
+            "git_run_id",
+            manifest_traceability.get("git_run_id"),
+            expect_run_id,
+        )
+
+    return manifest_traceability
+
+
+def _validate_manifest_readiness_summary(
+    manifest: dict[str, Any], readiness: dict[str, Any], errors: list[str]
+) -> None:
+    manifest_readiness = _as_dict(manifest.get("readiness"))
+    for field in READINESS_SUMMARY_FIELDS:
+        _compare_field(
+            errors,
+            "manifest.readiness",
+            field,
+            manifest_readiness.get(field),
+            readiness.get(field),
+        )
+
+    _compare_field(
+        errors,
+        "manifest.readiness",
+        "authenticated_eas_blockers",
+        manifest_readiness.get("authenticated_eas_blockers"),
+        readiness.get("authenticated_eas_blockers", []),
+    )
+    _compare_field(
+        errors,
+        "manifest.readiness",
+        "local_check_counts",
+        manifest_readiness.get("local_check_counts"),
+        _local_check_counts(readiness),
+    )
+    _compare_field(
+        errors,
+        "manifest.readiness",
+        "failed_local_checks",
+        manifest_readiness.get("failed_local_checks"),
+        _failed_local_checks(readiness),
+    )
+    _compare_field(
+        errors,
+        "manifest.readiness",
+        "warning_local_checks",
+        manifest_readiness.get("warning_local_checks"),
+        _warning_local_checks(readiness),
+    )
+    _compare_field(
+        errors,
+        "manifest.readiness",
+        "external_items",
+        manifest_readiness.get("external_items"),
+        _item_statuses(readiness.get("external_items")),
+    )
+    _compare_field(
+        errors,
+        "manifest.readiness",
+        "manual_external_items",
+        manifest_readiness.get("manual_external_items"),
+        _item_statuses(readiness.get("manual_external_items")),
+    )
+    _compare_field(
+        errors,
+        "manifest.readiness",
+        "next_action_ids",
+        manifest_readiness.get("next_action_ids"),
+        _next_action_ids(readiness),
+    )
+
+    if readiness.get("local_checks_status") != "pass":
+        errors.append("readiness.local_checks_status must be 'pass'")
+    if _failed_local_checks(readiness):
+        errors.append("readiness.local_checks must not contain failed checks")
+
+
+def _validate_release_notes(
+    manifest: dict[str, Any], release_notes: Path, errors: list[str]
+) -> str:
+    release_notes_summary = _as_dict(manifest.get("release_notes"))
+    actual_sha = _sha256_file(release_notes)
+    _compare_field(
+        errors,
+        "manifest.release_notes",
+        "sha256",
+        release_notes_summary.get("sha256"),
+        actual_sha,
+    )
+    _compare_field(
+        errors,
+        "manifest.release_notes",
+        "bytes",
+        release_notes_summary.get("bytes"),
+        release_notes.stat().st_size,
+    )
+    if release_notes_summary.get("present") is not True:
+        errors.append("manifest.release_notes.present must be true")
+    return actual_sha
+
+
+def _validate_store_rollout_handoff(
+    manifest: dict[str, Any],
+    readiness: Path,
+    manifest_path: Path,
+    release_notes_sha: str,
+    handoff: dict[str, Any],
+    handoff_summary: dict[str, Any],
+    errors: list[str],
+) -> None:
+    handoff_release = _as_dict(handoff.get("release"))
+    release = _as_dict(manifest.get("release"))
+    _compare_field(
+        errors,
+        "store_rollout_handoff.release",
+        "build_profile",
+        handoff_release.get("build_profile"),
+        release.get("profile"),
+    )
+    _compare_field(
+        errors,
+        "store_rollout_handoff.release",
+        "build_channel",
+        handoff_release.get("build_channel"),
+        release.get("channel"),
+    )
+    _compare_field(
+        errors,
+        "store_rollout_handoff.release",
+        "mobile_release_manifest_sha256",
+        handoff_release.get("mobile_release_manifest_sha256"),
+        _sha256_file(manifest_path),
+    )
+    _compare_field(
+        errors,
+        "store_rollout_handoff.release",
+        "mobile_release_readiness_sha256",
+        handoff_release.get("mobile_release_readiness_sha256"),
+        _sha256_file(readiness),
+    )
+    _compare_field(
+        errors,
+        "store_rollout_handoff.release",
+        "mobile_release_notes_sha256",
+        handoff_release.get("mobile_release_notes_sha256"),
+        release_notes_sha,
+    )
+
+    if handoff_summary.get("status") != "pass":
+        errors.append("store_rollout_handoff.summary.status must be 'pass'")
+    if sorted(handoff_summary.get("required_channels", [])) != [
+        "android:play_internal_testing",
+        "ios:testflight_internal",
+    ]:
+        errors.append("store_rollout_handoff.summary.required_channels mismatch")
+
+
+def verify_release_bundle(
+    *,
+    manifest_json: Path,
+    readiness_json: Path,
+    release_notes: Path,
+    store_rollout_handoff_json: Path,
+    store_rollout_summary_json: Path,
+    expect_git_sha: str | None = None,
+    expect_run_id: str | None = None,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    manifest = _load_json(manifest_json)
+    readiness = _load_json(readiness_json)
+    handoff = _load_json(store_rollout_handoff_json)
+    handoff_summary = _load_json(store_rollout_summary_json)
+
+    traceability = _validate_traceability(
+        manifest,
+        readiness,
+        handoff,
+        errors,
+        expect_git_sha=expect_git_sha,
+        expect_run_id=expect_run_id,
+    )
+    _validate_manifest_readiness_summary(manifest, readiness, errors)
+    release_notes_sha = _validate_release_notes(manifest, release_notes, errors)
+    _validate_store_rollout_handoff(
+        manifest,
+        readiness_json,
+        manifest_json,
+        release_notes_sha,
+        handoff,
+        handoff_summary,
+        errors,
+    )
+
+    return {
+        "status": "fail" if errors else "pass",
+        "traceability": traceability,
+        "readiness_status": readiness.get("status"),
+        "local_check_counts": _local_check_counts(readiness),
+        "external_readiness_status": readiness.get("external_readiness_status"),
+        "store_rollout_status": handoff_summary.get("rollout_status"),
+        "store_rollout_blocked_channels": handoff_summary.get("blocked_channels", []),
+        "artifact_sha256": {
+            "mobile_release_manifest": _sha256_file(manifest_json),
+            "mobile_release_readiness": _sha256_file(readiness_json),
+            "mobile_release_notes": release_notes_sha,
+            "mobile_store_rollout_handoff": _sha256_file(store_rollout_handoff_json),
+            "mobile_store_rollout_handoff_summary": _sha256_file(
+                store_rollout_summary_json
+            ),
+        },
+        "errors": errors,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify Mobile Build release artifacts belong to one coherent bundle."
+    )
+    parser.add_argument("--manifest-json", type=Path, required=True)
+    parser.add_argument("--readiness-json", type=Path, required=True)
+    parser.add_argument("--release-notes", type=Path, required=True)
+    parser.add_argument("--store-rollout-handoff-json", type=Path, required=True)
+    parser.add_argument("--store-rollout-summary-json", type=Path, required=True)
+    parser.add_argument("--expect-git-sha")
+    parser.add_argument("--expect-run-id")
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    summary = verify_release_bundle(
+        manifest_json=args.manifest_json,
+        readiness_json=args.readiness_json,
+        release_notes=args.release_notes,
+        store_rollout_handoff_json=args.store_rollout_handoff_json,
+        store_rollout_summary_json=args.store_rollout_summary_json,
+        expect_git_sha=args.expect_git_sha,
+        expect_run_id=args.expect_run_id,
+    )
+    encoded = json.dumps(summary, ensure_ascii=False, indent=2)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded + "\n", encoding="utf-8")
+    print(encoded)
+    return 0 if summary["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mobile_release_bundle_verifier.py
+++ b/tests/test_mobile_release_bundle_verifier.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path("scripts/verify_mobile_release_bundle.py")
+GIT_SHA = "599254d39fd45be81d512f6a99744ed0f1e3b39d"
+RUN_ID = "27038378926"
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
+    notes_path = tmp_path / "mobile-release-notes.md"
+    notes_path.write_text(
+        "# Uroflow Field Mobile Release Notes\n\nBundle verifier test notes.\n",
+        encoding="utf-8",
+    )
+
+    readiness = {
+        "status": "ready_except_external_credentials",
+        "local_checks_status": "pass",
+        "external_readiness_status": "blocked",
+        "authenticated_eas_status": "blocked",
+        "authenticated_eas_blockers": ["expo_token", "eas_project_identity"],
+        "clinical_hub_live_api_status": "missing",
+        "traceability": {
+            "git_sha": GIT_SHA,
+            "git_ref": "refs/heads/main",
+            "git_run_id": RUN_ID,
+            "workflow": "Mobile Build",
+        },
+        "local_checks": [
+            {"id": "mobile_store_rollout_handoff_template_present", "status": "pass"},
+            {
+                "id": "android_runtime_permissions_minimal",
+                "status": "pass",
+                "severity": "warning",
+            },
+        ],
+        "external_items": [
+            {"id": "expo_token", "status": "missing"},
+            {"id": "eas_project_identity", "status": "missing"},
+            {"id": "clinical_hub_live_api", "status": "missing"},
+        ],
+        "manual_external_items": [
+            {"id": "apple_developer_account", "status": "manual_required"},
+            {"id": "google_play_account", "status": "manual_required"},
+        ],
+        "next_actions": [
+            {"id": "configure_expo_token"},
+            {"id": "configure_eas_project_identity"},
+        ],
+    }
+    readiness_path = tmp_path / "mobile-release-readiness.json"
+    _write_json(readiness_path, readiness)
+
+    manifest = {
+        "release": {"profile": "preview", "channel": "preview"},
+        "traceability": copy.deepcopy(readiness["traceability"]),
+        "readiness": {
+            "status": readiness["status"],
+            "local_checks_status": readiness["local_checks_status"],
+            "external_readiness_status": readiness["external_readiness_status"],
+            "authenticated_eas_status": readiness["authenticated_eas_status"],
+            "authenticated_eas_blockers": readiness["authenticated_eas_blockers"],
+            "clinical_hub_live_api_status": readiness["clinical_hub_live_api_status"],
+            "local_check_counts": {"pass": 2},
+            "failed_local_checks": [],
+            "warning_local_checks": ["android_runtime_permissions_minimal"],
+            "external_items": [
+                {"id": "expo_token", "status": "missing"},
+                {"id": "eas_project_identity", "status": "missing"},
+                {"id": "clinical_hub_live_api", "status": "missing"},
+            ],
+            "manual_external_items": [
+                {"id": "apple_developer_account", "status": "manual_required"},
+                {"id": "google_play_account", "status": "manual_required"},
+            ],
+            "next_action_ids": [
+                "configure_expo_token",
+                "configure_eas_project_identity",
+            ],
+        },
+        "release_notes": {
+            "present": True,
+            "bytes": notes_path.stat().st_size,
+            "sha256": _sha256(notes_path),
+            "title": "Uroflow Field Mobile Release Notes",
+        },
+    }
+    manifest_path = tmp_path / "mobile-release-manifest.json"
+    _write_json(manifest_path, manifest)
+
+    handoff = {
+        "release": {
+            "git_sha": GIT_SHA,
+            "build_profile": "preview",
+            "build_channel": "preview",
+            "mobile_release_manifest_sha256": _sha256(manifest_path),
+            "mobile_release_readiness_sha256": _sha256(readiness_path),
+            "mobile_release_notes_sha256": _sha256(notes_path),
+        }
+    }
+    handoff_path = tmp_path / "mobile-store-rollout-handoff.json"
+    _write_json(handoff_path, handoff)
+
+    handoff_summary = {
+        "status": "pass",
+        "rollout_status": "blocked_external",
+        "blocked_channels": [
+            "android:play_internal_testing",
+            "ios:testflight_internal",
+        ],
+        "required_channels": [
+            "android:play_internal_testing",
+            "ios:testflight_internal",
+        ],
+    }
+    handoff_summary_path = tmp_path / "mobile-store-rollout-handoff-summary.json"
+    _write_json(handoff_summary_path, handoff_summary)
+
+    return {
+        "manifest": manifest_path,
+        "readiness": readiness_path,
+        "notes": notes_path,
+        "handoff": handoff_path,
+        "handoff_summary": handoff_summary_path,
+    }
+
+
+def _run_verifier(
+    paths: dict[str, Path],
+    *,
+    check: bool = True,
+    expect_git_sha: str | None = GIT_SHA,
+    expect_run_id: str | None = RUN_ID,
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        sys.executable,
+        str(SCRIPT),
+        "--manifest-json",
+        str(paths["manifest"]),
+        "--readiness-json",
+        str(paths["readiness"]),
+        "--release-notes",
+        str(paths["notes"]),
+        "--store-rollout-handoff-json",
+        str(paths["handoff"]),
+        "--store-rollout-summary-json",
+        str(paths["handoff_summary"]),
+        "--output",
+        str(paths["manifest"].parent / "bundle-summary.json"),
+    ]
+    if expect_git_sha is not None:
+        command.extend(["--expect-git-sha", expect_git_sha])
+    if expect_run_id is not None:
+        command.extend(["--expect-run-id", expect_run_id])
+    return subprocess.run(command, check=check, text=True, capture_output=True)
+
+
+def test_mobile_release_bundle_verifier_accepts_consistent_bundle(tmp_path: Path) -> None:
+    paths = _valid_bundle(tmp_path)
+
+    result = _run_verifier(paths)
+    summary = json.loads(result.stdout)
+
+    assert summary["status"] == "pass"
+    assert summary["traceability"]["git_sha"] == GIT_SHA
+    assert summary["local_check_counts"] == {"pass": 2}
+    assert summary["store_rollout_status"] == "blocked_external"
+    assert summary["store_rollout_blocked_channels"] == [
+        "android:play_internal_testing",
+        "ios:testflight_internal",
+    ]
+    assert json.loads((tmp_path / "bundle-summary.json").read_text()) == summary
+
+
+def test_mobile_release_bundle_verifier_rejects_handoff_digest_mismatch(
+    tmp_path: Path,
+) -> None:
+    paths = _valid_bundle(tmp_path)
+    handoff = json.loads(paths["handoff"].read_text(encoding="utf-8"))
+    handoff["release"]["mobile_release_manifest_sha256"] = "0" * 64
+    _write_json(paths["handoff"], handoff)
+
+    result = _run_verifier(paths, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert any("mobile_release_manifest_sha256 mismatch" in error for error in summary["errors"])
+
+
+def test_mobile_release_bundle_verifier_rejects_readiness_count_mismatch(
+    tmp_path: Path,
+) -> None:
+    paths = _valid_bundle(tmp_path)
+    manifest = json.loads(paths["manifest"].read_text(encoding="utf-8"))
+    manifest["readiness"]["local_check_counts"] = {"pass": 1}
+    _write_json(paths["manifest"], manifest)
+
+    result = _run_verifier(paths, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert any("local_check_counts mismatch" in error for error in summary["errors"])
+
+
+def test_mobile_release_bundle_verifier_rejects_expected_git_sha_mismatch(
+    tmp_path: Path,
+) -> None:
+    paths = _valid_bundle(tmp_path)
+
+    result = _run_verifier(paths, check=False, expect_git_sha="bad-sha")
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert any("expected.git_sha mismatch" in error for error in summary["errors"])

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -122,6 +122,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "mobile_device_smoke_log_template_present",
         "mobile_device_smoke_log_validator_sources",
         "mobile_device_smoke_log_validator_unit_tests_present",
+        "mobile_release_bundle_verifier_sources",
+        "mobile_release_bundle_verifier_unit_tests_present",
         "mobile_store_rollout_handoff_template_present",
         "mobile_store_rollout_handoff_validator_sources",
         "mobile_store_rollout_handoff_validator_unit_tests_present",


### PR DESCRIPTION
## Summary
- add a Mobile Build release-bundle verifier for manifest/readiness/notes/store-handoff consistency
- upload mobile-release-bundle-verification from the Mobile Build workflow
- add readiness gates and docs for verifier coverage

## Validation
- scripts/verify_mobile_release_bundle.py --manifest-json /tmp/mobile-build-27038378926/mobile-release-manifest/mobile-release-manifest.json --readiness-json /tmp/mobile-build-27038378926/mobile-release-readiness/mobile-release-readiness.json --release-notes /tmp/mobile-build-27038378926/mobile-release-notes/mobile-release-notes.md --store-rollout-handoff-json /tmp/mobile-build-27038378926/mobile-store-rollout-handoff/mobile-store-rollout-handoff.json --store-rollout-summary-json /tmp/mobile-build-27038378926/mobile-store-rollout-handoff/mobile-store-rollout-handoff-summary.json --expect-git-sha 599254d39fd45be81d512f6a99744ed0f1e3b39d --expect-run-id 27038378926 --output /tmp/mobile-release-bundle-verification-27038378926.json
- python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-bundle-verifier.json
- .venv/bin/ruff check .
- .venv/bin/pytest -q
- cd apps/field-mobile && npm run validate:ci