### PR TITLE
Add in-app mobile release identity

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -39,6 +39,7 @@ import { ApiConnectionSection } from "./src/components/ApiConnectionSection";
 import { MeasurementFormSection } from "./src/components/MeasurementFormSection";
 import { ResponseAndSummarySection } from "./src/components/ResponseAndSummarySection";
 import { RuntimeCaptureSection } from "./src/components/RuntimeCaptureSection";
+import { ReleaseIdentitySection } from "./src/components/ReleaseIdentitySection";
 import { styles } from "./src/styles/appStyles";
 import { usePendingSyncQueue } from "./src/hooks/usePendingSyncQueue";
 import { buildCapturePackagePayloadFromPaired } from "./src/payload/capturePackagePayload";
@@ -802,6 +803,13 @@ export default function App() {
           Capture contract auto-upload enabled: runtime audio/IMU samples are preferred, scaffold is
           fallback.
         </Text>
+
+        <ReleaseIdentitySection
+          appModelId={appModelId}
+          appVersion={appVersion}
+          captureMode={captureMode}
+          platform={platform}
+        />
 
         <ApiConnectionSection
           apiBaseUrl={apiBaseUrl}

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -26,6 +26,7 @@ Cross-platform mobile client (Expo React Native) for collecting paired measureme
 - `API Key` stored in device secure storage (`expo-secure-store`) with AsyncStorage fallback
 - On successful paired upload, app posts `capture_contract_json` to `POST /api/v1/capture-packages`
 - Runtime capture mode collects live audio + IMU samples (camera permission used for ROI validity flag)
+- In-app `Release Identity` panel shows canonical app version, model/schema, runtime config, privacy/data-residency flags, platform, and payload traceability alignment.
 - If runtime capture was not started, app falls back to scaffold contract payload
 - `Stop Capture` auto-fills app metrics (`Qmax/Qavg/Vvoid/FlowTime/TQmax`) and quality status/score from runtime-derived proxies
 - Runtime block shows `roi_valid_ratio` and `low_confidence_ratio` quality flags
@@ -140,6 +141,7 @@ secret blockers. The artifact has separate machine-readable gates:
 - `local_checks_status`: local app metadata, runtime release metadata, EAS profile shape,
   runtime config/defaults such as Clinical Hub v1 endpoint set, disabled debug gates,
   privacy-by-default switches, single-region data residency policy,
+  in-app release identity evidence,
   runtime motion quality gates, derivatives-only feature/media
   manifest gates, pending sync connectivity-restore trigger, device-smoke evidence template/validator,
   store rollout handoff template/validator, release bundle verifier,

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -8,6 +8,7 @@ rm -rf "$BUILD_DIR"
 tsc --ignoreConfig \
   src/utils/appHelpers.ts \
   src/utils/pendingSyncQueue.ts \
+  src/utils/releaseIdentity.ts \
   src/utils/submitOutcome.ts \
   src/config/appConfig.ts \
   src/config/releaseMetadata.ts \

--- a/apps/field-mobile/src/components/ReleaseIdentitySection.tsx
+++ b/apps/field-mobile/src/components/ReleaseIdentitySection.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Text, View } from "react-native";
+
+import { styles } from "../styles/appStyles";
+import { buildReleaseIdentitySnapshot } from "../utils/releaseIdentity";
+
+type ReleaseIdentitySectionProps = {
+  appVersion: string;
+  appModelId: string;
+  captureMode: string;
+  platform: string;
+};
+
+export function ReleaseIdentitySection({
+  appVersion,
+  appModelId,
+  captureMode,
+  platform,
+}: ReleaseIdentitySectionProps) {
+  const snapshot = buildReleaseIdentitySnapshot({
+    platform,
+    payloadAppVersion: appVersion,
+    payloadModelId: appModelId,
+    payloadCaptureMode: captureMode,
+  });
+  const statusStyle =
+    snapshot.payloadStatus === "aligned"
+      ? styles.releaseIdentityGoodText
+      : styles.releaseIdentityWarningText;
+
+  return (
+    <View style={styles.releaseIdentityBox}>
+      <Text style={styles.sectionTitle}>Release Identity</Text>
+      {snapshot.canonicalRows.map((row) => (
+        <Text key={row.label} style={styles.releaseIdentityText}>
+          {row.label}: {row.value}
+        </Text>
+      ))}
+      <Text style={[styles.releaseIdentityText, statusStyle]}>
+        Payload traceability: {snapshot.payloadStatus}
+      </Text>
+      <Text style={styles.releaseIdentityText}>{snapshot.payloadEvidence}</Text>
+      <Text style={styles.helperText}>{snapshot.artifactTraceabilityNote}</Text>
+    </View>
+  );
+}

--- a/apps/field-mobile/src/styles/appStyles.ts
+++ b/apps/field-mobile/src/styles/appStyles.ts
@@ -24,6 +24,27 @@ export const styles = StyleSheet.create({
     fontSize: 12,
     color: "#334155",
   },
+  releaseIdentityBox: {
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: "#cbd5e1",
+    backgroundColor: "#ffffff",
+    borderRadius: 10,
+    padding: 10,
+  },
+  releaseIdentityText: {
+    color: "#0f172a",
+    fontSize: 12,
+    marginBottom: 4,
+  },
+  releaseIdentityGoodText: {
+    color: "#166534",
+    fontWeight: "700",
+  },
+  releaseIdentityWarningText: {
+    color: "#b45309",
+    fontWeight: "700",
+  },
   sectionTitle: {
     marginTop: 14,
     marginBottom: 8,

--- a/apps/field-mobile/src/utils/releaseIdentity.ts
+++ b/apps/field-mobile/src/utils/releaseIdentity.ts
@@ -1,0 +1,90 @@
+import { APP_RUNTIME_CONFIG } from "../config/appConfig";
+import { APP_RELEASE_METADATA } from "../config/releaseMetadata";
+
+export type ReleaseIdentityRow = {
+  label: string;
+  value: string;
+};
+
+export type ReleaseIdentityStatus = "aligned" | "edited";
+
+export type ReleaseIdentitySnapshot = {
+  platform: string;
+  canonicalRows: ReleaseIdentityRow[];
+  payloadStatus: ReleaseIdentityStatus;
+  payloadEvidence: string;
+  artifactTraceabilityNote: string;
+};
+
+type BuildReleaseIdentitySnapshotOptions = {
+  platform?: string;
+  payloadAppVersion: string;
+  payloadModelId: string;
+  payloadCaptureMode: string;
+};
+
+function formatFlag(value: boolean): string {
+  return value ? "on" : "off";
+}
+
+function normalize(value: string): string {
+  return value.trim();
+}
+
+export function buildReleaseIdentitySnapshot(
+  options: BuildReleaseIdentitySnapshotOptions,
+): ReleaseIdentitySnapshot {
+  const platform = options.platform?.trim() || "unknown";
+  const payloadAppVersion = normalize(options.payloadAppVersion);
+  const payloadModelId = normalize(options.payloadModelId);
+  const payloadCaptureMode = normalize(options.payloadCaptureMode);
+  const privacy = APP_RUNTIME_CONFIG.privacyPolicy;
+  const residency = APP_RUNTIME_CONFIG.dataResidencyPolicy;
+  const debug = APP_RUNTIME_CONFIG.debugGates;
+  const payloadAligned =
+    payloadAppVersion === APP_RELEASE_METADATA.appVersion &&
+    payloadModelId === APP_RELEASE_METADATA.modelId &&
+    payloadCaptureMode === APP_RUNTIME_CONFIG.defaultCaptureMode;
+
+  return {
+    platform,
+    canonicalRows: [
+      { label: "App version", value: APP_RELEASE_METADATA.appVersion },
+      { label: "Model ID", value: APP_RELEASE_METADATA.modelId },
+      { label: "Capture schema", value: APP_RELEASE_METADATA.captureSchemaVersion },
+      { label: "Runtime mode", value: APP_RUNTIME_CONFIG.runtimeMode },
+      { label: "Endpoint set", value: APP_RUNTIME_CONFIG.endpointSet },
+      { label: "Default capture mode", value: APP_RUNTIME_CONFIG.defaultCaptureMode },
+      {
+        label: "Privacy",
+        value: `raw video ${formatFlag(privacy.storeRawVideo)}, raw audio ${formatFlag(
+          privacy.storeRawAudio,
+        )}, ROI-only ${formatFlag(privacy.roiOnly)}`,
+      },
+      {
+        label: "Data residency",
+        value: `${residency.region}/${residency.boundary}, cross-region sync ${formatFlag(
+          residency.allowCrossRegionSync,
+        )}`,
+      },
+      {
+        label: "Debug gates",
+        value: `debug controls ${formatFlag(debug.allowDebugControls)}, raw details ${formatFlag(
+          debug.allowRawResponseDetails,
+        )}, verbose logs ${formatFlag(debug.enableVerboseLogging)}`,
+      },
+      { label: "Device platform", value: platform },
+    ],
+    payloadStatus: payloadAligned ? "aligned" : "edited",
+    payloadEvidence: payloadAligned
+      ? "Payload app version, model ID, and capture mode match release metadata."
+      : [
+          `Payload app_version=${payloadAppVersion || "blank"}`,
+          `model_id=${payloadModelId || "blank"}`,
+          `capture_mode=${payloadCaptureMode || "blank"}`,
+          "do not match canonical release metadata.",
+        ].join("; "),
+    artifactTraceabilityNote:
+      "Git SHA, run ID, signing status, and store rollout evidence are tracked in Mobile Build artifacts.",
+  };
+}

--- a/apps/field-mobile/tests/releaseIdentity.test.js
+++ b/apps/field-mobile/tests/releaseIdentity.test.js
@@ -1,0 +1,44 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const releaseIdentity = require(path.join(buildDir, "utils/releaseIdentity.js"));
+
+test("release identity snapshot exposes canonical runtime release metadata", () => {
+  const snapshot = releaseIdentity.buildReleaseIdentitySnapshot({
+    platform: "ios",
+    payloadAppVersion: "0.1.0",
+    payloadModelId: "fusion-v0.1",
+    payloadCaptureMode: "water_impact",
+  });
+  const rows = Object.fromEntries(snapshot.canonicalRows.map((row) => [row.label, row.value]));
+
+  assert.equal(snapshot.platform, "ios");
+  assert.equal(rows["App version"], "0.1.0");
+  assert.equal(rows["Model ID"], "fusion-v0.1");
+  assert.equal(rows["Capture schema"], "ios_capture_v1");
+  assert.equal(rows["Runtime mode"], "pilot");
+  assert.equal(rows["Endpoint set"], "clinical_hub_v1");
+  assert.equal(rows["Default capture mode"], "water_impact");
+  assert.equal(rows.Privacy, "raw video off, raw audio off, ROI-only on");
+  assert.equal(rows["Data residency"], "us/single_region, cross-region sync off");
+  assert.equal(rows["Debug gates"], "debug controls off, raw details off, verbose logs off");
+  assert.equal(rows["Device platform"], "ios");
+  assert.equal(snapshot.payloadStatus, "aligned");
+  assert.match(snapshot.artifactTraceabilityNote, /Mobile Build artifacts/);
+});
+
+test("release identity snapshot warns when payload traceability is edited", () => {
+  const snapshot = releaseIdentity.buildReleaseIdentitySnapshot({
+    platform: "android",
+    payloadAppVersion: "0.1.1-local",
+    payloadModelId: "experimental-model",
+    payloadCaptureMode: "debug_capture",
+  });
+
+  assert.equal(snapshot.payloadStatus, "edited");
+  assert.match(snapshot.payloadEvidence, /app_version=0.1.1-local/);
+  assert.match(snapshot.payloadEvidence, /model_id=experimental-model/);
+  assert.match(snapshot.payloadEvidence, /capture_mode=debug_capture/);
+});

--- a/docs/mobile-install-and-field-test-runbook-v0.1.md
+++ b/docs/mobile-install-and-field-test-runbook-v0.1.md
@@ -89,6 +89,13 @@ Verify with `Test API` button before first patient run.
 Pending queue auto-sync stays paused until `API Base URL` is configured and starts with
 `http://` or `https://`.
 
+Before field use, verify the in-app `Release Identity` panel:
+- App version, model ID, and capture schema match the Mobile Build manifest.
+- Runtime mode is `pilot`, endpoint set is `clinical_hub_v1`, and default capture mode is `water_impact`.
+- Privacy flags show raw video/audio off and ROI-only on.
+- Data residency shows `us/single_region` with cross-region sync off.
+- `Payload traceability` is `aligned`; if it shows `edited`, reset the App Version, Model ID, and Capture Mode fields before collecting pilot data.
+
 ## 5. Paired Test Workflow
 
 Per subject/attempt:

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -21,6 +21,7 @@ Implemented now:
 - Physical-device smoke evidence JSON template and validator for iOS+Android release handoff.
 - Store rollout handoff JSON template, validator, and Mobile Build artifact for TestFlight/Play Internal traceability.
 - Mobile release bundle verifier for manifest/readiness/notes/store-handoff artifact consistency.
+- In-app Release Identity panel for app/model/schema/runtime/privacy/data-residency evidence on device.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -60,7 +60,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
@@ -178,12 +178,13 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 ## 5) Smoke test checklist (mandatory)
 
 1. App starts and opens settings screen.
-2. `Start Capture` and `Stop Capture` work on real device.
-3. `Contract payload: ready` after stop.
-4. Submit produces `paired-measurements` and `capture-packages` records.
-5. Offline mode queues both endpoint jobs.
-6. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
-7. Repository-level deterministic smoke confirms queued paired+capture replay drains after network restore.
+2. `Release Identity` shows app version, model/schema, runtime mode, endpoint set, privacy/data-residency flags, and `Payload traceability: aligned`.
+3. `Start Capture` and `Stop Capture` work on real device.
+4. `Contract payload: ready` after stop.
+5. Submit produces `paired-measurements` and `capture-packages` records.
+6. Offline mode queues both endpoint jobs.
+7. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
+8. Repository-level deterministic smoke confirms queued paired+capture replay drains after network restore.
 
 ## 6) Evidence to archive per build
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -740,6 +740,10 @@ def build_readiness_report(
     app_ts_path = mobile_root / "App.tsx"
     app_config_tests_path = mobile_root / "tests" / "appConfig.test.js"
     app_helpers_path = mobile_root / "src" / "utils" / "appHelpers.ts"
+    release_identity_source_path = mobile_root / "src" / "utils" / "releaseIdentity.ts"
+    release_identity_component_path = (
+        mobile_root / "src" / "components" / "ReleaseIdentitySection.tsx"
+    )
     clinical_hub_source_path = mobile_root / "src" / "api" / "clinicalHub.ts"
     connection_check_source_path = mobile_root / "src" / "api" / "connectionCheck.ts"
     pending_sync_queue_source_path = mobile_root / "src" / "utils" / "pendingSyncQueue.ts"
@@ -790,8 +794,11 @@ def build_readiness_report(
     )
     summary_requests_tests_path = mobile_root / "tests" / "summaryRequests.test.js"
     submit_outcome_tests_path = mobile_root / "tests" / "submitOutcome.test.js"
+    unit_runner_source = _read_file_text(unit_runner_path)
     app_ts_source = _read_file_text(app_ts_path)
     app_helpers_source = _read_file_text(app_helpers_path)
+    release_identity_source = _read_file_text(release_identity_source_path)
+    release_identity_component_source = _read_file_text(release_identity_component_path)
     clinical_hub_source = _read_file_text(clinical_hub_source_path)
     connection_check_source = _read_file_text(connection_check_source_path)
     pending_sync_queue_source = _read_file_text(pending_sync_queue_source_path)
@@ -799,6 +806,8 @@ def build_readiness_report(
     pending_storage_source = _read_file_text(pending_storage_source_path)
     submit_outcome_source = _read_file_text(submit_outcome_source_path)
     helper_tests_source = _read_file_text(helper_tests_path)
+    release_identity_tests_path = mobile_root / "tests" / "releaseIdentity.test.js"
+    release_identity_tests_source = _read_file_text(release_identity_tests_path)
     clinical_hub_tests_source = _read_file_text(clinical_hub_api_tests_path)
     connection_check_tests_source = _read_file_text(connection_check_tests_path)
     pending_sync_queue_tests_source = _read_file_text(pending_sync_queue_tests_path)
@@ -853,6 +862,38 @@ def build_readiness_report(
         "mobile_helper_unit_tests_present",
         helper_tests_path.is_file(),
         f"path={helper_tests_path}",
+    )
+    release_identity_source_requirements = {
+        "helper_file": release_identity_source_path.is_file(),
+        "component_file": release_identity_component_path.is_file(),
+        "app_renders_component": "ReleaseIdentitySection" in app_ts_source,
+        "component_uses_helper": "buildReleaseIdentitySnapshot"
+        in release_identity_component_source,
+        "canonical_metadata": "APP_RELEASE_METADATA" in release_identity_source,
+        "runtime_config": "APP_RUNTIME_CONFIG" in release_identity_source,
+        "payload_alignment_status": "payloadStatus" in release_identity_source,
+    }
+    _check(
+        checks,
+        "mobile_release_identity_sources",
+        all(release_identity_source_requirements.values()),
+        f"requirements={release_identity_source_requirements!r}",
+    )
+    release_identity_test_requirements = {
+        "unit_test_file": release_identity_tests_path.is_file(),
+        "canonical_metadata_test": (
+            "release identity snapshot exposes canonical runtime release metadata"
+        )
+        in release_identity_tests_source,
+        "edited_payload_test": "warns when payload traceability is edited"
+        in release_identity_tests_source,
+        "unit_runner_compiles_helper": "src/utils/releaseIdentity.ts" in unit_runner_source,
+    }
+    _check(
+        checks,
+        "mobile_release_identity_unit_tests_present",
+        all(release_identity_test_requirements.values()),
+        f"requirements={release_identity_test_requirements!r}",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -115,6 +115,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "mobile_phi_exception_redaction_unit_tests_present",
         "mobile_feature_media_manifest_sources",
         "mobile_feature_media_manifest_unit_tests_present",
+        "mobile_release_identity_sources",
+        "mobile_release_identity_unit_tests_present",
         "connection_check_unit_tests_present",
         "capture_contract_unit_tests_present",
         "mobile_e2e_sync_smoke_sources",


### PR DESCRIPTION
## Summary
- add an in-app Release Identity panel for app/model/schema/runtime/privacy/data-residency evidence
- warn operators when editable payload app version/model/capture mode diverge from canonical release metadata
- add readiness gates, unit tests, and runbook updates for release identity verification

## Validation
- python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-release-identity.json
- .venv/bin/ruff check .
- .venv/bin/pytest -q
- cd apps/field-mobile && npm run validate:ci
- strings /tmp/uroflow-field-mobile-export-*/_expo/static/js/*/*.hbc | rg "Release Identity|Payload traceability|Mobile Build artifacts"