### PR TITLE
Add mobile device identity defaults

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import { CameraView, useCameraPermissions } from "expo-camera";
+import * as Device from "expo-device";
 import {
   attemptSubmitEndpoint,
   buildMissingApiBaseUrlMessage,
@@ -79,11 +80,18 @@ import {
   formatSafeExceptionMessage,
   formatSafeResponseProblem,
 } from "./src/utils/appHelpers";
+import { buildDeviceModelLabel } from "./src/utils/deviceIdentity";
 
 const defaultMeasuredAt = new Date().toISOString().slice(0, 19) + "Z";
 
 export default function App() {
   const defaultPlatform = Platform.OS === "ios" ? "ios" : "android";
+  const defaultDeviceModel = buildDeviceModelLabel({
+    platform: defaultPlatform,
+    modelName: Device.modelName,
+    manufacturer: Device.manufacturer,
+    brand: Device.brand,
+  });
   const [cameraPermission, requestCameraPermission] = useCameraPermissions();
 
   const [apiBaseUrl, setApiBaseUrl] = useState(DEFAULT_API_BASE_URL);
@@ -98,7 +106,7 @@ export default function App() {
   const [attemptNumber, setAttemptNumber] = useState("1");
   const [measuredAt, setMeasuredAt] = useState(defaultMeasuredAt);
   const [platform, setPlatform] = useState<string>(defaultPlatform);
-  const [deviceModel, setDeviceModel] = useState<string>(Platform.OS);
+  const [deviceModel, setDeviceModel] = useState<string>(defaultDeviceModel);
   const [appVersion, setAppVersion] = useState(APP_RELEASE_VERSION);
   const [captureMode, setCaptureMode] = useState(APP_DEFAULT_CAPTURE_MODE);
 

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -24,6 +24,7 @@ Cross-platform mobile client (Expo React Native) for collecting paired measureme
 - Queue controls: `Test API`, `Sync Queue`, `Clear Queue`
 - Persisted local settings (`API URL`, `site/operator`, timeout, summary filter)
 - `API Key` stored in device secure storage (`expo-secure-store`) with AsyncStorage fallback
+- `Device Model` defaults from Expo Device metadata with platform fallback and remains editable for field correction.
 - On successful paired upload, app posts `capture_contract_json` to `POST /api/v1/capture-packages`
 - Runtime capture mode collects live audio + IMU samples (camera permission used for ROI validity flag)
 - In-app `Release Identity` panel shows canonical app version, model/schema, runtime config, privacy/data-residency flags, platform, and payload traceability alignment.
@@ -140,7 +141,7 @@ secret blockers. The artifact has separate machine-readable gates:
 
 - `local_checks_status`: local app metadata, runtime release metadata, EAS profile shape,
   runtime config/defaults such as Clinical Hub v1 endpoint set, disabled debug gates,
-  privacy-by-default switches, single-region data residency policy,
+  privacy-by-default switches, single-region data residency policy, Expo Device identity defaults,
   in-app release identity evidence,
   runtime motion quality gates, derivatives-only feature/media
   manifest gates, pending sync connectivity-restore trigger, device-smoke evidence template/validator,

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -7,6 +7,7 @@ TEST_FILES=""
 rm -rf "$BUILD_DIR"
 tsc --ignoreConfig \
   src/utils/appHelpers.ts \
+  src/utils/deviceIdentity.ts \
   src/utils/pendingSyncQueue.ts \
   src/utils/releaseIdentity.ts \
   src/utils/submitOutcome.ts \

--- a/apps/field-mobile/src/capture/runtimeCaptureSession.ts
+++ b/apps/field-mobile/src/capture/runtimeCaptureSession.ts
@@ -23,6 +23,7 @@ import {
   type RuntimeCaptureQuality,
   type RuntimeFlowPoint,
 } from "./runtimeMetrics";
+import { buildDeviceModelLabel, buildDeviceOsVersion } from "../utils/deviceIdentity";
 
 export type {
   RuntimeCaptureDerivedMetrics,
@@ -224,8 +225,18 @@ export class RuntimeCaptureSession {
       sampleCount: this.samples.length,
       averageMotionNorm: round4(avgMotionNorm),
       permissions: this.permissions,
-      deviceModel: Device.modelName ?? "unknown-device",
-      osVersion: String(Platform.Version),
+      deviceModel: buildDeviceModelLabel({
+        platform: Platform.OS,
+        modelName: Device.modelName,
+        manufacturer: Device.manufacturer,
+        brand: Device.brand,
+      }),
+      osVersion: buildDeviceOsVersion({
+        platform: Platform.OS,
+        osName: Device.osName,
+        osVersion: Device.osVersion,
+        platformVersion: Platform.Version,
+      }),
       samples: [...this.samples],
       flowSeries: [...this.flowSeries],
       derived,

--- a/apps/field-mobile/src/utils/deviceIdentity.ts
+++ b/apps/field-mobile/src/utils/deviceIdentity.ts
@@ -1,0 +1,58 @@
+export type DeviceIdentityInput = {
+  platform: string;
+  modelName?: string | null;
+  manufacturer?: string | null;
+  brand?: string | null;
+  osName?: string | null;
+  osVersion?: string | null;
+  platformVersion?: string | number | null;
+};
+
+function clean(value: string | number | null | undefined): string {
+  return String(value ?? "").trim();
+}
+
+function joinUnique(parts: string[]): string {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const part of parts) {
+    const normalized = clean(part);
+    if (!normalized || seen.has(normalized.toLowerCase())) {
+      continue;
+    }
+    seen.add(normalized.toLowerCase());
+    result.push(normalized);
+  }
+  return result.join(" ");
+}
+
+export function buildDeviceModelLabel(input: DeviceIdentityInput): string {
+  const modelName = clean(input.modelName);
+  if (modelName) {
+    return modelName;
+  }
+
+  const manufacturerModel = joinUnique([clean(input.manufacturer), clean(input.brand)]);
+  if (manufacturerModel) {
+    return manufacturerModel;
+  }
+
+  const platform = clean(input.platform) || "unknown";
+  return `${platform}-device`;
+}
+
+export function buildDeviceOsVersion(input: DeviceIdentityInput): string {
+  const osName = clean(input.osName);
+  const osVersion = clean(input.osVersion);
+  if (osName && osVersion) {
+    return `${osName} ${osVersion}`;
+  }
+  if (osVersion) {
+    return osVersion;
+  }
+  if (osName) {
+    return osName;
+  }
+  const platformVersion = clean(input.platformVersion);
+  return platformVersion || "unknown-os";
+}

--- a/apps/field-mobile/tests/deviceIdentity.test.js
+++ b/apps/field-mobile/tests/deviceIdentity.test.js
@@ -1,0 +1,81 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const deviceIdentity = require(path.join(buildDir, "utils/deviceIdentity.js"));
+
+test("buildDeviceModelLabel prefers Expo Device model name", () => {
+  assert.equal(
+    deviceIdentity.buildDeviceModelLabel({
+      platform: "ios",
+      modelName: " iPhone 15 Pro ",
+      manufacturer: "Apple",
+      brand: "Apple",
+    }),
+    "iPhone 15 Pro",
+  );
+});
+
+test("buildDeviceModelLabel falls back to manufacturer and brand", () => {
+  assert.equal(
+    deviceIdentity.buildDeviceModelLabel({
+      platform: "android",
+      modelName: "",
+      manufacturer: " Google ",
+      brand: " Pixel ",
+    }),
+    "Google Pixel",
+  );
+  assert.equal(
+    deviceIdentity.buildDeviceModelLabel({
+      platform: "android",
+      modelName: null,
+      manufacturer: "Google",
+      brand: "google",
+    }),
+    "Google",
+  );
+});
+
+test("buildDeviceModelLabel uses platform fallback when device details are unavailable", () => {
+  assert.equal(
+    deviceIdentity.buildDeviceModelLabel({
+      platform: "android",
+      modelName: null,
+      manufacturer: null,
+      brand: null,
+    }),
+    "android-device",
+  );
+});
+
+test("buildDeviceOsVersion prefers Expo Device OS name and version", () => {
+  assert.equal(
+    deviceIdentity.buildDeviceOsVersion({
+      platform: "ios",
+      osName: " iOS ",
+      osVersion: " 18.3 ",
+      platformVersion: "18.3",
+    }),
+    "iOS 18.3",
+  );
+  assert.equal(
+    deviceIdentity.buildDeviceOsVersion({
+      platform: "android",
+      osName: null,
+      osVersion: "15",
+      platformVersion: "35",
+    }),
+    "15",
+  );
+  assert.equal(
+    deviceIdentity.buildDeviceOsVersion({
+      platform: "android",
+      osName: null,
+      osVersion: null,
+      platformVersion: 35,
+    }),
+    "35",
+  );
+});

--- a/docs/mobile-install-and-field-test-runbook-v0.1.md
+++ b/docs/mobile-install-and-field-test-runbook-v0.1.md
@@ -84,6 +84,7 @@ In app API section set:
 - `Actor Role`: `operator`
 - `Site ID`: clinic/site code
 - `Operator ID`: current operator code
+- `Device Model`: auto-filled from Expo Device metadata; correct it manually only if the displayed physical model is wrong.
 
 Verify with `Test API` button before first patient run.
 Pending queue auto-sync stays paused until `API Base URL` is configured and starts with
@@ -94,6 +95,7 @@ Before field use, verify the in-app `Release Identity` panel:
 - Runtime mode is `pilot`, endpoint set is `clinical_hub_v1`, and default capture mode is `water_impact`.
 - Privacy flags show raw video/audio off and ROI-only on.
 - Data residency shows `us/single_region` with cross-region sync off.
+- Device platform/model match the physical device that will be recorded in the smoke log.
 - `Payload traceability` is `aligned`; if it shows `edited`, reset the App Version, Model ID, and Capture Mode fields before collecting pilot data.
 
 ## 5. Paired Test Workflow

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -22,6 +22,7 @@ Implemented now:
 - Store rollout handoff JSON template, validator, and Mobile Build artifact for TestFlight/Play Internal traceability.
 - Mobile release bundle verifier for manifest/readiness/notes/store-handoff artifact consistency.
 - In-app Release Identity panel for app/model/schema/runtime/privacy/data-residency evidence on device.
+- Expo Device-based device model/OS identity defaults for paired payload and capture package traceability.
 
 Not yet implemented:
 - Real sensor capture pipeline (camera/audio/IMU/depth).

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -60,7 +60,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
@@ -179,12 +179,13 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 
 1. App starts and opens settings screen.
 2. `Release Identity` shows app version, model/schema, runtime mode, endpoint set, privacy/data-residency flags, and `Payload traceability: aligned`.
-3. `Start Capture` and `Stop Capture` work on real device.
-4. `Contract payload: ready` after stop.
-5. Submit produces `paired-measurements` and `capture-packages` records.
-6. Offline mode queues both endpoint jobs.
-7. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
-8. Repository-level deterministic smoke confirms queued paired+capture replay drains after network restore.
+3. `Device Model` is auto-filled from the physical device model or a platform fallback, and matches the smoke-log device entry after any field correction.
+4. `Start Capture` and `Stop Capture` work on real device.
+5. `Contract payload: ready` after stop.
+6. Submit produces `paired-measurements` and `capture-packages` records.
+7. Offline mode queues both endpoint jobs.
+8. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
+9. Repository-level deterministic smoke confirms queued paired+capture replay drains after network restore.
 
 ## 6) Evidence to archive per build
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -740,6 +740,7 @@ def build_readiness_report(
     app_ts_path = mobile_root / "App.tsx"
     app_config_tests_path = mobile_root / "tests" / "appConfig.test.js"
     app_helpers_path = mobile_root / "src" / "utils" / "appHelpers.ts"
+    device_identity_source_path = mobile_root / "src" / "utils" / "deviceIdentity.ts"
     release_identity_source_path = mobile_root / "src" / "utils" / "releaseIdentity.ts"
     release_identity_component_path = (
         mobile_root / "src" / "components" / "ReleaseIdentitySection.tsx"
@@ -756,6 +757,9 @@ def build_readiness_report(
     connection_check_tests_path = mobile_root / "tests" / "connectionCheck.test.js"
     capture_package_payload_tests_path = mobile_root / "tests" / "capturePackagePayload.test.js"
     capture_contract_source_path = mobile_root / "src" / "capture" / "buildCaptureContract.ts"
+    runtime_capture_session_source_path = (
+        mobile_root / "src" / "capture" / "runtimeCaptureSession.ts"
+    )
     capture_tests_path = mobile_root / "tests" / "captureContract.test.js"
     repo_root = package_json.resolve().parent.parent.parent
     backend_capture_contract_path = repo_root / "src" / "uroflow_mobile" / "capture_contract.py"
@@ -797,6 +801,7 @@ def build_readiness_report(
     unit_runner_source = _read_file_text(unit_runner_path)
     app_ts_source = _read_file_text(app_ts_path)
     app_helpers_source = _read_file_text(app_helpers_path)
+    device_identity_source = _read_file_text(device_identity_source_path)
     release_identity_source = _read_file_text(release_identity_source_path)
     release_identity_component_source = _read_file_text(release_identity_component_path)
     clinical_hub_source = _read_file_text(clinical_hub_source_path)
@@ -806,6 +811,8 @@ def build_readiness_report(
     pending_storage_source = _read_file_text(pending_storage_source_path)
     submit_outcome_source = _read_file_text(submit_outcome_source_path)
     helper_tests_source = _read_file_text(helper_tests_path)
+    device_identity_tests_path = mobile_root / "tests" / "deviceIdentity.test.js"
+    device_identity_tests_source = _read_file_text(device_identity_tests_path)
     release_identity_tests_path = mobile_root / "tests" / "releaseIdentity.test.js"
     release_identity_tests_source = _read_file_text(release_identity_tests_path)
     clinical_hub_tests_source = _read_file_text(clinical_hub_api_tests_path)
@@ -816,6 +823,7 @@ def build_readiness_report(
     )
     submit_outcome_tests_source = _read_file_text(submit_outcome_tests_path)
     capture_contract_source = _read_file_text(capture_contract_source_path)
+    runtime_capture_session_source = _read_file_text(runtime_capture_session_source_path)
     capture_tests_source = _read_file_text(capture_tests_path)
     backend_capture_contract_source = _read_file_text(backend_capture_contract_path)
     backend_capture_tests_source = _read_file_text(backend_capture_tests_path)
@@ -862,6 +870,41 @@ def build_readiness_report(
         "mobile_helper_unit_tests_present",
         helper_tests_path.is_file(),
         f"path={helper_tests_path}",
+    )
+    device_identity_source_requirements = {
+        "helper_file": device_identity_source_path.is_file(),
+        "expo_device_dependency": "expo-device" in package_dependencies,
+        "model_label_helper": "buildDeviceModelLabel" in device_identity_source,
+        "os_version_helper": "buildDeviceOsVersion" in device_identity_source,
+        "app_imports_expo_device": 'import * as Device from "expo-device"'
+        in app_ts_source,
+        "app_default_device_model": "defaultDeviceModel" in app_ts_source
+        and "buildDeviceModelLabel" in app_ts_source,
+        "runtime_uses_model_helper": "buildDeviceModelLabel"
+        in runtime_capture_session_source,
+        "runtime_uses_os_helper": "buildDeviceOsVersion" in runtime_capture_session_source,
+    }
+    _check(
+        checks,
+        "mobile_device_identity_sources",
+        all(device_identity_source_requirements.values()),
+        f"requirements={device_identity_source_requirements!r}",
+    )
+    device_identity_test_requirements = {
+        "unit_test_file": device_identity_tests_path.is_file(),
+        "model_name_test": "prefers Expo Device model name" in device_identity_tests_source,
+        "manufacturer_brand_fallback_test": "falls back to manufacturer and brand"
+        in device_identity_tests_source,
+        "platform_fallback_test": "platform fallback" in device_identity_tests_source,
+        "os_version_test": "prefers Expo Device OS name and version"
+        in device_identity_tests_source,
+        "unit_runner_compiles_helper": "src/utils/deviceIdentity.ts" in unit_runner_source,
+    }
+    _check(
+        checks,
+        "mobile_device_identity_unit_tests_present",
+        all(device_identity_test_requirements.values()),
+        f"requirements={device_identity_test_requirements!r}",
     )
     release_identity_source_requirements = {
         "helper_file": release_identity_source_path.is_file(),

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -113,6 +113,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "mobile_api_response_redaction_unit_tests_present",
         "mobile_phi_exception_redaction_sources",
         "mobile_phi_exception_redaction_unit_tests_present",
+        "mobile_device_identity_sources",
+        "mobile_device_identity_unit_tests_present",
         "mobile_feature_media_manifest_sources",
         "mobile_feature_media_manifest_unit_tests_present",
         "mobile_release_identity_sources",


### PR DESCRIPTION
## Summary
- default Device Model from Expo Device metadata with platform fallback
- reuse the same device identity normalizer in runtime capture stop output
- add device identity unit tests, readiness gates, and runbook updates

## Validation
- python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-device-identity.json
- .venv/bin/ruff check .
- .venv/bin/pytest -q
- cd apps/field-mobile && npm run validate:ci