### PR TITLE
Add Clinical Hub preflight guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,9 @@ npm run start:device
 В мобильном клиенте есть встроенный раздел `Comparison Summary`, который подтягивает
 `/api/v1/comparison-summary` и показывает текущую сходимость с эталонным урофлоуметром.
 Также реализована offline-очередь отправки и ручная синхронизация pending-записей.
+Перед `Test API`, `Submit` и `Sync Queue` приложение выполняет Clinical Hub preflight:
+пустой/невалидный URL и очевидный cross-region Hub блокируются, local/LAN URL разрешён
+только как предупреждение для smoke-тестов.
 
 ## Интеграция Project Package v2.8
 

--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -11,11 +11,13 @@ import { CameraView, useCameraPermissions } from "expo-camera";
 import * as Device from "expo-device";
 import {
   attemptSubmitEndpoint,
-  buildMissingApiBaseUrlMessage,
   buildRequestHeaders,
   fetchWithTimeout,
-  isConfiguredApiBaseUrl,
 } from "./src/api/clinicalHub";
+import {
+  buildClinicalHubPreflight,
+  isClinicalHubPreflightActionAllowed,
+} from "./src/api/clinicalHubPreflight";
 import {
   buildApiCheckFailedMessage,
   buildAuthContextCheckFailedMessage,
@@ -176,6 +178,10 @@ export default function App() {
   const requestHeaderContext = useMemo<RequestHeaderContext>(
     () => buildHeaderContextFromValues(apiKey, actorRole, siteId, operatorId),
     [actorRole, apiKey, operatorId, siteId],
+  );
+  const clinicalHubPreflight = useMemo(
+    () => buildClinicalHubPreflight(apiBaseUrl),
+    [apiBaseUrl],
   );
 
   const {
@@ -518,10 +524,10 @@ export default function App() {
   }
 
   async function testApiConnection(): Promise<void> {
-    if (!isConfiguredApiBaseUrl(apiBaseUrl)) {
-      const message = buildMissingApiBaseUrlMessage();
+    if (!isClinicalHubPreflightActionAllowed(clinicalHubPreflight)) {
+      const message = clinicalHubPreflight.message;
       setLastResponse(message);
-      Alert.alert("API URL required", message);
+      Alert.alert("API preflight blocked", message);
       return;
     }
     const authContextUrl = buildAuthContextUrl(apiBaseUrl);
@@ -571,17 +577,17 @@ export default function App() {
   }
 
   function validateRequired(): string | null {
-    if (!isConfiguredApiBaseUrl(apiBaseUrl)) {
-      return buildMissingApiBaseUrlMessage();
+    if (!isClinicalHubPreflightActionAllowed(clinicalHubPreflight)) {
+      return clinicalHubPreflight.message;
     }
     return validatePairedPayloadForSubmission(payload, { captureRunning });
   }
 
   async function syncPendingQueueWithConfiguredApi(): Promise<void> {
-    if (!isConfiguredApiBaseUrl(apiBaseUrl)) {
-      const message = buildMissingApiBaseUrlMessage();
+    if (!isClinicalHubPreflightActionAllowed(clinicalHubPreflight)) {
+      const message = clinicalHubPreflight.message;
       setLastResponse(message);
-      Alert.alert("API URL required", message);
+      Alert.alert("API preflight blocked", message);
       return;
     }
     await syncPendingSubmissions();
@@ -718,9 +724,9 @@ export default function App() {
   }
 
   async function loadComparisonSummary() {
-    if (!isConfiguredApiBaseUrl(apiBaseUrl)) {
+    if (!isClinicalHubPreflightActionAllowed(clinicalHubPreflight)) {
       setSummary(null);
-      setSummaryError(buildMissingApiBaseUrlMessage());
+      setSummaryError(clinicalHubPreflight.message);
       return;
     }
     const url = buildComparisonSummaryUrl({
@@ -758,9 +764,9 @@ export default function App() {
   }
 
   async function loadCaptureCoverageSummary() {
-    if (!isConfiguredApiBaseUrl(apiBaseUrl)) {
+    if (!isClinicalHubPreflightActionAllowed(clinicalHubPreflight)) {
       setCoverageSummary(null);
-      setCoverageError(buildMissingApiBaseUrlMessage());
+      setCoverageError(clinicalHubPreflight.message);
       return;
     }
     const url = buildCaptureCoverageSummaryUrl({
@@ -824,6 +830,8 @@ export default function App() {
           apiKey={apiKey}
           actorRole={actorRole}
           requestTimeoutMs={requestTimeoutMs}
+          clinicalHubPreflightMessage={clinicalHubPreflight.message}
+          clinicalHubPreflightStatus={clinicalHubPreflight.status}
           pendingQueue={pendingQueue}
           syncingPending={syncingPending}
           syncStatusMessage={syncStatusMessage}

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -22,6 +22,8 @@ Cross-platform mobile client (Expo React Native) for collecting paired measureme
 - Sync runs in bounded batches of 10 queued jobs to avoid long foreground stalls on large offline queues
 - Auto-sync retries queued jobs every ~25s only after API Base URL is configured
 - Queue controls: `Test API`, `Sync Queue`, `Clear Queue`
+- Clinical Hub preflight is shown in the API block; missing/invalid URLs and obvious
+  cross-region Hub targets are blocked before `Test API`, `Submit`, or `Sync Queue`.
 - Persisted local settings (`API URL`, `site/operator`, timeout, summary filter)
 - `API Key` stored in device secure storage (`expo-secure-store`) with AsyncStorage fallback
 - `Device Model` defaults from Expo Device metadata with platform fallback and remains editable for field correction.
@@ -97,6 +99,10 @@ Notes:
 
 Set `API Base URL` in the app screen.
 If backend API-key protection is enabled, set `API Key` too (sent as `x-api-key` header).
+The API block shows a preflight result. Missing/unsupported URLs block field actions.
+Local/LAN URLs are allowed with a warning for smoke tests. HTTPS URLs with an obvious
+non-US region token are blocked because the pilot runtime policy requires the configured
+single-region Clinical Hub.
 
 Examples:
 
@@ -142,6 +148,7 @@ secret blockers. The artifact has separate machine-readable gates:
 - `local_checks_status`: local app metadata, runtime release metadata, EAS profile shape,
   runtime config/defaults such as Clinical Hub v1 endpoint set, disabled debug gates,
   privacy-by-default switches, single-region data residency policy, Expo Device identity defaults,
+  Clinical Hub preflight guard,
   in-app release identity evidence,
   runtime motion quality gates, derivatives-only feature/media
   manifest gates, pending sync connectivity-restore trigger, device-smoke evidence template/validator,

--- a/apps/field-mobile/scripts/run-unit-tests.sh
+++ b/apps/field-mobile/scripts/run-unit-tests.sh
@@ -18,6 +18,7 @@ tsc --ignoreConfig \
   src/payload/capturePackagePayload.ts \
   src/payload/pairedPayload.ts \
   src/api/clinicalHub.ts \
+  src/api/clinicalHubPreflight.ts \
   src/api/connectionCheck.ts \
   src/api/summaryRequests.ts \
   src/capture/buildCaptureContract.ts \

--- a/apps/field-mobile/src/api/clinicalHubPreflight.ts
+++ b/apps/field-mobile/src/api/clinicalHubPreflight.ts
@@ -1,0 +1,181 @@
+import {
+  APP_ALLOW_CROSS_REGION_SYNC,
+  APP_DATA_RESIDENCY_REGION,
+  APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB,
+} from "../config/appConfig";
+import { buildBaseUrl, buildMissingApiBaseUrlMessage } from "./clinicalHub";
+
+export type ClinicalHubPreflightStatus = "pass" | "warning" | "blocked";
+
+export type ClinicalHubPreflightCode =
+  | "configured"
+  | "insecure_transport"
+  | "local_dev"
+  | "missing_url"
+  | "region_mismatch"
+  | "region_unknown"
+  | "unsupported_url";
+
+export type ClinicalHubPreflightResult = {
+  status: ClinicalHubPreflightStatus;
+  code: ClinicalHubPreflightCode;
+  message: string;
+  normalizedBaseUrl: string;
+  expectedRegion: string;
+  inferredRegion: string | null;
+};
+
+const REGION_ALIASES: Readonly<Record<string, string>> = Object.freeze({
+  au: "au",
+  ca: "ca",
+  cn: "cn",
+  eu: "eu",
+  uk: "uk",
+  us: "us",
+  usa: "us",
+});
+
+function tokenizeHostname(hostname: string): string[] {
+  return hostname.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+export function inferClinicalHubRegionFromHostname(hostname: string): string | null {
+  for (const token of tokenizeHostname(hostname)) {
+    const region = REGION_ALIASES[token];
+    if (region) {
+      return region;
+    }
+  }
+  return null;
+}
+
+export function isLocalClinicalHubHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  if (
+    normalized === "localhost" ||
+    normalized === "0.0.0.0" ||
+    normalized === "::1" ||
+    normalized === "[::1]" ||
+    normalized.endsWith(".local") ||
+    normalized.startsWith("127.")
+  ) {
+    return true;
+  }
+
+  const octets = normalized.split(".").map((part) => Number(part));
+  if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part))) {
+    return false;
+  }
+  return (
+    octets[0] === 10 ||
+    (octets[0] === 192 && octets[1] === 168) ||
+    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31)
+  );
+}
+
+export function buildClinicalHubPreflight(apiBaseUrl: string): ClinicalHubPreflightResult {
+  const normalizedBaseUrl = buildBaseUrl(apiBaseUrl);
+  const expectedRegion = APP_DATA_RESIDENCY_REGION;
+  const baseResult = {
+    normalizedBaseUrl,
+    expectedRegion,
+    inferredRegion: null,
+  };
+
+  if (!normalizedBaseUrl) {
+    return {
+      ...baseResult,
+      status: "blocked",
+      code: "missing_url",
+      message: buildMissingApiBaseUrlMessage(),
+    };
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(normalizedBaseUrl);
+  } catch {
+    return {
+      ...baseResult,
+      status: "blocked",
+      code: "unsupported_url",
+      message: "Clinical Hub API Base URL must include http:// or https://.",
+    };
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    return {
+      ...baseResult,
+      status: "blocked",
+      code: "unsupported_url",
+      message: "Clinical Hub API Base URL must use http:// or https://.",
+    };
+  }
+
+  const hostname = parsedUrl.hostname;
+  const inferredRegion = inferClinicalHubRegionFromHostname(hostname);
+  const policyRequiresRegionMatch =
+    APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB && !APP_ALLOW_CROSS_REGION_SYNC;
+  const withRegion = {
+    ...baseResult,
+    inferredRegion,
+  };
+
+  if (
+    policyRequiresRegionMatch &&
+    inferredRegion != null &&
+    inferredRegion !== expectedRegion
+  ) {
+    return {
+      ...withRegion,
+      status: "blocked",
+      code: "region_mismatch",
+      message:
+        `Clinical Hub region mismatch: app policy requires ${expectedRegion}, ` +
+        `URL appears to target ${inferredRegion}.`,
+    };
+  }
+
+  if (isLocalClinicalHubHostname(hostname)) {
+    return {
+      ...withRegion,
+      status: "warning",
+      code: "local_dev",
+      message:
+        "Clinical Hub preflight warning: local/LAN URL is allowed for smoke testing only, not live release.",
+    };
+  }
+
+  if (parsedUrl.protocol !== "https:") {
+    return {
+      ...withRegion,
+      status: "warning",
+      code: "insecure_transport",
+      message:
+        "Clinical Hub preflight warning: use https:// for live pilot sync outside local smoke tests.",
+    };
+  }
+
+  if (policyRequiresRegionMatch && inferredRegion == null) {
+    return {
+      ...withRegion,
+      status: "warning",
+      code: "region_unknown",
+      message:
+        `Clinical Hub preflight warning: URL region is not obvious; confirm it is ${expectedRegion} before live pilot sync.`,
+    };
+  }
+
+  return {
+    ...withRegion,
+    status: "pass",
+    code: "configured",
+    message: `Clinical Hub preflight OK for ${expectedRegion} region policy.`,
+  };
+}
+
+export function isClinicalHubPreflightActionAllowed(
+  preflight: ClinicalHubPreflightResult,
+): boolean {
+  return preflight.status !== "blocked";
+}

--- a/apps/field-mobile/src/components/ApiConnectionSection.tsx
+++ b/apps/field-mobile/src/components/ApiConnectionSection.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Pressable, Text, View } from "react-native";
 
+import type { ClinicalHubPreflightStatus } from "../api/clinicalHubPreflight";
 import type { PendingSubmission } from "../types";
 import { normalizeActorRoleInput } from "../utils/appHelpers";
 import { styles } from "../styles/appStyles";
@@ -12,6 +13,8 @@ type ApiConnectionSectionProps = {
   apiKey: string;
   actorRole: string;
   requestTimeoutMs: string;
+  clinicalHubPreflightMessage: string;
+  clinicalHubPreflightStatus: ClinicalHubPreflightStatus;
   pendingQueue: PendingSubmission[];
   syncingPending: boolean;
   syncStatusMessage: string;
@@ -29,6 +32,8 @@ export function ApiConnectionSection({
   apiKey,
   actorRole,
   requestTimeoutMs,
+  clinicalHubPreflightMessage,
+  clinicalHubPreflightStatus,
   pendingQueue,
   syncingPending,
   syncStatusMessage,
@@ -49,11 +54,25 @@ export function ApiConnectionSection({
         onChangeText={onApiBaseUrlChange}
         placeholder="https://<clinical-hub-host>"
       />
-      {!apiBaseUrl.trim() ? (
-        <Text style={styles.helperText}>
-          Configure the Clinical Hub URL before Test API, Submit, or Sync Queue.
+      <View
+        style={[
+          styles.preflightBox,
+          clinicalHubPreflightStatus === "pass" && styles.preflightPassBox,
+          clinicalHubPreflightStatus === "warning" && styles.preflightWarningBox,
+          clinicalHubPreflightStatus === "blocked" && styles.preflightBlockedBox,
+        ]}
+      >
+        <Text
+          style={[
+            styles.preflightText,
+            clinicalHubPreflightStatus === "pass" && styles.preflightPassText,
+            clinicalHubPreflightStatus === "warning" && styles.preflightWarningText,
+            clinicalHubPreflightStatus === "blocked" && styles.preflightBlockedText,
+          ]}
+        >
+          Clinical Hub preflight: {clinicalHubPreflightMessage}
         </Text>
-      ) : null}
+      </View>
       <LabeledInput
         label="API Key (x-api-key)"
         value={apiKey}

--- a/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
+++ b/apps/field-mobile/src/hooks/usePendingSyncQueue.ts
@@ -1,12 +1,14 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, AppState } from "react-native";
 import NetInfo from "@react-native-community/netinfo";
 
 import {
   attemptSubmitEndpoint,
-  buildMissingApiBaseUrlMessage,
-  isConfiguredApiBaseUrl,
 } from "../api/clinicalHub";
+import {
+  buildClinicalHubPreflight,
+  isClinicalHubPreflightActionAllowed,
+} from "../api/clinicalHubPreflight";
 import {
   loadPendingSubmissions,
   savePendingSubmissions,
@@ -46,7 +48,11 @@ export function usePendingSyncQueue({
   const syncInFlightRef = useRef(false);
   const autoSyncIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const networkReachableRef = useRef<boolean | null>(null);
-  const apiConfigured = isConfiguredApiBaseUrl(apiBaseUrl);
+  const clinicalHubPreflight = useMemo(
+    () => buildClinicalHubPreflight(apiBaseUrl),
+    [apiBaseUrl],
+  );
+  const apiConfigured = isClinicalHubPreflightActionAllowed(clinicalHubPreflight);
 
   const persistPendingQueue = useCallback(async (queue: PendingSubmission[]): Promise<void> => {
     await savePendingSubmissions(queue);
@@ -88,11 +94,11 @@ export function usePendingSyncQueue({
   const syncPendingSubmissions = useCallback(
     async (showAlert = true): Promise<void> => {
       if (!apiConfigured) {
-        const message = buildMissingApiBaseUrlMessage();
+        const message = clinicalHubPreflight.message;
         setSyncStatusMessage(message);
         onLastResponse(message);
         if (showAlert) {
-          Alert.alert("API URL required", message);
+          Alert.alert("API preflight blocked", message);
         }
         return;
       }
@@ -137,6 +143,7 @@ export function usePendingSyncQueue({
     [
       apiConfigured,
       apiBaseUrl,
+      clinicalHubPreflight.message,
       onLastResponse,
       persistPendingQueue,
       requestHeaderContext,
@@ -181,7 +188,7 @@ export function usePendingSyncQueue({
         autoSyncIntervalRef.current = null;
       }
       if (settingsHydrated && pendingQueue.length > 0 && !apiConfigured) {
-        setSyncStatusMessage(buildMissingApiBaseUrlMessage());
+        setSyncStatusMessage(clinicalHubPreflight.message);
       }
       return;
     }
@@ -200,7 +207,13 @@ export function usePendingSyncQueue({
         autoSyncIntervalRef.current = null;
       }
     };
-  }, [apiConfigured, pendingQueue.length, settingsHydrated, syncPendingSubmissions]);
+  }, [
+    apiConfigured,
+    clinicalHubPreflight.message,
+    pendingQueue.length,
+    settingsHydrated,
+    syncPendingSubmissions,
+  ]);
 
   useEffect(() => {
     const unsubscribe = NetInfo.addEventListener((state) => {

--- a/apps/field-mobile/src/styles/appStyles.ts
+++ b/apps/field-mobile/src/styles/appStyles.ts
@@ -24,6 +24,37 @@ export const styles = StyleSheet.create({
     fontSize: 12,
     color: "#334155",
   },
+  preflightBox: {
+    marginTop: 2,
+    marginBottom: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    padding: 8,
+  },
+  preflightPassBox: {
+    borderColor: "#86efac",
+    backgroundColor: "#f0fdf4",
+  },
+  preflightWarningBox: {
+    borderColor: "#fbbf24",
+    backgroundColor: "#fffbeb",
+  },
+  preflightBlockedBox: {
+    borderColor: "#fca5a5",
+    backgroundColor: "#fef2f2",
+  },
+  preflightText: {
+    fontSize: 12,
+  },
+  preflightPassText: {
+    color: "#166534",
+  },
+  preflightWarningText: {
+    color: "#92400e",
+  },
+  preflightBlockedText: {
+    color: "#991b1b",
+  },
   releaseIdentityBox: {
     marginBottom: 8,
     borderWidth: 1,

--- a/apps/field-mobile/tests/clinicalHubPreflight.test.js
+++ b/apps/field-mobile/tests/clinicalHubPreflight.test.js
@@ -1,0 +1,69 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const buildDir = process.env.MOBILE_UNIT_BUILD_DIR ?? "/tmp/uroflow-field-mobile-unit";
+const preflight = require(path.join(buildDir, "api/clinicalHubPreflight.js"));
+
+test("blocks missing Clinical Hub URL before field actions", () => {
+  const result = preflight.buildClinicalHubPreflight(" ");
+
+  assert.equal(result.status, "blocked");
+  assert.equal(result.code, "missing_url");
+  assert.equal(
+    result.message,
+    "Configure Clinical Hub API Base URL before testing, submitting, or syncing.",
+  );
+  assert.equal(preflight.isClinicalHubPreflightActionAllowed(result), false);
+});
+
+test("blocks Clinical Hub URLs without supported protocol", () => {
+  const result = preflight.buildClinicalHubPreflight("clinical.example.test");
+
+  assert.equal(result.status, "blocked");
+  assert.equal(result.code, "unsupported_url");
+  assert.equal(preflight.isClinicalHubPreflightActionAllowed(result), false);
+});
+
+test("allows local Clinical Hub smoke URLs with warning", () => {
+  const result = preflight.buildClinicalHubPreflight("http://192.168.1.20:8000/");
+
+  assert.equal(result.status, "warning");
+  assert.equal(result.code, "local_dev");
+  assert.equal(result.normalizedBaseUrl, "http://192.168.1.20:8000");
+  assert.equal(preflight.isClinicalHubPreflightActionAllowed(result), true);
+  assert.equal(
+    preflight.buildClinicalHubPreflight("http://[::1]:8000").code,
+    "local_dev",
+  );
+});
+
+test("passes obvious region-matched HTTPS Clinical Hub URLs", () => {
+  const result = preflight.buildClinicalHubPreflight("https://clinical-us.example.test");
+
+  assert.equal(result.status, "pass");
+  assert.equal(result.code, "configured");
+  assert.equal(result.expectedRegion, "us");
+  assert.equal(result.inferredRegion, "us");
+  assert.equal(preflight.isClinicalHubPreflightActionAllowed(result), true);
+});
+
+test("blocks obvious cross-region Clinical Hub URLs", () => {
+  const result = preflight.buildClinicalHubPreflight("https://clinical-eu.example.test");
+
+  assert.equal(result.status, "blocked");
+  assert.equal(result.code, "region_mismatch");
+  assert.equal(result.expectedRegion, "us");
+  assert.equal(result.inferredRegion, "eu");
+  assert.match(result.message, /requires us/);
+  assert.equal(preflight.isClinicalHubPreflightActionAllowed(result), false);
+});
+
+test("warns when Clinical Hub URL region is not obvious", () => {
+  const result = preflight.buildClinicalHubPreflight("https://clinical.example.test");
+
+  assert.equal(result.status, "warning");
+  assert.equal(result.code, "region_unknown");
+  assert.equal(result.inferredRegion, null);
+  assert.equal(preflight.isClinicalHubPreflightActionAllowed(result), true);
+});

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -50,6 +50,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - icon/adaptive-icon paths, `expo-splash-screen` image path, SHA-256 fingerprints, byte sizes, PNG dimensions, and splash background/resize/width config,
 - runtime release metadata from `apps/field-mobile/src/config/releaseMetadata.ts` for app version, model ID, and capture schema version,
 - runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, single-region data residency policy, and disabled debug gates,
+- Clinical Hub preflight guard evidence proving the app blocks missing/unsupported URLs and obvious cross-region Hub targets before Test API, Submit, or Sync Queue,
 - runtime quality evidence for ROI validity, low-confidence depth ratio, and high-motion IMU artifact ratio in `capture_payload.analysis.runtime_quality`,
 - source-backed derivatives-only feature/media manifest evidence in `capture_contract.feature_manifest`, including manifest version, feature keys, `sample_count` source, `raw_media.*=false`, and `privacy.media_scope=roi_derivatives_only`,
 - readiness gate summary in `readiness`, including local/external/EAS/Clinical Hub statuses, local check counts, failed check IDs, external blocker statuses, and next-action IDs without secret values or detailed evidence strings,
@@ -60,7 +61,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, Clinical Hub preflight guard, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
@@ -179,13 +180,14 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 
 1. App starts and opens settings screen.
 2. `Release Identity` shows app version, model/schema, runtime mode, endpoint set, privacy/data-residency flags, and `Payload traceability: aligned`.
-3. `Device Model` is auto-filled from the physical device model or a platform fallback, and matches the smoke-log device entry after any field correction.
-4. `Start Capture` and `Stop Capture` work on real device.
-5. `Contract payload: ready` after stop.
-6. Submit produces `paired-measurements` and `capture-packages` records.
-7. Offline mode queues both endpoint jobs.
-8. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
-9. Repository-level deterministic smoke confirms queued paired+capture replay drains after network restore.
+3. API block shows Clinical Hub preflight status; missing URL is blocked, local/LAN smoke URL is warning-only, and live URL is confirmed against the configured region policy.
+4. `Device Model` is auto-filled from the physical device model or a platform fallback, and matches the smoke-log device entry after any field correction.
+5. `Start Capture` and `Stop Capture` work on real device.
+6. `Contract payload: ready` after stop.
+7. Submit produces `paired-measurements` and `capture-packages` records.
+8. Offline mode queues both endpoint jobs.
+9. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
+10. Repository-level deterministic smoke confirms queued paired+capture replay drains after network restore.
 
 ## 6) Evidence to archive per build
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -746,7 +746,13 @@ def build_readiness_report(
         mobile_root / "src" / "components" / "ReleaseIdentitySection.tsx"
     )
     clinical_hub_source_path = mobile_root / "src" / "api" / "clinicalHub.ts"
+    clinical_hub_preflight_source_path = (
+        mobile_root / "src" / "api" / "clinicalHubPreflight.ts"
+    )
     connection_check_source_path = mobile_root / "src" / "api" / "connectionCheck.ts"
+    api_connection_section_path = (
+        mobile_root / "src" / "components" / "ApiConnectionSection.tsx"
+    )
     pending_sync_queue_source_path = mobile_root / "src" / "utils" / "pendingSyncQueue.ts"
     pending_sync_hook_source_path = mobile_root / "src" / "hooks" / "usePendingSyncQueue.ts"
     pending_storage_source_path = mobile_root / "src" / "storage" / "pendingSubmissionStorage.ts"
@@ -754,6 +760,9 @@ def build_readiness_report(
     helper_tests_path = mobile_root / "tests" / "appHelpers.test.js"
     app_settings_storage_tests_path = mobile_root / "tests" / "appSettingsStorage.test.js"
     clinical_hub_api_tests_path = mobile_root / "tests" / "clinicalHub.test.js"
+    clinical_hub_preflight_tests_path = (
+        mobile_root / "tests" / "clinicalHubPreflight.test.js"
+    )
     connection_check_tests_path = mobile_root / "tests" / "connectionCheck.test.js"
     capture_package_payload_tests_path = mobile_root / "tests" / "capturePackagePayload.test.js"
     capture_contract_source_path = mobile_root / "src" / "capture" / "buildCaptureContract.ts"
@@ -805,7 +814,9 @@ def build_readiness_report(
     release_identity_source = _read_file_text(release_identity_source_path)
     release_identity_component_source = _read_file_text(release_identity_component_path)
     clinical_hub_source = _read_file_text(clinical_hub_source_path)
+    clinical_hub_preflight_source = _read_file_text(clinical_hub_preflight_source_path)
     connection_check_source = _read_file_text(connection_check_source_path)
+    api_connection_section_source = _read_file_text(api_connection_section_path)
     pending_sync_queue_source = _read_file_text(pending_sync_queue_source_path)
     pending_sync_hook_source = _read_file_text(pending_sync_hook_source_path)
     pending_storage_source = _read_file_text(pending_storage_source_path)
@@ -816,6 +827,9 @@ def build_readiness_report(
     release_identity_tests_path = mobile_root / "tests" / "releaseIdentity.test.js"
     release_identity_tests_source = _read_file_text(release_identity_tests_path)
     clinical_hub_tests_source = _read_file_text(clinical_hub_api_tests_path)
+    clinical_hub_preflight_tests_source = _read_file_text(
+        clinical_hub_preflight_tests_path
+    )
     connection_check_tests_source = _read_file_text(connection_check_tests_path)
     pending_sync_queue_tests_source = _read_file_text(pending_sync_queue_tests_path)
     pending_submission_storage_tests_source = _read_file_text(
@@ -955,6 +969,50 @@ def build_readiness_report(
         "clinical_hub_api_unit_tests_present",
         clinical_hub_api_tests_path.is_file(),
         f"path={clinical_hub_api_tests_path}",
+    )
+    clinical_hub_preflight_requirements = {
+        "source_file": clinical_hub_preflight_source_path.is_file(),
+        "uses_data_residency_policy": (
+            "APP_DATA_RESIDENCY_REGION" in clinical_hub_preflight_source
+            and "APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB"
+            in clinical_hub_preflight_source
+            and "APP_ALLOW_CROSS_REGION_SYNC" in clinical_hub_preflight_source
+        ),
+        "blocked_status": '"blocked"' in clinical_hub_preflight_source,
+        "region_mismatch_guard": "region_mismatch" in clinical_hub_preflight_source,
+        "app_uses_preflight": (
+            "buildClinicalHubPreflight" in app_ts_source
+            and "isClinicalHubPreflightActionAllowed" in app_ts_source
+        ),
+        "hook_uses_preflight": (
+            "buildClinicalHubPreflight" in pending_sync_hook_source
+            and "isClinicalHubPreflightActionAllowed" in pending_sync_hook_source
+        ),
+        "ui_displays_preflight": "clinicalHubPreflightMessage"
+        in api_connection_section_source,
+        "unit_runner_compiles_preflight": "src/api/clinicalHubPreflight.ts"
+        in unit_runner_source,
+    }
+    _check(
+        checks,
+        "clinical_hub_preflight_sources",
+        all(clinical_hub_preflight_requirements.values()),
+        f"requirements={clinical_hub_preflight_requirements!r}",
+    )
+    clinical_hub_preflight_test_requirements = {
+        "unit_test_file": clinical_hub_preflight_tests_path.is_file(),
+        "missing_url_test": "blocks missing Clinical Hub URL"
+        in clinical_hub_preflight_tests_source,
+        "local_smoke_warning_test": "allows local Clinical Hub smoke URLs with warning"
+        in clinical_hub_preflight_tests_source,
+        "cross_region_test": "blocks obvious cross-region Clinical Hub URLs"
+        in clinical_hub_preflight_tests_source,
+    }
+    _check(
+        checks,
+        "clinical_hub_preflight_unit_tests_present",
+        all(clinical_hub_preflight_test_requirements.values()),
+        f"requirements={clinical_hub_preflight_test_requirements!r}",
     )
     _check(
         checks,


### PR DESCRIPTION
## Summary
- add a Clinical Hub preflight helper that blocks missing/unsupported URLs and obvious cross-region Hub targets before field actions
- surface preflight status in the API section and reuse it for Test API, Submit, summaries, manual sync, and auto-sync gating
- add readiness gates, unit tests, and release/runbook docs for the preflight guard

## Local verification
- `cd apps/field-mobile && npm run typecheck && npm run test:unit` (83/83 mobile unit tests)
- `cd apps/field-mobile && npm run validate:ci`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (122 passed)
- `python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-clinical-preflight-final.json` -> `ready_except_external_credentials`, local `92/92 pass`, external blockers unchanged: `expo_token`, `eas_project_identity`, Clinical Hub live API missing

Note: an initial `npm run validate:ci` attempt saw a transient Expo Doctor package-version subprocess error; the isolated `npx expo install --check --json` returned `upToDate=true`, `npm run doctor` then passed 21/21, and the full `validate:ci` rerun passed.