### PR TITLE
Add Clinical Hub runtime trace headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,8 @@ npm run start:device
 Перед `Test API`, `Submit` и `Sync Queue` приложение выполняет Clinical Hub preflight:
 пустой/невалидный URL и очевидный cross-region Hub блокируются, local/LAN URL разрешён
 только как предупреждение для smoke-тестов.
+Все Clinical Hub запросы также несут runtime trace headers (`x-uroflow-*`) с app/model/schema,
+endpoint-set и data-residency политикой без секретных значений.
 
 ## Интеграция Project Package v2.8
 

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -24,6 +24,8 @@ Cross-platform mobile client (Expo React Native) for collecting paired measureme
 - Queue controls: `Test API`, `Sync Queue`, `Clear Queue`
 - Clinical Hub preflight is shown in the API block; missing/invalid URLs and obvious
   cross-region Hub targets are blocked before `Test API`, `Submit`, or `Sync Queue`.
+- All Clinical Hub requests include non-secret `x-uroflow-*` trace headers for app version,
+  model/schema, runtime mode, endpoint set, and data-residency policy.
 - Persisted local settings (`API URL`, `site/operator`, timeout, summary filter)
 - `API Key` stored in device secure storage (`expo-secure-store`) with AsyncStorage fallback
 - `Device Model` defaults from Expo Device metadata with platform fallback and remains editable for field correction.
@@ -103,6 +105,10 @@ The API block shows a preflight result. Missing/unsupported URLs block field act
 Local/LAN URLs are allowed with a warning for smoke tests. HTTPS URLs with an obvious
 non-US region token are blocked because the pilot runtime policy requires the configured
 single-region Clinical Hub.
+Requests add `x-uroflow-app-version`, `x-uroflow-model-id`,
+`x-uroflow-capture-schema-version`, `x-uroflow-runtime-mode`,
+`x-uroflow-endpoint-set`, and data-residency headers so Clinical Hub logs can be
+matched to the release manifest without exposing API keys or PHI.
 
 Examples:
 
@@ -149,6 +155,7 @@ secret blockers. The artifact has separate machine-readable gates:
   runtime config/defaults such as Clinical Hub v1 endpoint set, disabled debug gates,
   privacy-by-default switches, single-region data residency policy, Expo Device identity defaults,
   Clinical Hub preflight guard,
+  Clinical Hub runtime trace headers,
   in-app release identity evidence,
   runtime motion quality gates, derivatives-only feature/media
   manifest gates, pending sync connectivity-restore trigger, device-smoke evidence template/validator,

--- a/apps/field-mobile/src/api/clinicalHub.ts
+++ b/apps/field-mobile/src/api/clinicalHub.ts
@@ -4,7 +4,19 @@ import type {
   RequestHeaderContext,
   SubmitAttemptResult,
 } from "../types";
-import { APP_ENDPOINT_PATHS } from "../config/appConfig";
+import {
+  APP_DATA_RESIDENCY_BOUNDARY,
+  APP_DATA_RESIDENCY_REGION,
+  APP_ENDPOINT_PATHS,
+  APP_ENDPOINT_SET,
+  APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB,
+  APP_RUNTIME_MODE,
+} from "../config/appConfig";
+import {
+  APP_CAPTURE_SCHEMA_VERSION,
+  APP_MODEL_ID,
+  APP_RELEASE_VERSION,
+} from "../config/releaseMetadata";
 import {
   clampTimeoutMs,
   classifyRetryable,
@@ -28,11 +40,24 @@ export function endpointPath(endpoint: PendingEndpoint): string {
   return APP_ENDPOINT_PATHS[endpoint];
 }
 
+export function buildRuntimeTraceHeaders(): Record<string, string> {
+  return {
+    "x-uroflow-app-version": APP_RELEASE_VERSION,
+    "x-uroflow-model-id": APP_MODEL_ID,
+    "x-uroflow-capture-schema-version": APP_CAPTURE_SCHEMA_VERSION,
+    "x-uroflow-runtime-mode": APP_RUNTIME_MODE,
+    "x-uroflow-endpoint-set": APP_ENDPOINT_SET,
+    "x-uroflow-data-residency-region": APP_DATA_RESIDENCY_REGION,
+    "x-uroflow-data-residency-boundary": APP_DATA_RESIDENCY_BOUNDARY,
+    "x-uroflow-region-match-required": String(APP_REQUIRE_REGION_MATCHED_CLINICAL_HUB),
+  };
+}
+
 export function buildRequestHeaders(
   includeContentType: boolean,
   headerContext: RequestHeaderContext,
 ): Record<string, string> {
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = buildRuntimeTraceHeaders();
   if (includeContentType) {
     headers["Content-Type"] = "application/json";
   }

--- a/apps/field-mobile/tests/appHelpers.test.js
+++ b/apps/field-mobile/tests/appHelpers.test.js
@@ -184,6 +184,14 @@ test("buildRequestHeaders uses stable request id when provided", () => {
   assert.equal(headers["x-site-id"], "SITE-001");
   assert.equal(headers["x-operator-id"], "OP-01");
   assert.equal(headers["x-request-id"], "REQ-STABLE");
+  assert.equal(headers["x-uroflow-app-version"], "0.1.0");
+  assert.equal(headers["x-uroflow-model-id"], "fusion-v0.1");
+  assert.equal(headers["x-uroflow-capture-schema-version"], "ios_capture_v1");
+  assert.equal(headers["x-uroflow-runtime-mode"], "pilot");
+  assert.equal(headers["x-uroflow-endpoint-set"], "clinical_hub_v1");
+  assert.equal(headers["x-uroflow-data-residency-region"], "us");
+  assert.equal(headers["x-uroflow-data-residency-boundary"], "single_region");
+  assert.equal(headers["x-uroflow-region-match-required"], "true");
 });
 
 test("buildRequestHeaders creates a request id fallback without leaking empty headers", () => {
@@ -198,5 +206,6 @@ test("buildRequestHeaders creates a request id fallback without leaking empty he
   assert.equal(headers["x-site-id"], undefined);
   assert.equal(headers["x-operator-id"], undefined);
   assert.equal(headers["x-actor-role"], "operator");
+  assert.equal(headers["x-uroflow-data-residency-region"], "us");
   assert.match(headers["x-request-id"], /^PENDING-\d+-[a-z0-9]+$/);
 });

--- a/apps/field-mobile/tests/clinicalHub.test.js
+++ b/apps/field-mobile/tests/clinicalHub.test.js
@@ -44,6 +44,19 @@ test("isConfiguredApiBaseUrl requires explicit http or https Clinical Hub URL", 
   );
 });
 
+test("buildRuntimeTraceHeaders exposes release and residency metadata without secrets", () => {
+  assert.deepEqual(clinicalHub.buildRuntimeTraceHeaders(), {
+    "x-uroflow-app-version": "0.1.0",
+    "x-uroflow-model-id": "fusion-v0.1",
+    "x-uroflow-capture-schema-version": "ios_capture_v1",
+    "x-uroflow-runtime-mode": "pilot",
+    "x-uroflow-endpoint-set": "clinical_hub_v1",
+    "x-uroflow-data-residency-region": "us",
+    "x-uroflow-data-residency-boundary": "single_region",
+    "x-uroflow-region-match-required": "true",
+  });
+});
+
 test("attemptSubmitEndpoint posts serialized payloads with request headers", async () => {
   const originalFetch = global.fetch;
   try {
@@ -56,6 +69,14 @@ test("attemptSubmitEndpoint posts serialized payloads with request headers", asy
       assert.equal(init.headers["x-site-id"], "SITE-001");
       assert.equal(init.headers["x-operator-id"], "OP-001");
       assert.equal(init.headers["x-request-id"], "REQ-001");
+      assert.equal(init.headers["x-uroflow-app-version"], "0.1.0");
+      assert.equal(init.headers["x-uroflow-model-id"], "fusion-v0.1");
+      assert.equal(init.headers["x-uroflow-capture-schema-version"], "ios_capture_v1");
+      assert.equal(init.headers["x-uroflow-runtime-mode"], "pilot");
+      assert.equal(init.headers["x-uroflow-endpoint-set"], "clinical_hub_v1");
+      assert.equal(init.headers["x-uroflow-data-residency-region"], "us");
+      assert.equal(init.headers["x-uroflow-data-residency-boundary"], "single_region");
+      assert.equal(init.headers["x-uroflow-region-match-required"], "true");
       assert.deepEqual(JSON.parse(init.body), buildPayload());
       return new Response('{"id": 17}', { status: 201 });
     };

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -51,6 +51,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - runtime release metadata from `apps/field-mobile/src/config/releaseMetadata.ts` for app version, model ID, and capture schema version,
 - runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, single-region data residency policy, and disabled debug gates,
 - Clinical Hub preflight guard evidence proving the app blocks missing/unsupported URLs and obvious cross-region Hub targets before Test API, Submit, or Sync Queue,
+- Clinical Hub request trace header evidence proving app/model/schema, runtime mode, endpoint set, and data-residency policy are sent as non-secret `x-uroflow-*` headers on API checks, submissions, summaries, and sync replay,
 - runtime quality evidence for ROI validity, low-confidence depth ratio, and high-motion IMU artifact ratio in `capture_payload.analysis.runtime_quality`,
 - source-backed derivatives-only feature/media manifest evidence in `capture_contract.feature_manifest`, including manifest version, feature keys, `sample_count` source, `raw_media.*=false`, and `privacy.media_scope=roi_derivatives_only`,
 - readiness gate summary in `readiness`, including local/external/EAS/Clinical Hub statuses, local check counts, failed check IDs, external blocker statuses, and next-action IDs without secret values or detailed evidence strings,
@@ -61,7 +62,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, Clinical Hub preflight guard, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, Clinical Hub preflight guard, Clinical Hub runtime trace headers, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
@@ -181,13 +182,14 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 1. App starts and opens settings screen.
 2. `Release Identity` shows app version, model/schema, runtime mode, endpoint set, privacy/data-residency flags, and `Payload traceability: aligned`.
 3. API block shows Clinical Hub preflight status; missing URL is blocked, local/LAN smoke URL is warning-only, and live URL is confirmed against the configured region policy.
-4. `Device Model` is auto-filled from the physical device model or a platform fallback, and matches the smoke-log device entry after any field correction.
-5. `Start Capture` and `Stop Capture` work on real device.
-6. `Contract payload: ready` after stop.
-7. Submit produces `paired-measurements` and `capture-packages` records.
-8. Offline mode queues both endpoint jobs.
-9. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
-10. Repository-level deterministic smoke confirms queued paired+capture replay drains after network restore.
+4. Clinical Hub request logs include non-secret `x-uroflow-*` release/runtime/data-residency trace headers.
+5. `Device Model` is auto-filled from the physical device model or a platform fallback, and matches the smoke-log device entry after any field correction.
+6. `Start Capture` and `Stop Capture` work on real device.
+7. `Contract payload: ready` after stop.
+8. Submit produces `paired-measurements` and `capture-packages` records.
+9. Offline mode queues both endpoint jobs.
+10. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
+11. Repository-level deterministic smoke confirms queued paired+capture replay drains after network restore.
 
 ## 6) Evidence to archive per build
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -970,6 +970,52 @@ def build_readiness_report(
         clinical_hub_api_tests_path.is_file(),
         f"path={clinical_hub_api_tests_path}",
     )
+    runtime_trace_header_requirements = {
+        "helper_function": "buildRuntimeTraceHeaders" in clinical_hub_source,
+        "release_version_header": "x-uroflow-app-version" in clinical_hub_source
+        and "APP_RELEASE_VERSION" in clinical_hub_source,
+        "model_id_header": "x-uroflow-model-id" in clinical_hub_source
+        and "APP_MODEL_ID" in clinical_hub_source,
+        "capture_schema_header": "x-uroflow-capture-schema-version"
+        in clinical_hub_source
+        and "APP_CAPTURE_SCHEMA_VERSION" in clinical_hub_source,
+        "runtime_mode_header": "x-uroflow-runtime-mode" in clinical_hub_source
+        and "APP_RUNTIME_MODE" in clinical_hub_source,
+        "endpoint_set_header": "x-uroflow-endpoint-set" in clinical_hub_source
+        and "APP_ENDPOINT_SET" in clinical_hub_source,
+        "data_residency_headers": (
+            "x-uroflow-data-residency-region" in clinical_hub_source
+            and "APP_DATA_RESIDENCY_REGION" in clinical_hub_source
+            and "x-uroflow-data-residency-boundary" in clinical_hub_source
+            and "APP_DATA_RESIDENCY_BOUNDARY" in clinical_hub_source
+            and "x-uroflow-region-match-required" in clinical_hub_source
+        ),
+        "request_headers_include_trace": (
+            "const headers: Record<string, string> = buildRuntimeTraceHeaders()"
+            in clinical_hub_source
+        ),
+    }
+    _check(
+        checks,
+        "clinical_hub_runtime_trace_headers_sources",
+        all(runtime_trace_header_requirements.values()),
+        f"requirements={runtime_trace_header_requirements!r}",
+    )
+    runtime_trace_header_test_requirements = {
+        "runtime_trace_header_test": (
+            "buildRuntimeTraceHeaders exposes release and residency metadata without secrets"
+            in clinical_hub_tests_source
+        ),
+        "submit_header_test": "x-uroflow-data-residency-region"
+        in clinical_hub_tests_source,
+        "helper_header_test": "x-uroflow-runtime-mode" in helper_tests_source,
+    }
+    _check(
+        checks,
+        "clinical_hub_runtime_trace_headers_unit_tests_present",
+        all(runtime_trace_header_test_requirements.values()),
+        f"requirements={runtime_trace_header_test_requirements!r}",
+    )
     clinical_hub_preflight_requirements = {
         "source_file": clinical_hub_preflight_source_path.is_file(),
         "uses_data_residency_policy": (


### PR DESCRIPTION
## Summary
- add non-secret `x-uroflow-*` runtime trace headers to every Clinical Hub request
- cover app version, model ID, capture schema, runtime mode, endpoint set, and data-residency policy
- add unit tests, readiness gates, and release/runbook documentation for request traceability

## Local verification
- `cd apps/field-mobile && npm run typecheck && npm run test:unit` (84/84 mobile unit tests)
- `cd apps/field-mobile && npm run validate:ci`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (122 passed)
- `python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-trace-headers.json` -> `ready_except_external_credentials`, local `94/94 pass`, external blockers unchanged: `expo_token`, `eas_project_identity`, Clinical Hub live API missing