### PR TITLE
Enforce Clinical Hub runtime trace headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,8 @@ npm run start:device
 только как предупреждение для smoke-тестов.
 Все Clinical Hub запросы также несут runtime trace headers (`x-uroflow-*`) с app/model/schema,
 endpoint-set и data-residency политикой без секретных значений.
+Clinical Hub audit trail сохраняет эти trace headers и отклоняет запросы с явно
+несовпадающим `x-uroflow-data-residency-region`, endpoint-set или runtime-mode.
 
 ## Интеграция Project Package v2.8
 

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -51,7 +51,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - runtime release metadata from `apps/field-mobile/src/config/releaseMetadata.ts` for app version, model ID, and capture schema version,
 - runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, single-region data residency policy, and disabled debug gates,
 - Clinical Hub preflight guard evidence proving the app blocks missing/unsupported URLs and obvious cross-region Hub targets before Test API, Submit, or Sync Queue,
-- Clinical Hub request trace header evidence proving app/model/schema, runtime mode, endpoint set, and data-residency policy are sent as non-secret `x-uroflow-*` headers on API checks, submissions, summaries, and sync replay,
+- Clinical Hub request trace header evidence proving app/model/schema, runtime mode, endpoint set, and data-residency policy are sent as non-secret `x-uroflow-*` headers on API checks, submissions, summaries, and sync replay; backend audit stores these headers and rejects explicit region/runtime/endpoint mismatches,
 - runtime quality evidence for ROI validity, low-confidence depth ratio, and high-motion IMU artifact ratio in `capture_payload.analysis.runtime_quality`,
 - source-backed derivatives-only feature/media manifest evidence in `capture_contract.feature_manifest`, including manifest version, feature keys, `sample_count` source, `raw_media.*=false`, and `privacy.media_scope=roi_derivatives_only`,
 - readiness gate summary in `readiness`, including local/external/EAS/Clinical Hub statuses, local check counts, failed check IDs, external blocker statuses, and next-action IDs without secret values or detailed evidence strings,
@@ -182,7 +182,7 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 1. App starts and opens settings screen.
 2. `Release Identity` shows app version, model/schema, runtime mode, endpoint set, privacy/data-residency flags, and `Payload traceability: aligned`.
 3. API block shows Clinical Hub preflight status; missing URL is blocked, local/LAN smoke URL is warning-only, and live URL is confirmed against the configured region policy.
-4. Clinical Hub request logs include non-secret `x-uroflow-*` release/runtime/data-residency trace headers.
+4. Clinical Hub request logs include non-secret `x-uroflow-*` release/runtime/data-residency trace headers, and backend contract tests reject a deliberate mismatched region header.
 5. `Device Model` is auto-filled from the physical device model or a platform fallback, and matches the smoke-log device entry after any field correction.
 6. `Start Capture` and `Stop Capture` work on real device.
 7. `Contract payload: ready` after stop.

--- a/src/uroflow_mobile/clinical_hub.py
+++ b/src/uroflow_mobile/clinical_hub.py
@@ -5,7 +5,7 @@ import hashlib
 import json
 import math
 import sqlite3
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from contextlib import asynccontextmanager
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -27,6 +27,19 @@ PILOT_REPORT_TYPE = Literal[
     "gate_summary",
 ]
 _CROSS_SITE_ALLOWED_ROLES = {"data_manager", "admin"}
+_DEFAULT_EXPECTED_DATA_RESIDENCY_REGION = "us"
+_DEFAULT_EXPECTED_ENDPOINT_SET = "clinical_hub_v1"
+_DEFAULT_EXPECTED_RUNTIME_MODE = "pilot"
+_RUNTIME_TRACE_HEADER_KEYS = (
+    "x-uroflow-app-version",
+    "x-uroflow-model-id",
+    "x-uroflow-capture-schema-version",
+    "x-uroflow-runtime-mode",
+    "x-uroflow-endpoint-set",
+    "x-uroflow-data-residency-region",
+    "x-uroflow-data-residency-boundary",
+    "x-uroflow-region-match-required",
+)
 
 
 class FlowMetrics(BaseModel):
@@ -344,6 +357,70 @@ def _normalize_operator_id(operator_id: str | None) -> str | None:
     if not stripped:
         return None
     return stripped
+
+
+def _normalize_trace_value(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip().lower()
+    return stripped or None
+
+
+def _extract_runtime_trace_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    trace_headers: dict[str, str] = {}
+    for key in _RUNTIME_TRACE_HEADER_KEYS:
+        value = headers.get(key)
+        if value is None:
+            continue
+        stripped = value.strip()
+        if stripped:
+            trace_headers[key] = stripped
+    return trace_headers
+
+
+def _build_runtime_trace_policy_error(
+    trace_headers: dict[str, str],
+    *,
+    expected_data_residency_region: str | None,
+    expected_endpoint_set: str | None,
+    expected_runtime_mode: str | None,
+) -> str | None:
+    expected_by_header = {
+        "x-uroflow-data-residency-region": expected_data_residency_region,
+        "x-uroflow-endpoint-set": expected_endpoint_set,
+        "x-uroflow-runtime-mode": expected_runtime_mode,
+    }
+    label_by_header = {
+        "x-uroflow-data-residency-region": "data residency region",
+        "x-uroflow-endpoint-set": "endpoint set",
+        "x-uroflow-runtime-mode": "runtime mode",
+    }
+    for header, expected in expected_by_header.items():
+        observed = _normalize_trace_value(trace_headers.get(header))
+        if observed is None or expected is None or observed == expected:
+            continue
+        return (
+            f"runtime trace {label_by_header[header]} mismatch: "
+            f"expected {expected}, got {observed}"
+        )
+    return None
+
+
+def _build_audit_detail_json(
+    *,
+    query: str,
+    reason: str | None = None,
+    runtime_trace_headers: dict[str, str] | None = None,
+    expected_runtime_trace: dict[str, str | None] | None = None,
+) -> str:
+    detail: dict[str, object] = {"query": query}
+    if reason is not None:
+        detail["reason"] = reason
+    if runtime_trace_headers:
+        detail["runtime_trace_headers"] = runtime_trace_headers
+    if expected_runtime_trace is not None:
+        detail["expected_runtime_trace"] = expected_runtime_trace
+    return json.dumps(detail, ensure_ascii=False)
 
 
 def _connect(db_path: Path) -> sqlite3.Connection:
@@ -2123,6 +2200,9 @@ def create_clinical_hub_app(
     db_path: Path,
     api_key: str | None = None,
     api_key_policy_map: dict[str, dict[str, str | None]] | None = None,
+    expected_data_residency_region: str = _DEFAULT_EXPECTED_DATA_RESIDENCY_REGION,
+    expected_endpoint_set: str = _DEFAULT_EXPECTED_ENDPOINT_SET,
+    expected_runtime_mode: str = _DEFAULT_EXPECTED_RUNTIME_MODE,
 ) -> FastAPI:
     @asynccontextmanager
     async def _lifespan(_: FastAPI) -> AsyncIterator[None]:
@@ -2138,6 +2218,11 @@ def create_clinical_hub_app(
     app.state.db_path = db_path
     app.state.api_key = api_key
     app.state.api_key_policy_map = _validate_api_key_policy_map(api_key_policy_map)
+    app.state.expected_runtime_trace = {
+        "data_residency_region": _normalize_trace_value(expected_data_residency_region),
+        "endpoint_set": _normalize_trace_value(expected_endpoint_set),
+        "runtime_mode": _normalize_trace_value(expected_runtime_mode),
+    }
 
     @app.middleware("http")
     async def _audit_and_auth_middleware(
@@ -2151,6 +2236,8 @@ def create_clinical_hub_app(
         body_bytes = await request.body()
         session_meta = _extract_session_metadata_from_body(body_bytes)
         request_api_key = request.headers.get("x-api-key")
+        runtime_trace_headers = _extract_runtime_trace_headers(request.headers)
+        expected_runtime_trace = app.state.expected_runtime_trace
         actor_operator_id = _normalize_operator_id(request.headers.get("x-operator-id"))
         if actor_operator_id is None:
             actor_operator_id = _normalize_operator_id(session_meta["operator_id"])
@@ -2202,12 +2289,49 @@ def create_clinical_hub_app(
                     subject_id=session_meta["subject_id"],
                     operator_id=session_meta["operator_id"],
                     remote_addr=request.client.host if request.client else None,
-                    detail_json=json.dumps(
-                        {
-                            "query": str(request.url.query),
-                            "reason": "missing_or_invalid_api_key",
-                        },
-                        ensure_ascii=False,
+                    detail_json=_build_audit_detail_json(
+                        query=str(request.url.query),
+                        reason="missing_or_invalid_api_key",
+                        runtime_trace_headers=runtime_trace_headers,
+                        expected_runtime_trace=expected_runtime_trace,
+                    ),
+                )
+                audit_connection.commit()
+            return response
+
+        runtime_trace_error = _build_runtime_trace_policy_error(
+            runtime_trace_headers,
+            expected_data_residency_region=expected_runtime_trace[
+                "data_residency_region"
+            ],
+            expected_endpoint_set=expected_runtime_trace["endpoint_set"],
+            expected_runtime_mode=expected_runtime_trace["runtime_mode"],
+        )
+        if runtime_trace_error is not None:
+            response = JSONResponse(status_code=400, content={"detail": runtime_trace_error})
+            with _connect(app.state.db_path) as audit_connection:
+                _insert_audit_event(
+                    audit_connection,
+                    method=request.method,
+                    path=path,
+                    status_code=400,
+                    auth_result=auth_result,
+                    api_key_fingerprint=_hash_api_key(request_api_key),
+                    actor_operator_id=actor_operator_id,
+                    actor_role=actor_role,
+                    actor_site_id=actor_site_id,
+                    request_id=request_id,
+                    session_id=session_meta["session_id"],
+                    sync_id=session_meta["sync_id"],
+                    site_id=session_meta["site_id"],
+                    subject_id=session_meta["subject_id"],
+                    operator_id=session_meta["operator_id"],
+                    remote_addr=request.client.host if request.client else None,
+                    detail_json=_build_audit_detail_json(
+                        query=str(request.url.query),
+                        reason="runtime_trace_policy_mismatch",
+                        runtime_trace_headers=runtime_trace_headers,
+                        expected_runtime_trace=expected_runtime_trace,
                     ),
                 )
                 audit_connection.commit()
@@ -2240,12 +2364,11 @@ def create_clinical_hub_app(
                     subject_id=session_meta["subject_id"],
                     operator_id=session_meta["operator_id"],
                     remote_addr=request.client.host if request.client else None,
-                    detail_json=json.dumps(
-                        {
-                            "query": str(request.url.query),
-                            "reason": "missing_actor_operator_id_for_operator_role",
-                        },
-                        ensure_ascii=False,
+                    detail_json=_build_audit_detail_json(
+                        query=str(request.url.query),
+                        reason="missing_actor_operator_id_for_operator_role",
+                        runtime_trace_headers=runtime_trace_headers,
+                        expected_runtime_trace=expected_runtime_trace,
                     ),
                 )
                 audit_connection.commit()
@@ -2275,7 +2398,13 @@ def create_clinical_hub_app(
                 subject_id=session_meta["subject_id"],
                 operator_id=session_meta["operator_id"],
                 remote_addr=request.client.host if request.client else None,
-                detail_json=json.dumps({"query": str(request.url.query)}, ensure_ascii=False),
+                detail_json=_build_audit_detail_json(
+                    query=str(request.url.query),
+                    runtime_trace_headers=runtime_trace_headers,
+                    expected_runtime_trace=expected_runtime_trace
+                    if runtime_trace_headers
+                    else None,
+                ),
             )
             audit_connection.commit()
         return response

--- a/tests/test_clinical_hub.py
+++ b/tests/test_clinical_hub.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import json
 from io import StringIO
 from pathlib import Path
 
@@ -543,6 +544,67 @@ def test_clinical_hub_api_key_and_audit_export(tmp_path: Path) -> None:
 
     assert len(rows) >= 2
     assert any(row["status_code"] == "401" for row in rows)
+
+
+def test_clinical_hub_runtime_trace_headers_are_audited_and_enforced(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "clinical_hub_runtime_trace.db"
+    app = create_clinical_hub_app(db_path)
+    trace_headers = {
+        "x-uroflow-app-version": "0.1.0",
+        "x-uroflow-model-id": "fusion-v0.1",
+        "x-uroflow-capture-schema-version": "ios_capture_v1",
+        "x-uroflow-runtime-mode": "pilot",
+        "x-uroflow-endpoint-set": "clinical_hub_v1",
+        "x-uroflow-data-residency-region": "us",
+        "x-uroflow-data-residency-boundary": "single_region",
+        "x-uroflow-region-match-required": "true",
+    }
+
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/paired-measurements",
+            json=_payload(session_id="session-trace-001", sync_id="sync-trace-001"),
+            headers=trace_headers,
+        )
+        assert created.status_code == 201
+
+        rejected = client.post(
+            "/api/v1/paired-measurements",
+            json=_payload(session_id="session-trace-002", sync_id="sync-trace-002"),
+            headers={**trace_headers, "x-uroflow-data-residency-region": "eu"},
+        )
+        assert rejected.status_code == 400
+        assert "expected us, got eu" in rejected.json()["detail"]
+
+        audit_events = client.get("/api/v1/audit-events")
+        assert audit_events.status_code == 200
+        events = audit_events.json()
+
+    accepted_details = [
+        json.loads(item["detail_json"])
+        for item in events
+        if item["sync_id"] == "sync-trace-001" and item["status_code"] == 201
+    ]
+    assert accepted_details
+    assert (
+        accepted_details[0]["runtime_trace_headers"]["x-uroflow-data-residency-region"]
+        == "us"
+    )
+    assert accepted_details[0]["expected_runtime_trace"]["endpoint_set"] == "clinical_hub_v1"
+
+    rejected_details = [
+        json.loads(item["detail_json"])
+        for item in events
+        if item["sync_id"] == "sync-trace-002" and item["status_code"] == 400
+    ]
+    assert rejected_details
+    assert rejected_details[0]["reason"] == "runtime_trace_policy_mismatch"
+    assert (
+        rejected_details[0]["runtime_trace_headers"]["x-uroflow-data-residency-region"]
+        == "eu"
+    )
 
 
 def test_pilot_automation_reports_crud_and_csv_export(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- audit non-secret `x-uroflow-*` runtime trace headers in Clinical Hub request audit events
- reject requests with explicit mismatched data-residency region, endpoint set, or runtime mode while preserving legacy clients that omit the headers
- add backend contract coverage and release docs for header enforcement

## Local verification
- `.venv/bin/ruff check src/uroflow_mobile/clinical_hub.py tests/test_clinical_hub.py`
- `.venv/bin/pytest -q tests/test_clinical_hub.py` (21 passed)
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (123 passed)
- `python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-backend-trace-enforcement.json` -> `ready_except_external_credentials`, local `94/94 pass`, external blockers unchanged