### PR TITLE
Add mobile EAS submit readiness gates

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -152,6 +152,7 @@ CI:
 secret blockers. The artifact has separate machine-readable gates:
 
 - `local_checks_status`: local app metadata, runtime release metadata, EAS profile shape,
+  EAS production submit shape for TestFlight / Play Internal Testing handoff,
   runtime config/defaults such as Clinical Hub v1 endpoint set, disabled debug gates,
   privacy-by-default switches, single-region data residency policy, Expo Device identity defaults,
   Clinical Hub preflight guard,
@@ -176,8 +177,8 @@ release handoff checklist:
 | `configure_expo_token` | `gh secret set EXPO_TOKEN --body "<expo_access_token>"` | Re-run `Mobile Build`; `external_items.expo_token` becomes `present`. |
 | `configure_eas_project_identity` | `gh variable set EAS_PROJECT_ID --body "<eas_project_uuid>"` or commit `expo.extra.eas.projectId` in `app.json` | Re-run `Mobile Build`; `external_items.eas_project_identity` becomes `present`. |
 | `configure_clinical_hub_live_api` | `gh secret set CLINICAL_HUB_URL --body "https://<clinical-hub>"` and `gh secret set CLINICAL_HUB_API_KEY --body "<api_key>"` | Re-run `Mobile Build`; `external_items.clinical_hub_live_api` becomes `present` rather than `missing`/`invalid`. |
-| `provision_apple_developer_account` | Apple Developer access, signing certificates/profiles, and TestFlight permissions | Trigger signed iOS EAS build and confirm TestFlight upload readiness. |
-| `provision_google_play_account` | Google Play Console access, Android signing, and internal testing track permissions | Trigger signed Android EAS build and confirm Play Internal Testing upload readiness. |
+| `provision_apple_developer_account` | Apple Developer access, App Store Connect app record, signing certificates/profiles, and TestFlight permissions | Trigger signed iOS EAS build and confirm TestFlight upload readiness. |
+| `provision_google_play_account` | Google Play Console access, Android signing, internal testing track permissions, and EAS file secret `GOOGLE_SERVICE_ACCOUNT` | Trigger signed Android EAS build and confirm Play Internal Testing upload readiness. |
 
 Do not commit secret values. Keep live Clinical Hub keys in GitHub Actions secrets and device-local
 app settings only.
@@ -205,6 +206,18 @@ or via npm script:
 ```bash
 npm run build:preview
 ```
+
+Production store submit commands are also wired for authenticated release handoff:
+
+```bash
+npm run submit:ios:production
+npm run submit:android:production
+npm run submit:production
+```
+
+iOS submit still requires the external App Store Connect app record and Apple credentials.
+Android submit uses `submit.production.android.serviceAccountKeyPath=@secret:GOOGLE_SERVICE_ACCOUNT`
+and targets the Play Internal Testing track.
 
 Detailed release SOP:
 - `docs/mobile-release-runbook-v0.1.md`

--- a/apps/field-mobile/eas.json
+++ b/apps/field-mobile/eas.json
@@ -21,6 +21,13 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {},
+      "android": {
+        "serviceAccountKeyPath": "@secret:GOOGLE_SERVICE_ACCOUNT",
+        "track": "internal",
+        "releaseStatus": "completed"
+      }
+    }
   }
 }

--- a/apps/field-mobile/package-lock.json
+++ b/apps/field-mobile/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "12.0.1",
-        "expo": "56.0.8",
-        "expo-asset": "~56.0.15",
+        "expo": "~56.0.9",
+        "expo-asset": "~56.0.16",
         "expo-audio": "~56.0.11",
         "expo-camera": "~56.0.7",
         "expo-device": "~56.0.4",
@@ -1191,9 +1191,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.19.3.tgz",
-      "integrity": "sha512-w9Au2IVrtc0Ct+WRa05DVHGNHXYq6VyPZWuFP+5x055OeZ5q6k5Yg+aJ1gfShmjdOhDftRcsvmWmTdTZlWaTZw==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.19.4.tgz",
+      "integrity": "sha512-PsowRlO8+S7JlO8go7yhNEXp7sqlsWDE2AlCwoss7zH0dcajXFo74Fy0KdXEc4UXK7kKoHD37oDgsZ8aHSLr7A==",
       "license": "MIT",
       "dependencies": {
         "@expo/env": "^2.3.0",
@@ -1228,9 +1228,9 @@
       }
     },
     "node_modules/@expo/inline-modules": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.0.10.tgz",
-      "integrity": "sha512-DKEfq877UTAmL/gOT5aFhlLNDg/EVmTSca7JQMKDGR6mjFSAcrmQf4GJNsi6ztiaqj6cTnIfoSz0hAYdnr6RJQ==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.0.11.tgz",
+      "integrity": "sha512-ZlIfKL61DPnW8YUTdMEjMA31xrDDV6p7Xi8rWYyhd5qXBV8MwGwjuJ7vKeaVaMjRqxJk1N9lv7zlfyvQpRCNNw==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-plugins": "~56.0.8"
@@ -1276,73 +1276,6 @@
         "metro-symbolicate": "0.84.4",
         "metro-transform-plugins": "0.84.4",
         "metro-transform-worker": "0.84.4"
-      }
-    },
-    "node_modules/@expo/metro-config": {
-      "version": "56.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-56.0.13.tgz",
-      "integrity": "sha512-OPyNYiex/6Ms8zT2POdIZsLhcAZYk7O+yJvpz5uG/4QRA7aiESfCy1I+0YHewMlR4P1YQeyxIrfTurs6m9xfZA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.5",
-        "@expo/config": "~56.0.9",
-        "@expo/env": "~2.3.0",
-        "@expo/json-file": "~10.2.0",
-        "@expo/metro": "~56.0.0",
-        "@expo/require-utils": "^56.1.3",
-        "@expo/spawn-async": "^1.8.0",
-        "@jridgewell/gen-mapping": "^0.3.13",
-        "@jridgewell/remapping": "^2.3.5",
-        "@jridgewell/sourcemap-codec": "^1.5.5",
-        "browserslist": "^4.25.0",
-        "chalk": "^4.1.0",
-        "debug": "^4.3.2",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "hermes-parser": "^0.33.3",
-        "jsc-safe-url": "^0.2.4",
-        "lightningcss": "^1.30.1",
-        "msgpackr": "^2.0.1",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "resolve-from": "^5.0.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/hermes-estree": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
-      "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
-      "license": "MIT"
-    },
-    "node_modules/@expo/metro-config/node_modules/hermes-parser": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
-      "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.33.3"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@expo/metro-file-map": {
@@ -1397,9 +1330,9 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "56.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-56.0.14.tgz",
-      "integrity": "sha512-JHdMqR7Mf5ApLC50ZwTL0Z86ezrHOMYwoSHcWT6Pha/+1TcC+/J+i7vjhP06wGXQ2Kvjt74p/3mKg2Pd12KjhQ==",
+      "version": "56.0.15",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-56.0.15.tgz",
+      "integrity": "sha512-6GC+QjdCkzp/5wjsqgfu/B2+2yf5MyZMtzf9szIPrLt9uKhzV2PdyM0vU0kvbj1YT8weHCtO7bsrzimman0sjA==",
       "license": "MIT",
       "dependencies": {
         "@expo/config": "~56.0.9",
@@ -1409,7 +1342,7 @@
         "@expo/json-file": "^10.2.0",
         "@react-native/normalize-colors": "0.85.3",
         "debug": "^4.3.1",
-        "expo-modules-autolinking": "~56.0.14",
+        "expo-modules-autolinking": "~56.0.15",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
       }
@@ -2766,31 +2699,31 @@
       }
     },
     "node_modules/expo": {
-      "version": "56.0.8",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-56.0.8.tgz",
-      "integrity": "sha512-GzQi5450yrCk5JRSlm0epsmtURBErh0wS77uWLZImFdnPICuX912MaRWooR+Q1Sw/7aQjp9F+KXH+dvrqGxpeQ==",
+      "version": "56.0.9",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-56.0.9.tgz",
+      "integrity": "sha512-Zd/fhhyC600PO4cA14r+K+DlhhUZLNaDNF6dYg+hgne2kLvg9HMnkZ902sTPZYLkW56JOXLJ5dk7hsIoH26N2A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "^56.1.13",
+        "@expo/cli": "^56.1.14",
         "@expo/config": "~56.0.9",
         "@expo/config-plugins": "~56.0.8",
         "@expo/devtools": "~56.0.2",
         "@expo/dom-webview": "~56.0.5",
-        "@expo/fingerprint": "^0.19.3",
+        "@expo/fingerprint": "^0.19.4",
         "@expo/local-build-cache-provider": "^56.0.8",
         "@expo/log-box": "^56.0.12",
         "@expo/metro": "~56.0.0",
         "@expo/metro-config": "~56.0.13",
         "@ungap/structured-clone": "^1.3.0",
         "babel-preset-expo": "~56.0.14",
-        "expo-asset": "~56.0.15",
-        "expo-constants": "~56.0.16",
+        "expo-asset": "~56.0.16",
+        "expo-constants": "~56.0.17",
         "expo-file-system": "~56.0.7",
         "expo-font": "~56.0.5",
         "expo-keep-awake": "~56.0.3",
-        "expo-modules-autolinking": "~56.0.14",
-        "expo-modules-core": "~56.0.14",
+        "expo-modules-autolinking": "~56.0.15",
+        "expo-modules-core": "~56.0.15",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-minimum": "^0.1.2"
@@ -2828,13 +2761,13 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "56.0.15",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-56.0.15.tgz",
-      "integrity": "sha512-BHGi2IAOPQTcOelkUdcz1WIknfCTRjkcpYHX1azjMwgYenrVC+J5qcqJGaC8eUOWLCRtkRJWGnmFQRYtLU1nUQ==",
+      "version": "56.0.16",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-56.0.16.tgz",
+      "integrity": "sha512-iIxPo6C6+/d8JxGV74ZKZbIcCz2s8//dVl7oBAj124NcPMFhzdwycFBpMqq5LUxin+lVy5cCoEjv2LD8ulnkiQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/image-utils": "^0.10.1",
-        "expo-constants": "~56.0.16"
+        "expo-constants": "~56.0.17"
       },
       "peerDependencies": {
         "expo": "*",
@@ -2875,9 +2808,9 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "56.0.16",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.16.tgz",
-      "integrity": "sha512-6tsiN+gmTUPp/atyA+uY9Tg8VOdXdmb4s/3TVGolfn6A/oCAraw1pcPZX5XllyD+xUguxB6eBSFAT8494hZVMA==",
+      "version": "56.0.17",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.17.tgz",
+      "integrity": "sha512-bU8iU1+7cI7QzfGQVnz2C1nlbXD08YPwD6h8ZEuNspgUuD2prXfmrhrdLe1GjCPYGw4hB3BNjWPjpenNyyymfQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/env": "~2.3.0"
@@ -2913,9 +2846,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "56.0.14",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-56.0.14.tgz",
-      "integrity": "sha512-9ugtZkheNPYDkW4DZopY1rH2BCbUICaafUEPxRgbLDR5UNRF5K3cdHMIMEt8pxZPq2+eX4wCm+6pbSvdY/DPHg==",
+      "version": "56.0.15",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-56.0.15.tgz",
+      "integrity": "sha512-WqpBFwLzn7DsrUkWltIjVmAjwuI1VdQ2jRMlvk1nh2kVadwdJBkSjUBQWRifsEePNhiMT/rFOovBolUU/ARt5w==",
       "license": "MIT",
       "dependencies": {
         "@expo/require-utils": "^56.1.3",
@@ -2928,13 +2861,13 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "56.0.14",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.14.tgz",
-      "integrity": "sha512-dl1TlYRm1k7xk9QeAyDoMfFE2p6rNyzHUcH5ArcGwUzO8YKku+Z2tQ8+kG7zLe3OhfMoJcFR/czrFy7vGSVI6w==",
+      "version": "56.0.15",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.15.tgz",
+      "integrity": "sha512-XOXuWjtUA/xF8VjMHoRTRxuAmrAeUv8QyASX3h/CpTNS58fOt3stV8EYW7BinJPJyqwV7BZoYV83iN0p2FzyZw==",
       "license": "MIT",
       "dependencies": {
         "@expo/expo-modules-macros-plugin": "~0.0.9",
-        "expo-modules-jsi": "~56.0.7",
+        "expo-modules-jsi": "~56.0.8",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
@@ -2949,9 +2882,9 @@
       }
     },
     "node_modules/expo-modules-jsi": {
-      "version": "56.0.7",
-      "resolved": "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-56.0.7.tgz",
-      "integrity": "sha512-iBAj4Xeh/8HT201VVxFlmf+VBfmtQV1ZUoJdLQQENm0+j9gnD2QswZLJyNo3CmNNXl46esJeLR5lpGpYZts/zA==",
+      "version": "56.0.8",
+      "resolved": "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-56.0.8.tgz",
+      "integrity": "sha512-tXqFU1MHrf7Ctq+Pw0qOeIPDFl1W51p9nRRZy9vVUn4GNuAk1Av0vrj0SGLvcxJvDf3aGwSzr8o8dgUsX5sG0g==",
       "license": "MIT",
       "peerDependencies": {
         "react-native": "*"
@@ -2980,9 +2913,9 @@
       }
     },
     "node_modules/expo-server": {
-      "version": "56.0.4",
-      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-56.0.4.tgz",
-      "integrity": "sha512-4dJ57KuAwDl7eQGD6aG9kTzBIftWAfHH1+6Zxy7NcPCBrKYis3/H5enGUz1asH8HHhONXfJ5BdJqfEWAEAgWxA==",
+      "version": "56.0.5",
+      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-56.0.5.tgz",
+      "integrity": "sha512-SmM2p2g3Jrktpiazcst+OxhjSzOHXKAY4BPURHYHXvApzzoybMmrNF4IEZ8DKZ145BhSe4ydAmlEFCRTsdtgUQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
@@ -3014,9 +2947,9 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "56.1.13",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-56.1.13.tgz",
-      "integrity": "sha512-7n5VzlBr7TKW0BgWgpEopWy+v8buPhMvbSEsuXD+bI1YIJBopkfWAub0qTvlc357E8wWOvV5MJXYyoeRvoOjoQ==",
+      "version": "56.1.14",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-56.1.14.tgz",
+      "integrity": "sha512-rSH3ygjEPipEYG6dgiJ116J8KqCQ/BYKcwQDipStSh4IFWJ10RZaYP4u5B74jxfeIWjWrOeqvwB6NZfQBjaQ4Q==",
       "license": "MIT",
       "dependencies": {
         "@expo/code-signing-certificates": "^0.0.6",
@@ -3025,7 +2958,7 @@
         "@expo/devcert": "^1.2.1",
         "@expo/env": "~2.3.0",
         "@expo/image-utils": "^0.10.1",
-        "@expo/inline-modules": "^0.0.10",
+        "@expo/inline-modules": "^0.0.11",
         "@expo/json-file": "^10.2.0",
         "@expo/log-box": "^56.0.12",
         "@expo/metro": "~56.0.0",
@@ -3034,9 +2967,9 @@
         "@expo/osascript": "^2.6.0",
         "@expo/package-manager": "^1.12.1",
         "@expo/plist": "^0.7.0",
-        "@expo/prebuild-config": "^56.0.14",
+        "@expo/prebuild-config": "^56.0.15",
         "@expo/require-utils": "^56.1.3",
-        "@expo/router-server": "^56.0.12",
+        "@expo/router-server": "^56.0.13",
         "@expo/schema-utils": "^56.0.0",
         "@expo/spawn-async": "^1.8.0",
         "@expo/ws-tunnel": "^1.0.1",
@@ -3052,7 +2985,7 @@
         "connect": "^3.7.0",
         "debug": "^4.3.4",
         "dnssd-advertise": "^1.1.4",
-        "expo-server": "^56.0.4",
+        "expo-server": "^56.0.5",
         "fetch-nodeshim": "^0.4.10",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
@@ -3095,20 +3028,20 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/router-server": {
-      "version": "56.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-56.0.12.tgz",
-      "integrity": "sha512-RqKV2/Z8BH/z8l0ngSpG6//5xxJPaF5dTQvSfPQ0nrvCjikGMeIvyj3B9BeLnmZZhxb3gBtXqrj3irAoiIp2aQ==",
+      "version": "56.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-56.0.13.tgz",
+      "integrity": "sha512-M2H2zHlRBKIPENCWV8Gqo3/9WANCS9vvOMCcdWfS9wD8XXMnDASFniS0bBoGwwS1qq1LIpYzX8m8wdv7Awy88g==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
       },
       "peerDependencies": {
-        "@expo/metro-runtime": "^56.0.13",
+        "@expo/metro-runtime": "^56.0.14",
         "expo": "*",
-        "expo-constants": "^56.0.16",
+        "expo-constants": "^56.0.17",
         "expo-font": "^56.0.5",
         "expo-router": "*",
-        "expo-server": "^56.0.4",
+        "expo-server": "^56.0.5",
         "react": "*",
         "react-dom": "*",
         "react-server-dom-webpack": "~19.0.1 || ~19.1.2 || ~19.2.1"
@@ -3154,6 +3087,46 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo/node_modules/@expo/metro-config": {
+      "version": "56.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-56.0.13.tgz",
+      "integrity": "sha512-OPyNYiex/6Ms8zT2POdIZsLhcAZYk7O+yJvpz5uG/4QRA7aiESfCy1I+0YHewMlR4P1YQeyxIrfTurs6m9xfZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.5",
+        "@expo/config": "~56.0.9",
+        "@expo/env": "~2.3.0",
+        "@expo/json-file": "~10.2.0",
+        "@expo/metro": "~56.0.0",
+        "@expo/require-utils": "^56.1.3",
+        "@expo/spawn-async": "^1.8.0",
+        "@jridgewell/gen-mapping": "^0.3.13",
+        "@jridgewell/remapping": "^2.3.5",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "browserslist": "^4.25.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.2",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "hermes-parser": "^0.33.3",
+        "jsc-safe-url": "^0.2.4",
+        "lightningcss": "^1.30.1",
+        "msgpackr": "^2.0.1",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo/node_modules/accepts": {
@@ -3283,6 +3256,21 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo/node_modules/hermes-estree": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
+      "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
+      "license": "MIT"
+    },
+    "node_modules/expo/node_modules/hermes-parser": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
+      "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.33.3"
       }
     },
     "node_modules/expo/node_modules/mime-db": {

--- a/apps/field-mobile/package.json
+++ b/apps/field-mobile/package.json
@@ -20,13 +20,16 @@
     "export:android": "CI=1 expo export --platform android --clear --output-dir /tmp/uroflow-field-mobile-export-android",
     "validate:ci": "npm run typecheck && npm run test:unit && npm run doctor && npm run audit:prod && npm run export:ios && npm run export:android",
     "build:preview": "eas build --platform all --profile preview",
-    "build:production": "eas build --platform all --profile production"
+    "build:production": "eas build --platform all --profile production",
+    "submit:ios:production": "eas submit --platform ios --profile production --non-interactive",
+    "submit:android:production": "eas submit --platform android --profile production --non-interactive",
+    "submit:production": "eas submit --platform all --profile production --non-interactive"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "12.0.1",
-    "expo": "56.0.8",
-    "expo-asset": "~56.0.15",
+    "expo": "~56.0.9",
+    "expo-asset": "~56.0.16",
     "expo-audio": "~56.0.11",
     "expo-camera": "~56.0.7",
     "expo-device": "~56.0.4",

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -10,7 +10,9 @@ Scope: pilot installable builds for Uroflow Field Mobile
 3. GitHub secret `EXPO_TOKEN` configured.
 4. `EAS_PROJECT_ID` configured as a GitHub repo variable or `expo.extra.eas.projectId` set in `app.json`.
 5. Expo project credentials configured for iOS and Android signing.
-6. Clinical Hub secrets configured when live API smoke/report push is part of the release:
+6. App Store Connect app record exists for the iOS bundle ID before TestFlight submit.
+7. Google Play Console app exists for the Android package and EAS file secret `GOOGLE_SERVICE_ACCOUNT` is configured for Play API submit.
+8. Clinical Hub secrets configured when live API smoke/report push is part of the release:
    - `CLINICAL_HUB_URL` (`https://...`, non-localhost for live release readiness)
    - `CLINICAL_HUB_API_KEY`
 
@@ -41,6 +43,20 @@ cd apps/field-mobile
 npm run build:preview
 ```
 
+Production store-submit fallback after a signed production build is available:
+
+```bash
+cd apps/field-mobile
+npm run submit:ios:production
+npm run submit:android:production
+# or submit both platforms from the production profile:
+npm run submit:production
+```
+
+Do not commit Apple credentials or Google service-account JSON. Android submit is configured to read
+the Google Play service account as EAS file secret `GOOGLE_SERVICE_ACCOUNT`; iOS submit still depends
+on Apple Developer/App Store Connect credentials and the external app record.
+
 ## 3) Release manifest and traceability
 
 Workflow generates artifact `mobile-release-manifest` containing:
@@ -50,6 +66,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - icon/adaptive-icon paths, `expo-splash-screen` image path, SHA-256 fingerprints, byte sizes, PNG dimensions, and splash background/resize/width config,
 - runtime release metadata from `apps/field-mobile/src/config/releaseMetadata.ts` for app version, model ID, and capture schema version,
 - runtime app config from `apps/field-mobile/src/config/appConfig.ts` for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, single-region data residency policy, and disabled debug gates,
+- EAS production submit config shape for iOS handoff and Android Play Internal Testing via `@secret:GOOGLE_SERVICE_ACCOUNT`,
 - Clinical Hub preflight guard evidence proving the app blocks missing/unsupported URLs and obvious cross-region Hub targets before Test API, Submit, or Sync Queue,
 - Clinical Hub request trace header evidence proving app/model/schema, runtime mode, endpoint set, and data-residency policy are sent as non-secret `x-uroflow-*` headers on API checks, submissions, summaries, and sync replay; backend audit stores these headers and rejects explicit region/runtime/endpoint mismatches,
 - runtime quality evidence for ROI validity, low-confidence depth ratio, and high-motion IMU artifact ratio in `capture_payload.analysis.runtime_quality`,
@@ -62,7 +79,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, Clinical Hub preflight guard, Clinical Hub runtime trace headers, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, EAS build/submit profile shape, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, Clinical Hub preflight guard, Clinical Hub runtime trace headers, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
@@ -147,25 +164,26 @@ gh secret set EXPO_TOKEN --body "<expo_access_token>"
 gh variable set EAS_PROJECT_ID --body "<eas_project_uuid>"
 gh secret set CLINICAL_HUB_URL --body "https://<clinical-hub>"
 gh secret set CLINICAL_HUB_API_KEY --body "<api_key>"
+eas secret:create --name GOOGLE_SERVICE_ACCOUNT --value "$(cat /secure/path/google-service-account.json)" --type file
 ```
 
 Manual store-account handoff remains outside GitHub secrets:
-- `provision_apple_developer_account`: Apple Developer access, signing certificates/profiles, and TestFlight permissions.
-- `provision_google_play_account`: Google Play Console access, Android signing, and internal testing track permissions.
+- `provision_apple_developer_account`: Apple Developer access, App Store Connect app record, signing certificates/profiles, and TestFlight permissions.
+- `provision_google_play_account`: Google Play Console access, Android signing, Play API service account, and internal testing track permissions.
 
 ## 4) Distribution channels
 
 iOS:
 1. Download `mobile-store-rollout-handoff` from the Mobile Build run.
-2. Configure Apple Developer/App Store Connect access, signing credentials, and the internal TestFlight group.
-3. Use EAS output for TestFlight upload (internal testers).
+2. Configure Apple Developer/App Store Connect access, app record, signing credentials, and the internal TestFlight group.
+3. Run `npm run submit:ios:production` from `apps/field-mobile` or use EAS output for TestFlight upload (internal testers).
 4. Update the iOS channel in `mobile-store-rollout-handoff.json` from `blocked_external` to the actual rollout state and fill in EAS/TestFlight evidence.
 5. Verify build metadata, privacy strings, and permissions prompt behavior.
 
 Android:
 1. Download `mobile-store-rollout-handoff` from the Mobile Build run.
-2. Configure Google Play Console access, Android signing, and the internal testing track.
-3. Use EAS output for Play Internal Testing.
+2. Configure Google Play Console access, Android signing, EAS file secret `GOOGLE_SERVICE_ACCOUNT`, and the internal testing track.
+3. Run `npm run submit:android:production` from `apps/field-mobile` or use EAS output for Play Internal Testing.
 4. Update the Android channel in `mobile-store-rollout-handoff.json` from `blocked_external` to the actual rollout state and fill in EAS/Play evidence.
 5. Verify package name, versionCode increment, and install/update path.
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -332,6 +332,16 @@ def build_readiness_report(
     scripts = package_payload.get("scripts", {})
     root_lock = lock_payload.get("packages", {}).get("", {})
     eas_build = eas_payload.get("build", {})
+    eas_submit = eas_payload.get("submit", {})
+    if not isinstance(eas_submit, dict):
+        eas_submit = {}
+    eas_submit_production = eas_submit.get("production", {})
+    if not isinstance(eas_submit_production, dict):
+        eas_submit_production = {}
+    eas_submit_ios_is_object = isinstance(eas_submit_production.get("ios"), dict)
+    eas_submit_android = eas_submit_production.get("android", {})
+    if not isinstance(eas_submit_android, dict):
+        eas_submit_android = {}
     mobile_root = package_json.parent
 
     checks: list[dict[str, Any]] = []
@@ -727,6 +737,36 @@ def build_readiness_report(
         eas_build.get("preview", {}).get("android", {}).get("buildType") == "apk",
         f"preview.android={eas_build.get('preview', {}).get('android')!r}",
         severity="warning",
+    )
+    _check(
+        checks,
+        "eas_submit_profile_production",
+        (
+            "production" in eas_submit
+            and "ios" in eas_submit_production
+            and "android" in eas_submit_production
+            and eas_submit_ios_is_object
+            and isinstance(eas_submit_production.get("android"), dict)
+        ),
+        (
+            f"eas submit production keys={sorted(eas_submit_production)}, "
+            f"ios_object={eas_submit_ios_is_object!r}, "
+            f"android_object={isinstance(eas_submit_production.get('android'), dict)!r}"
+        ),
+    )
+    android_service_account_key_path = eas_submit_android.get("serviceAccountKeyPath")
+    _check(
+        checks,
+        "eas_submit_android_internal_track",
+        isinstance(android_service_account_key_path, str)
+        and android_service_account_key_path.startswith("@secret:")
+        and eas_submit_android.get("track") == "internal"
+        and eas_submit_android.get("releaseStatus") == "completed",
+        (
+            f"android.serviceAccountKeyPath={android_service_account_key_path!r}, "
+            f"track={eas_submit_android.get('track')!r}, "
+            f"releaseStatus={eas_submit_android.get('releaseStatus')!r}"
+        ),
     )
     _check(
         checks,
@@ -1443,6 +1483,16 @@ def build_readiness_report(
         "build_scripts",
         "build:preview" in scripts and "build:production" in scripts,
         "package build scripts are present",
+    )
+    _check(
+        checks,
+        "eas_submit_scripts_present",
+        {
+            "submit:ios:production",
+            "submit:android:production",
+            "submit:production",
+        }.issubset(set(scripts)),
+        "package EAS submit scripts are present",
     )
     _check(
         checks,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -87,6 +87,9 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "eas_cli_version_declared",
         "eas_production_auto_increment",
         "eas_profile_channels",
+        "eas_submit_android_internal_track",
+        "eas_submit_profile_production",
+        "eas_submit_scripts_present",
         "ios_privacy_usage_descriptions",
         "app_config_unit_tests_present",
         "paired_payload_unit_tests_present",
@@ -293,6 +296,35 @@ def test_mobile_release_readiness_fails_localhost_default_api_url(tmp_path: Path
     assert payload["local_checks_status"] == "fail"
     assert check["status"] == "fail"
     assert "http://127.0.0.1:8000" in check["evidence"]
+
+
+def test_mobile_release_readiness_fails_unsafe_android_submit_config(tmp_path: Path) -> None:
+    mutated_eas_json = tmp_path / "eas.json"
+    eas_payload = json.loads(EAS_JSON.read_text(encoding="utf-8"))
+    eas_payload["submit"]["production"]["android"] = {
+        "serviceAccountKeyPath": "./google-service-account.json",
+        "track": "production",
+        "releaseStatus": "completed",
+    }
+    mutated_eas_json.write_text(json.dumps(eas_payload), encoding="utf-8")
+
+    payload = _run_readiness_with_paths(
+        tmp_path / "readiness.json",
+        env={"PATH": os.environ.get("PATH", "")},
+        eas_json=mutated_eas_json,
+        check=False,
+    )
+
+    check = next(
+        item
+        for item in payload["local_checks"]
+        if item["id"] == "eas_submit_android_internal_track"
+    )
+    assert payload["status"] == "not_ready"
+    assert payload["local_checks_status"] == "fail"
+    assert check["status"] == "fail"
+    assert "./google-service-account.json" in check["evidence"]
+    assert "track='production'" in check["evidence"]
 
 
 def test_mobile_release_readiness_fails_raw_media_runtime_config(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- configure production EAS submit shape for iOS handoff and Android Play Internal Testing via EAS file secret `GOOGLE_SERVICE_ACCOUNT`
- add production submit npm scripts and readiness gates for submit profile/scripts
- update release docs with TestFlight/Play Internal submit handoff and refresh Expo SDK patch deps required by Expo Doctor

## Validation
- `python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-eas-submit-final.json` -> `ready_except_external_credentials`, local `97/97 pass`
- `.venv/bin/ruff check scripts/check_mobile_release_readiness.py tests/test_mobile_release_readiness_script.py`
- `.venv/bin/pytest -q tests/test_mobile_release_readiness_script.py` -> `13 passed`
- `npm run typecheck && npm run test:unit` -> `84/84 pass`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` -> `124 passed`
- `npm run validate:ci` -> Expo Doctor `21/21`, audit `0 vulnerabilities`, iOS/Android export pass