### PR TITLE
Add guarded mobile EAS submit workflow

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -30,6 +30,29 @@ on:
         description: "Operator-facing release notes for this mobile build"
         required: false
         type: string
+      submit_to_store:
+        description: "Submit the latest production EAS build to configured stores"
+        required: false
+        type: boolean
+        default: false
+      submit_platform:
+        description: "Store submit platform"
+        required: false
+        type: choice
+        options:
+          - all
+          - ios
+          - android
+        default: all
+      wait_for_submit:
+        description: "Wait until EAS submit completes"
+        required: false
+        type: boolean
+        default: false
+      what_to_test:
+        description: "Optional TestFlight 'What to Test' text for iOS submit"
+        required: false
+        type: string
   push:
     branches:
       - main
@@ -134,6 +157,8 @@ jobs:
 
       - name: Publish release readiness summary
         shell: bash
+        env:
+          WORKFLOW_SUBMIT_TO_STORE: ${{ github.event.inputs.submit_to_store || 'false' }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -164,6 +189,14 @@ jobs:
           ]
           authenticated_eas_status = payload.get("authenticated_eas_status")
           eas_trigger_status = "enabled" if authenticated_eas_status == "pass" else "blocked"
+          submit_requested = os.environ.get("WORKFLOW_SUBMIT_TO_STORE", "false").lower() == "true"
+          eas_submit_trigger_status = (
+              "enabled"
+              if submit_requested and authenticated_eas_status == "pass"
+              else "blocked"
+              if submit_requested
+              else "not_requested"
+          )
           lines = [
               "## Mobile Release Readiness",
               f"- Status: `{payload.get('status')}`",
@@ -172,6 +205,7 @@ jobs:
               f"- Authenticated EAS readiness: `{authenticated_eas_status}`",
               f"- Authenticated EAS blockers: `{', '.join(payload.get('authenticated_eas_blockers', [])) if payload.get('authenticated_eas_blockers') else 'none'}`",
               f"- Authenticated EAS build trigger: `{eas_trigger_status}`",
+              f"- Authenticated EAS submit trigger: `{eas_submit_trigger_status}`",
               f"- Clinical Hub live API: `{payload.get('clinical_hub_live_api_status')}`",
               f"- Missing external items: `{', '.join(missing) if missing else 'none'}`",
               f"- Invalid external items: `{', '.join(invalid) if invalid else 'none'}`",
@@ -187,6 +221,8 @@ jobs:
           WORKFLOW_BUILD_PROFILE: ${{ github.event.inputs.build_profile || 'preview' }}
           WORKFLOW_BUILD_PLATFORM: ${{ github.event.inputs.build_platform || 'all' }}
           WORKFLOW_RELEASE_NOTES: ${{ github.event.inputs.release_notes || '' }}
+          WORKFLOW_SUBMIT_TO_STORE: ${{ github.event.inputs.submit_to_store || 'false' }}
+          WORKFLOW_SUBMIT_PLATFORM: ${{ github.event.inputs.submit_platform || 'all' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -209,6 +245,8 @@ jobs:
               f"- GitHub run: `{os.environ.get('GITHUB_RUN_ID', 'local')}`",
               f"- Build profile: `{os.environ.get('WORKFLOW_BUILD_PROFILE', 'preview')}`",
               f"- Build platform: `{os.environ.get('WORKFLOW_BUILD_PLATFORM', 'all')}`",
+              f"- Store submit requested: `{os.environ.get('WORKFLOW_SUBMIT_TO_STORE', 'false')}`",
+              f"- Store submit platform: `{os.environ.get('WORKFLOW_SUBMIT_PLATFORM', 'all')}`",
               "",
               "## Operator Notes",
               "",
@@ -473,12 +511,94 @@ jobs:
           )
           PY
 
-      - name: Publish skip summary
-        if: ${{ steps.expo.outputs.available != 'true' }}
-        shell: bash
+  eas-submit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    needs: preflight
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.submit_to_store == 'true' && needs.preflight.outputs.authenticated_eas_status == 'pass' }}
+
+    defaults:
+      run:
+        working-directory: apps/field-mobile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22.13.x"
+          cache: "npm"
+          cache-dependency-path: apps/field-mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Install EAS CLI
+        run: npm install -g eas-cli@20.0.0
+
+      - name: Trigger EAS submit
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          WORKFLOW_SUBMIT_PLATFORM: ${{ github.event.inputs.submit_platform || 'all' }}
+          WORKFLOW_WAIT_FOR_SUBMIT: ${{ github.event.inputs.wait_for_submit || 'false' }}
+          WORKFLOW_WHAT_TO_TEST: ${{ github.event.inputs.what_to_test || '' }}
         run: |
+          set -euo pipefail
+          platform="${WORKFLOW_SUBMIT_PLATFORM:-all}"
+          wait_for_submit="${WORKFLOW_WAIT_FOR_SUBMIT:-false}"
+          what_to_test="${WORKFLOW_WHAT_TO_TEST:-}"
+
+          cmd=(eas submit --platform "$platform" --profile production --latest --non-interactive)
+          if [[ "$wait_for_submit" == "true" ]]; then
+            cmd+=(--wait)
+          else
+            cmd+=(--no-wait)
+          fi
+          if [[ -n "$what_to_test" && "$platform" == "ios" ]]; then
+            cmd+=(--what-to-test "$what_to_test")
+          fi
+
           {
-            echo "## Mobile EAS Build"
-            echo "- Status: \`skipped\`"
-            echo "- Reason: \`EXPO_TOKEN is not configured in repository secrets\`"
+            printf 'Command:'
+            printf ' %q' "${cmd[@]}"
+            printf '\n\n'
+          } > /tmp/eas-submit-result.log
+
+          set +e
+          "${cmd[@]}" >> /tmp/eas-submit-result.log 2>&1
+          submit_exit_code=$?
+          set -e
+          cat /tmp/eas-submit-result.log
+          echo "$submit_exit_code" > /tmp/eas-submit-exit-code
+          exit "$submit_exit_code"
+
+      - name: Upload EAS submit result artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: mobile-eas-submit-result-${{ github.run_id }}
+          path: |
+            /tmp/eas-submit-result.log
+            /tmp/eas-submit-exit-code
+          if-no-files-found: warn
+
+      - name: Publish EAS submit summary
+        if: ${{ always() }}
+        shell: bash
+        env:
+          WORKFLOW_SUBMIT_PLATFORM: ${{ github.event.inputs.submit_platform || 'all' }}
+          WORKFLOW_WAIT_FOR_SUBMIT: ${{ github.event.inputs.wait_for_submit || 'false' }}
+        run: |
+          set -euo pipefail
+          submit_exit_code="$(cat /tmp/eas-submit-exit-code 2>/dev/null || echo not-run)"
+          {
+            echo "## Mobile EAS Submit"
+            echo "- Profile: \`production\`"
+            echo "- Platform: \`${WORKFLOW_SUBMIT_PLATFORM:-all}\`"
+            echo "- Build source: \`latest\`"
+            echo "- Wait mode: \`${WORKFLOW_WAIT_FOR_SUBMIT:-false}\`"
+            echo "- Exit code: \`${submit_exit_code}\`"
+            echo "- Result artifact: \`mobile-eas-submit-result-${GITHUB_RUN_ID}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -132,10 +132,14 @@ When backend is configured with API key policy map (`--api-key-map-json`), set i
 CI:
 - `.github/workflows/mobile-ci.yml` runs `npm run validate:ci` for `apps/field-mobile/**` changes.
 - `validate:ci` covers TypeScript, Clinical Hub API client/connection check/summary requests + mobile helper/API + runtime config + submit outcome + paired/capture-package payload + capture-contract + ROI signal + runtime metric + pending queue + deterministic sync smoke + storage unit tests, Expo Doctor, production dependency audit, and iOS/Android Expo exports.
-- `.github/workflows/mobile-build.yml` runs release preflight for mobile app/release-script changes and provides manual EAS build trigger (`workflow_dispatch`) with inputs:
+- `.github/workflows/mobile-build.yml` runs release preflight for mobile app/release-script changes and provides manual EAS build/submit triggers (`workflow_dispatch`) with inputs:
   - `build_profile` (`preview` / `development` / `production`)
   - `build_platform` (`all` / `ios` / `android`)
   - `wait_for_build` (`true` / `false`)
+  - `submit_to_store` (`true` / `false`; submits the latest production build only when authenticated EAS readiness is `pass`)
+  - `submit_platform` (`all` / `ios` / `android`)
+  - `wait_for_submit` (`true` / `false`)
+  - `what_to_test` (optional TestFlight text for iOS submit)
   - `release_notes` (operator-facing handoff notes archived as `mobile-release-notes`)
 - `mobile-build` uploads:
   - `mobile-release-manifest` (version + runtime release metadata/config + release notes digest + capture contract feature-manifest evidence + readiness gate summary + git SHA + model/schema traceability)
@@ -144,6 +148,7 @@ CI:
   - `mobile-release-bundle-verification` (manifest/readiness/notes/store-handoff digest and traceability consistency summary)
   - `mobile-store-rollout-handoff` (per-run TestFlight/Play Internal handoff template + validation summary with current external blockers)
   - `mobile-eas-build-result-<run_id>` (raw EAS JSON response for build IDs/URLs)
+  - `mobile-eas-submit-result-<run_id>` (raw EAS submit log + exit code when `submit_to_store=true`)
 - Workflow summary includes release readiness status and direct EAS build links for operator/release use.
 
 ## Release Readiness Handoff
@@ -217,7 +222,8 @@ npm run submit:production
 
 iOS submit still requires the external App Store Connect app record and Apple credentials.
 Android submit uses `submit.production.android.serviceAccountKeyPath=@secret:GOOGLE_SERVICE_ACCOUNT`
-and targets the Play Internal Testing track.
+and targets the Play Internal Testing track. All submit scripts use `--latest` so non-interactive
+handoff submits the latest completed EAS production build rather than prompting for build selection.
 
 Detailed release SOP:
 - `docs/mobile-release-runbook-v0.1.md`

--- a/apps/field-mobile/package.json
+++ b/apps/field-mobile/package.json
@@ -21,9 +21,9 @@
     "validate:ci": "npm run typecheck && npm run test:unit && npm run doctor && npm run audit:prod && npm run export:ios && npm run export:android",
     "build:preview": "eas build --platform all --profile preview",
     "build:production": "eas build --platform all --profile production",
-    "submit:ios:production": "eas submit --platform ios --profile production --non-interactive",
-    "submit:android:production": "eas submit --platform android --profile production --non-interactive",
-    "submit:production": "eas submit --platform all --profile production --non-interactive"
+    "submit:ios:production": "eas submit --platform ios --profile production --latest --non-interactive",
+    "submit:android:production": "eas submit --platform android --profile production --latest --non-interactive",
+    "submit:production": "eas submit --platform all --profile production --latest --non-interactive"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -24,6 +24,10 @@ From GitHub Actions:
    - `build_profile` (`preview` for pilot by default),
    - `build_platform` (`all`/`ios`/`android`),
    - `wait_for_build` (`false` for fast trigger, `true` for full wait mode),
+   - `submit_to_store` (`false` by default; set `true` only after a signed production build is ready),
+   - `submit_platform` (`all`/`ios`/`android`),
+   - `wait_for_submit` (`false` for fast trigger, `true` for full submit wait mode),
+   - `what_to_test` for optional TestFlight notes when submitting iOS,
    - `release_notes` for operator-facing clinic handoff notes.
 3. Verify `preflight` passes.
 4. Open workflow summary (`Mobile Release Readiness`) and confirm:
@@ -32,9 +36,10 @@ From GitHub Actions:
    - `Clinical Hub live API` is `present` before live API smoke/report push is expected,
    - missing or invalid external items are understood and either configured or accepted as blockers for this run.
    - `Next actions` maps the remaining external blockers to concrete setup tasks.
-5. Verify `eas-build` starts. If `Authenticated EAS readiness` is `blocked`, `eas-build` is skipped by design and the readiness artifact is the handoff output.
+5. Verify `eas-build` starts when a build is requested. If `Authenticated EAS readiness` is `blocked`, authenticated EAS jobs are skipped by design and the readiness artifact is the handoff output.
 6. Open workflow summary (`Mobile EAS Build`) and copy build links.
 7. Download artifact `mobile-eas-build-result-<run_id>` for traceability JSON.
+8. If `submit_to_store=true`, open workflow summary (`Mobile EAS Submit`) and download artifact `mobile-eas-submit-result-<run_id>` for the EAS submit log and exit code.
 
 Local fallback:
 
@@ -55,7 +60,8 @@ npm run submit:production
 
 Do not commit Apple credentials or Google service-account JSON. Android submit is configured to read
 the Google Play service account as EAS file secret `GOOGLE_SERVICE_ACCOUNT`; iOS submit still depends
-on Apple Developer/App Store Connect credentials and the external app record.
+on Apple Developer/App Store Connect credentials and the external app record. Submit commands use
+`--latest` and therefore submit the latest completed production EAS build for the selected platform.
 
 ## 3) Release manifest and traceability
 
@@ -89,6 +95,7 @@ Workflow also generates artifact `mobile-release-readiness` containing:
 Workflow also generates artifact `mobile-release-notes` containing:
 - git SHA/ref/run-id,
 - selected build profile/platform,
+- selected store-submit request/platform,
 - operator-facing release notes from workflow input or an explicit placeholder when not supplied,
 - required evidence reminders for manifest, readiness, EAS build links, and physical-device smoke logs.
 
@@ -176,14 +183,14 @@ Manual store-account handoff remains outside GitHub secrets:
 iOS:
 1. Download `mobile-store-rollout-handoff` from the Mobile Build run.
 2. Configure Apple Developer/App Store Connect access, app record, signing credentials, and the internal TestFlight group.
-3. Run `npm run submit:ios:production` from `apps/field-mobile` or use EAS output for TestFlight upload (internal testers).
+3. Run `npm run submit:ios:production` from `apps/field-mobile`, or dispatch `Mobile Build` with `submit_to_store=true` and `submit_platform=ios`, to submit the latest production EAS build to TestFlight internal testers.
 4. Update the iOS channel in `mobile-store-rollout-handoff.json` from `blocked_external` to the actual rollout state and fill in EAS/TestFlight evidence.
 5. Verify build metadata, privacy strings, and permissions prompt behavior.
 
 Android:
 1. Download `mobile-store-rollout-handoff` from the Mobile Build run.
 2. Configure Google Play Console access, Android signing, EAS file secret `GOOGLE_SERVICE_ACCOUNT`, and the internal testing track.
-3. Run `npm run submit:android:production` from `apps/field-mobile` or use EAS output for Play Internal Testing.
+3. Run `npm run submit:android:production` from `apps/field-mobile`, or dispatch `Mobile Build` with `submit_to_store=true` and `submit_platform=android`, to submit the latest production EAS build to Play Internal Testing.
 4. Update the Android channel in `mobile-store-rollout-handoff.json` from `blocked_external` to the actual rollout state and fill in EAS/Play evidence.
 5. Verify package name, versionCode increment, and install/update path.
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -1484,15 +1484,43 @@ def build_readiness_report(
         "build:preview" in scripts and "build:production" in scripts,
         "package build scripts are present",
     )
+    submit_script_requirements = {
+        "ios_script": "submit:ios:production" in scripts,
+        "ios_platform": "--platform ios" in scripts.get("submit:ios:production", ""),
+        "android_script": "submit:android:production" in scripts,
+        "android_platform": "--platform android" in scripts.get("submit:android:production", ""),
+        "all_script": "submit:production" in scripts,
+        "all_platform": "--platform all" in scripts.get("submit:production", ""),
+        "production_profile": all(
+            "--profile production" in scripts.get(script_name, "")
+            for script_name in (
+                "submit:ios:production",
+                "submit:android:production",
+                "submit:production",
+            )
+        ),
+        "latest_build_source": all(
+            "--latest" in scripts.get(script_name, "")
+            for script_name in (
+                "submit:ios:production",
+                "submit:android:production",
+                "submit:production",
+            )
+        ),
+        "non_interactive": all(
+            "--non-interactive" in scripts.get(script_name, "")
+            for script_name in (
+                "submit:ios:production",
+                "submit:android:production",
+                "submit:production",
+            )
+        ),
+    }
     _check(
         checks,
         "eas_submit_scripts_present",
-        {
-            "submit:ios:production",
-            "submit:android:production",
-            "submit:production",
-        }.issubset(set(scripts)),
-        "package EAS submit scripts are present",
+        all(submit_script_requirements.values()),
+        f"requirements={submit_script_requirements!r}",
     )
     _check(
         checks,


### PR DESCRIPTION
## Summary
- add manual `workflow_dispatch` inputs and a guarded `eas-submit` job for submitting the latest production EAS build
- update submit scripts and readiness gates to require `--latest` for non-interactive EAS submit
- document store submit handoff artifacts and remove a stale misleading EAS build skip summary step

## Validation
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/mobile-build.yml\"); puts \"yaml-ok\"'`
- `python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-submit-workflow-final.json` -> `ready_except_external_credentials`, local `97/97 pass`
- `.venv/bin/ruff check scripts/check_mobile_release_readiness.py tests/test_mobile_release_readiness_script.py`
- `.venv/bin/pytest -q tests/test_mobile_release_readiness_script.py` -> `13 passed`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` -> `124 passed`
- `npm run validate:ci` -> Expo Doctor `21/21`, audit `0 vulnerabilities`, iOS/Android export pass

## External blockers preserved
Live EAS submit remains gated by `EXPO_TOKEN`, deterministic EAS project identity, Apple Developer/App Store Connect setup, and Google Play/EAS `GOOGLE_SERVICE_ACCOUNT` file secret.