### PR TITLE
Clarify mobile store handoff next actions

### DIFF
--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -266,11 +266,12 @@ def _build_next_actions(
             "status": "manual_required",
             "owner": "account_admin",
             "action": (
-                "Provision Apple Developer access, signing certificates/profiles, and TestFlight "
-                "distribution permissions."
+                "Provision Apple Developer access, App Store Connect app record, signing "
+                "certificates/profiles, and TestFlight distribution permissions."
             ),
             "verification": (
-                "Trigger a signed iOS EAS build and confirm TestFlight upload readiness."
+                "Trigger a signed iOS EAS build, then submit the latest production build and "
+                "confirm TestFlight upload readiness."
             ),
             "secret_names": [],
             "variable_names": [],
@@ -283,14 +284,14 @@ def _build_next_actions(
             "status": "manual_required",
             "owner": "account_admin",
             "action": (
-                "Provision Google Play Console access, Android signing, and internal testing track "
-                "permissions."
+                "Provision Google Play Console access, Android signing, Play API service account, "
+                "EAS file secret GOOGLE_SERVICE_ACCOUNT, and internal testing track permissions."
             ),
             "verification": (
-                "Trigger a signed Android EAS build and confirm Play Internal Testing upload "
-                "readiness."
+                "Trigger a signed Android EAS build, then submit the latest production build and "
+                "confirm Play Internal Testing upload readiness."
             ),
-            "secret_names": [],
+            "secret_names": ["GOOGLE_SERVICE_ACCOUNT"],
             "variable_names": [],
             "file_paths": [],
             "doc": "docs/mobile-release-runbook-v0.1.md",

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -161,6 +161,21 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
     )
     assert expo_action["secret_names"] == ["EXPO_TOKEN"]
     assert expo_action["verification"]
+    apple_action = next(
+        item
+        for item in payload["next_actions"]
+        if item["id"] == "provision_apple_developer_account"
+    )
+    assert "App Store Connect app record" in apple_action["action"]
+    assert "latest production build" in apple_action["verification"]
+    google_action = next(
+        item
+        for item in payload["next_actions"]
+        if item["id"] == "provision_google_play_account"
+    )
+    assert "GOOGLE_SERVICE_ACCOUNT" in google_action["action"]
+    assert google_action["secret_names"] == ["GOOGLE_SERVICE_ACCOUNT"]
+    assert "latest production build" in google_action["verification"]
 
 
 def test_mobile_release_readiness_fails_missing_app_icon(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- update machine-readable mobile readiness next_actions for Apple/App Store Connect and Google Play/EAS service-account handoff
- add regression assertions so release artifacts keep mentioning latest production submit handoff and GOOGLE_SERVICE_ACCOUNT

## Validation
- `python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-next-actions.json` -> `ready_except_external_credentials`, local `97/97 pass`
- `.venv/bin/ruff check scripts/check_mobile_release_readiness.py tests/test_mobile_release_readiness_script.py`
- `.venv/bin/pytest -q tests/test_mobile_release_readiness_script.py` -> `13 passed`
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` -> `124 passed`