### PR TITLE
Add runtime capture preflight guard

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -35,6 +35,7 @@ import {
   RuntimeCaptureSession,
   type RuntimeFlowPoint,
 } from "./src/capture/runtimeCaptureSession";
+import { buildRuntimeCaptureReadiness } from "./src/capture/runtimeMetrics";
 import { APP_MODEL_ID, APP_RELEASE_VERSION } from "./src/config/releaseMetadata";
 import { estimateRoiSignalFromBase64 } from "./src/capture/roiSignalEstimator";
 import { APP_DEFAULT_CAPTURE_MODE } from "./src/config/appConfig";
@@ -343,7 +344,7 @@ export default function App() {
   }, [cameraPermission?.granted]);
 
   useEffect(() => {
-    if (!captureRunning || !cameraPermission?.granted || !cameraPreviewReady) {
+    if ((!captureRunning && !roiLocked) || !cameraPermission?.granted || !cameraPreviewReady) {
       if (roiFrameIntervalRef.current != null) {
         clearInterval(roiFrameIntervalRef.current);
         roiFrameIntervalRef.current = null;
@@ -400,29 +401,43 @@ export default function App() {
       }
       roiFrameInFlightRef.current = false;
     };
-  }, [cameraPermission?.granted, cameraPreviewReady, captureRunning]);
+  }, [cameraPermission?.granted, cameraPreviewReady, captureRunning, roiLocked]);
+
+  function toggleRoiLock(): void {
+    resetRoiFrameTracking();
+    setRoiLocked((current) => !current);
+  }
 
   async function startRuntimeCapture(): Promise<void> {
     const runtime = captureRuntimeRef.current ?? new RuntimeCaptureSession();
     captureRuntimeRef.current = runtime;
 
     try {
+      let cameraPermissionGranted = cameraPermission?.granted ?? false;
       if (!cameraPermission?.granted) {
         const permissionResult = await requestCameraPermission();
-        if (!permissionResult.granted) {
+        cameraPermissionGranted = permissionResult.granted;
+        if (!cameraPermissionGranted) {
           Alert.alert(
             "Camera permission missing",
             "Camera permission is required for ROI validity checks.",
           );
         }
       }
-      if (!roiLocked) {
-        Alert.alert(
-          "ROI not locked",
-          "Lock ROI before capture for better quality. Capture will continue but may be marked repeat/reject.",
-        );
+
+      const captureReadiness = buildRuntimeCaptureReadiness({
+        cameraPermissionGranted,
+        cameraPreviewReady,
+        roiLocked,
+        roiFrameCount,
+        roiFrameValid,
+      });
+      if (!captureReadiness.ready) {
+        setCaptureStatus(`Capture preflight blocked: ${captureReadiness.message}`);
+        Alert.alert("Capture preflight blocked", captureReadiness.message);
+        return;
       }
-      resetRoiFrameTracking();
+
       setCaptureStatus("Requesting permissions...");
       const startResult = await runtime.start();
       setCaptureRunning(true);
@@ -874,7 +889,7 @@ export default function App() {
           onToggleManualAppMetricsOverride={() =>
             setManualAppMetricsOverride((current) => !current)
           }
-          onToggleRoiLock={() => setRoiLocked((current) => !current)}
+          onToggleRoiLock={toggleRoiLock}
         />
 
         <MeasurementFormSection

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -31,6 +31,8 @@ Cross-platform mobile client (Expo React Native) for collecting paired measureme
 - `Device Model` defaults from Expo Device metadata with platform fallback and remains editable for field correction.
 - On successful paired upload, app posts `capture_contract_json` to `POST /api/v1/capture-packages`
 - Runtime capture mode collects live audio + IMU samples (camera permission used for ROI validity flag)
+- `Start Capture` is blocked until camera permission, camera preview readiness, ROI lock,
+  and at least one valid ROI frame are confirmed.
 - In-app `Release Identity` panel shows canonical app version, model/schema, runtime config, privacy/data-residency flags, platform, and payload traceability alignment.
 - If runtime capture was not started, app falls back to scaffold contract payload
 - `Stop Capture` auto-fills app metrics (`Qmax/Qavg/Vvoid/FlowTime/TQmax`) and quality status/score from runtime-derived proxies
@@ -163,7 +165,7 @@ secret blockers. The artifact has separate machine-readable gates:
   Clinical Hub preflight guard,
   Clinical Hub runtime trace headers,
   in-app release identity evidence,
-  runtime motion quality gates, derivatives-only feature/media
+  runtime capture preflight guard, runtime motion quality gates, derivatives-only feature/media
   manifest gates, pending sync connectivity-restore trigger, device-smoke evidence template/validator,
   store rollout handoff template/validator, release bundle verifier,
   API response + submit exception + runtime exception PHI redaction, and non-localhost API URL defaults,

--- a/apps/field-mobile/src/capture/runtimeMetrics.ts
+++ b/apps/field-mobile/src/capture/runtimeMetrics.ts
@@ -29,6 +29,20 @@ export type RuntimeFlowPoint = {
   flow_ml_s: number;
 };
 
+export type RuntimeCaptureReadinessCode =
+  | "ready"
+  | "camera_permission_missing"
+  | "camera_preview_not_ready"
+  | "roi_not_locked"
+  | "roi_frame_not_validated"
+  | "roi_frame_invalid";
+
+export type RuntimeCaptureReadiness = {
+  ready: boolean;
+  code: RuntimeCaptureReadinessCode;
+  message: string;
+};
+
 export const HIGH_MOTION_SAMPLE_THRESHOLD = 0.35;
 const HIGH_MOTION_REPEAT_RATIO = 0.2;
 const HIGH_MOTION_REJECT_RATIO = 0.45;
@@ -59,6 +73,55 @@ export function integrateRuntimeFlowSeries(series: RuntimeFlowPoint[]): number {
     sum += ((prev.flow_ml_s + curr.flow_ml_s) * 0.5) * dt;
   }
   return sum;
+}
+
+export function buildRuntimeCaptureReadiness(input: {
+  cameraPermissionGranted: boolean;
+  cameraPreviewReady: boolean;
+  roiLocked: boolean;
+  roiFrameCount: number;
+  roiFrameValid: boolean;
+}): RuntimeCaptureReadiness {
+  if (!input.cameraPermissionGranted) {
+    return {
+      ready: false,
+      code: "camera_permission_missing",
+      message: "Grant camera permission before starting runtime capture.",
+    };
+  }
+  if (!input.cameraPreviewReady) {
+    return {
+      ready: false,
+      code: "camera_preview_not_ready",
+      message: "Wait for the camera preview to become ready before starting runtime capture.",
+    };
+  }
+  if (!input.roiLocked) {
+    return {
+      ready: false,
+      code: "roi_not_locked",
+      message: "Lock ROI before starting runtime capture.",
+    };
+  }
+  if (input.roiFrameCount < 1) {
+    return {
+      ready: false,
+      code: "roi_frame_not_validated",
+      message: "Wait for at least one ROI frame validation after locking ROI.",
+    };
+  }
+  if (!input.roiFrameValid) {
+    return {
+      ready: false,
+      code: "roi_frame_invalid",
+      message: "Re-aim the phone until ROI frame validity is yes, then start capture.",
+    };
+  }
+  return {
+    ready: true,
+    code: "ready",
+    message: "Runtime capture preflight ready.",
+  };
 }
 
 export function deriveRuntimeCaptureMetrics(input: {

--- a/apps/field-mobile/tests/runtimeMetrics.test.js
+++ b/apps/field-mobile/tests/runtimeMetrics.test.js
@@ -177,3 +177,77 @@ test("calculateAverageMotionNorm handles empty samples", () => {
     0.2,
   );
 });
+
+test("buildRuntimeCaptureReadiness blocks unsafe capture starts", () => {
+  assert.deepEqual(
+    runtime.buildRuntimeCaptureReadiness({
+      cameraPermissionGranted: false,
+      cameraPreviewReady: true,
+      roiLocked: true,
+      roiFrameCount: 1,
+      roiFrameValid: true,
+    }),
+    {
+      ready: false,
+      code: "camera_permission_missing",
+      message: "Grant camera permission before starting runtime capture.",
+    },
+  );
+  assert.equal(
+    runtime.buildRuntimeCaptureReadiness({
+      cameraPermissionGranted: true,
+      cameraPreviewReady: false,
+      roiLocked: true,
+      roiFrameCount: 1,
+      roiFrameValid: true,
+    }).code,
+    "camera_preview_not_ready",
+  );
+  assert.equal(
+    runtime.buildRuntimeCaptureReadiness({
+      cameraPermissionGranted: true,
+      cameraPreviewReady: true,
+      roiLocked: false,
+      roiFrameCount: 1,
+      roiFrameValid: true,
+    }).code,
+    "roi_not_locked",
+  );
+  assert.equal(
+    runtime.buildRuntimeCaptureReadiness({
+      cameraPermissionGranted: true,
+      cameraPreviewReady: true,
+      roiLocked: true,
+      roiFrameCount: 0,
+      roiFrameValid: true,
+    }).code,
+    "roi_frame_not_validated",
+  );
+  assert.equal(
+    runtime.buildRuntimeCaptureReadiness({
+      cameraPermissionGranted: true,
+      cameraPreviewReady: true,
+      roiLocked: true,
+      roiFrameCount: 2,
+      roiFrameValid: false,
+    }).code,
+    "roi_frame_invalid",
+  );
+});
+
+test("buildRuntimeCaptureReadiness allows validated ROI capture starts", () => {
+  assert.deepEqual(
+    runtime.buildRuntimeCaptureReadiness({
+      cameraPermissionGranted: true,
+      cameraPreviewReady: true,
+      roiLocked: true,
+      roiFrameCount: 2,
+      roiFrameValid: true,
+    }),
+    {
+      ready: true,
+      code: "ready",
+      message: "Runtime capture preflight ready.",
+    },
+  );
+});

--- a/docs/mobile-install-and-field-test-runbook-v0.1.md
+++ b/docs/mobile-install-and-field-test-runbook-v0.1.md
@@ -103,16 +103,18 @@ Before field use, verify the in-app `Release Identity` panel:
 Per subject/attempt:
 
 1. Prepare reference uroflowmeter as per clinic SOP.
-2. In app, lock ROI, press `Start Capture`, then record voiding.
-3. Press `Stop Capture`.
-4. Check runtime block:
+2. In app, lock ROI and wait until `ROI frames` is at least `1` and `valid: yes`.
+3. Press `Start Capture`, then record voiding. If the app shows `Capture preflight blocked`,
+   fix the listed camera/preview/ROI issue before retrying.
+4. Press `Stop Capture`.
+5. Check runtime block:
    - `quality score/status`
    - `roi_valid_ratio` and `low_confidence_ratio`
    - `Runtime Q(t) Preview`
-5. Enter reference metrics (`Qmax/Qavg/Vvoid` and optional time metrics).
-6. Submit paired measurement.
-7. If network failed, ensure queue item exists and run `Sync Queue` later.
-8. For retry/audit troubleshooting, match the pending item `request_id` to Clinical Hub request logs.
+6. Enter reference metrics (`Qmax/Qavg/Vvoid` and optional time metrics).
+7. Submit paired measurement.
+8. If network failed, ensure queue item exists and run `Sync Queue` later.
+9. For retry/audit troubleshooting, match the pending item `request_id` to Clinical Hub request logs.
 
 For release handoff, copy `docs/mobile-device-smoke-log-template-v0.1.json`, fill one
 iPhone and one Android run, then validate it:

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -11,6 +11,8 @@ Implemented now:
 - Pilot automation and release gates (`v4.2`) in repository.
 - App-level runtime config for pilot mode, Clinical Hub v1 endpoint set, default capture mode, privacy-by-default switches, single-region data residency policy, and disabled debug gates.
 - Runtime capture quality gates for ROI validity, low-confidence depth, and high-motion IMU artifacts.
+- Runtime capture preflight blocks start until camera permission, camera preview readiness,
+  ROI lock, and a valid ROI frame are confirmed on device.
 - Derivatives-only feature/media manifest in mobile `ios_capture_v1` payloads, with backend validation that raw media storage/upload flags remain disabled.
 - Release manifest traceability for app version, git SHA, model/schema, runtime config, capture contract feature-manifest evidence, and readiness gate summary.
 - Mobile API response, submit exception outcome, and runtime exception redaction gates for raw body, PHI-like subject/site/operator IDs, and secret-like error details.
@@ -33,7 +35,8 @@ Not yet implemented:
 
 ### G1. Sensor capture gap
 - Native sensor capture exists as a pilot runtime path, but still needs physical-device calibration against target iPhone/Android models.
-- ROI-only processing pipeline is proxy-based and still needs native-grade ROI extraction on device.
+- ROI-only processing pipeline is proxy-based with pre-capture ROI frame validation, and still
+  needs native-grade ROI extraction on device.
 - IMU motion gating is implemented in runtime quality scoring, but threshold calibration needs real device smoke evidence.
 
 ### G2. Data contract gap
@@ -72,7 +75,7 @@ DoD:
 1. Implement capture start/stop session service.
 2. Record audio envelope + ROI motion/texture + IMU jitter over unified timeline.
 3. Build live `ios_capture_v1` payload from runtime samples.
-4. Add quality pre-checks before submit (`roi_valid_ratio`, motion threshold, depth confidence ratio). Status: implemented in runtime payload scoring; needs physical-device threshold calibration.
+4. Add quality pre-checks before submit (`roi_valid_ratio`, motion threshold, depth confidence ratio). Status: implemented in runtime payload scoring plus pre-capture camera/ROI readiness guard; needs physical-device threshold calibration.
 5. Add feature/media manifest for derived mobile capture features. Status: implemented as derivatives-only manifest with raw media disabled in payload and backend validator.
 
 DoD:

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -1160,6 +1160,28 @@ def build_readiness_report(
     )
     _check(
         checks,
+        "runtime_capture_preflight_sources",
+        "buildRuntimeCaptureReadiness" in runtime_metrics_source
+        and "buildRuntimeCaptureReadiness" in app_ts_source
+        and "Capture preflight blocked" in app_ts_source
+        and "roiFrameCount" in app_ts_source
+        and "roiFrameValid" in app_ts_source
+        and "roiLocked" in app_ts_source,
+        (
+            f"runtime_metrics={runtime_metrics_source_path}, "
+            f"app={app_ts_path}"
+        ),
+    )
+    _check(
+        checks,
+        "runtime_capture_preflight_unit_tests_present",
+        "buildRuntimeCaptureReadiness blocks unsafe capture starts" in runtime_metrics_tests_source
+        and "buildRuntimeCaptureReadiness allows validated ROI capture starts"
+        in runtime_metrics_tests_source,
+        f"path={runtime_metrics_tests_path}",
+    )
+    _check(
+        checks,
         "mobile_feature_media_manifest_sources",
         "feature_manifest" in capture_contract_source
         and "mobile_feature_manifest_v0.1" in capture_contract_source

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -140,6 +140,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "pending_sync_queue_unit_tests_present",
         "roi_signal_unit_tests_present",
         "runtime_metrics_unit_tests_present",
+        "runtime_capture_preflight_sources",
+        "runtime_capture_preflight_unit_tests_present",
         "runtime_motion_quality_gate_sources",
         "runtime_motion_quality_gate_unit_tests_present",
         "release_metadata_capture_schema_version",


### PR DESCRIPTION
## Summary
- block runtime capture start unless camera permission, camera preview readiness, ROI lock, and at least one valid ROI frame are confirmed
- keep ROI frame sampling active after ROI lock so users can validate before pressing Start Capture
- add readiness-script gates, unit coverage, and field-test documentation for the preflight behavior

## Validation
- npm run typecheck && npm run test:unit (apps/field-mobile)
- python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-capture-preflight.json
- .venv/bin/ruff check scripts/check_mobile_release_readiness.py tests/test_mobile_release_readiness_script.py
- .venv/bin/pytest -q tests/test_mobile_release_readiness_script.py
- .venv/bin/ruff check .
- .venv/bin/pytest -q
- npm run validate:ci (apps/field-mobile)
- git diff --check