### PR TITLE
Add runtime capture timeline analysis

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -38,6 +38,8 @@ Cross-platform mobile client (Expo React Native) for collecting paired measureme
 - `Stop Capture` auto-fills app metrics (`Qmax/Qavg/Vvoid/FlowTime/TQmax`) and quality status/score from runtime-derived proxies
 - Runtime block shows `roi_valid_ratio` and `low_confidence_ratio` quality flags
 - Runtime block includes in-app `Q(t)` preview for operator review before submission
+- Runtime capture contract analysis includes `runtime_timeline` timing integrity metadata
+  (`duration_s`, sample count, median sample step, max gap, and gap warning).
 
 ## Run
 
@@ -95,6 +97,8 @@ Notes:
 - Runtime capture currently logs sampled audio metering + motion, and derives proxy level traces.
 - Camera preview + ROI lock state are included in runtime quality gating.
 - Runtime quality scoring includes `roi_valid_ratio`, `low_confidence_ratio`, and `high_motion_ratio`.
+- Runtime contract analysis includes `runtime_timeline` so Clinical Hub evidence can flag
+  timing gaps caused by foreground stalls or device load.
 - Raw media is not stored by default (privacy-by-default behavior).
 - Capture contract payloads include a derivatives-only `feature_manifest` with sample count,
   derived feature keys, and raw media storage/upload flags pinned to `false`.

--- a/apps/field-mobile/src/capture/buildCaptureContract.ts
+++ b/apps/field-mobile/src/capture/buildCaptureContract.ts
@@ -21,8 +21,20 @@ export type CaptureContractRuntimeFlowPoint = {
   flow_ml_s: number;
 };
 
+export type CaptureContractRuntimeTimeline = {
+  clock_source: "elapsed_wall_clock_ms";
+  sample_count: number;
+  duration_s: number;
+  median_sample_step_s: number | null;
+  max_sample_gap_s: number | null;
+  max_sample_gap_ratio: number | null;
+  monotonic: boolean;
+  gap_warning: boolean;
+};
+
 export type CaptureContractAnalysis = {
   runtime_flow_series?: CaptureContractRuntimeFlowPoint[];
+  runtime_timeline?: CaptureContractRuntimeTimeline;
   runtime_quality?: {
     quality_score?: number;
     quality_status?: CaptureContractQualityStatus;
@@ -129,6 +141,18 @@ function round4(value: number): number {
   return Math.round(value * 10000) / 10000;
 }
 
+function median(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const midpoint = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[midpoint];
+  }
+  return (sorted[midpoint - 1] + sorted[midpoint]) / 2;
+}
+
 function normalizeStartedAt(startedAtIso: string): string {
   const parsed = new Date(startedAtIso);
   if (Number.isNaN(parsed.getTime())) {
@@ -163,6 +187,75 @@ function sanitizeRuntimeFlowSeries(
     reduced.push(lastPoint);
   }
   return reduced;
+}
+
+function sanitizeNullablePositiveMetric(value: number | null | undefined): number | null {
+  if (value == null || !Number.isFinite(value)) {
+    return null;
+  }
+  return round4(Math.max(0, value));
+}
+
+function sanitizeNonNegativeInteger(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.round(value));
+}
+
+export function deriveRuntimeTimeline(
+  samples: CaptureContractSample[],
+): CaptureContractRuntimeTimeline {
+  const timestamps = samples
+    .map((sample) => sample.t_s)
+    .filter((timestamp) => Number.isFinite(timestamp) && timestamp >= 0);
+  const deltas: number[] = [];
+  for (let index = 1; index < timestamps.length; index += 1) {
+    deltas.push(timestamps[index] - timestamps[index - 1]);
+  }
+
+  const monotonic = deltas.every((delta) => delta > 0);
+  const positiveDeltas = deltas.filter((delta) => delta > 0);
+  const medianStep = median(positiveDeltas);
+  const maxGap = positiveDeltas.length > 0 ? Math.max(...positiveDeltas) : null;
+  const maxGapRatio =
+    medianStep != null && medianStep > 0 && maxGap != null ? maxGap / medianStep : null;
+  const duration =
+    timestamps.length >= 2 ? timestamps[timestamps.length - 1] - timestamps[0] : 0;
+
+  return {
+    clock_source: "elapsed_wall_clock_ms",
+    sample_count: samples.length,
+    duration_s: round4(Math.max(0, duration)),
+    median_sample_step_s: sanitizeNullablePositiveMetric(medianStep),
+    max_sample_gap_s: sanitizeNullablePositiveMetric(maxGap),
+    max_sample_gap_ratio: sanitizeNullablePositiveMetric(maxGapRatio),
+    monotonic,
+    gap_warning:
+      !monotonic ||
+      (maxGapRatio != null && maxGapRatio > 2.5) ||
+      (maxGap != null && maxGap > 1.5),
+  };
+}
+
+function sanitizeRuntimeTimeline(
+  timeline: CaptureContractRuntimeTimeline | undefined,
+): CaptureContractRuntimeTimeline | undefined {
+  if (!timeline) {
+    return undefined;
+  }
+  return {
+    clock_source: "elapsed_wall_clock_ms",
+    sample_count: sanitizeNonNegativeInteger(timeline.sample_count),
+    duration_s: Number.isFinite(timeline.duration_s)
+      ? round4(Math.max(0, timeline.duration_s))
+      : 0,
+    median_sample_step_s: sanitizeNullablePositiveMetric(timeline.median_sample_step_s),
+    max_sample_gap_s: sanitizeNullablePositiveMetric(timeline.max_sample_gap_s),
+    max_sample_gap_ratio: sanitizeNullablePositiveMetric(timeline.max_sample_gap_ratio),
+    monotonic: timeline.monotonic === true,
+    gap_warning: timeline.gap_warning === true,
+  };
 }
 
 function sanitizeNullableLevel(value: number | null): number | null {
@@ -202,12 +295,12 @@ function sanitizeRuntimeSamples(samples: CaptureContractSample[]): CaptureContra
 
 function sanitizeAnalysis(
   analysis: CaptureContractAnalysis | undefined,
+  fallbackTimeline?: CaptureContractRuntimeTimeline,
 ): CaptureContractAnalysis | undefined {
-  if (!analysis) {
-    return undefined;
-  }
-  const runtimeFlowSeries = sanitizeRuntimeFlowSeries(analysis.runtime_flow_series);
-  const runtimeQualityRaw = analysis.runtime_quality;
+  const runtimeFlowSeries = sanitizeRuntimeFlowSeries(analysis?.runtime_flow_series);
+  const runtimeTimeline =
+    sanitizeRuntimeTimeline(analysis?.runtime_timeline) ?? fallbackTimeline;
+  const runtimeQualityRaw = analysis?.runtime_quality;
   const runtimeQuality: CaptureContractAnalysis["runtime_quality"] = {};
   if (runtimeQualityRaw) {
     if (Number.isFinite(runtimeQualityRaw.quality_score)) {
@@ -237,11 +330,12 @@ function sanitizeAnalysis(
     }
   }
   const hasRuntimeQuality = Object.keys(runtimeQuality).length > 0;
-  if (!hasRuntimeQuality && runtimeFlowSeries.length === 0) {
+  if (!hasRuntimeQuality && runtimeFlowSeries.length === 0 && !runtimeTimeline) {
     return undefined;
   }
   return {
     ...(runtimeFlowSeries.length > 0 ? { runtime_flow_series: runtimeFlowSeries } : {}),
+    ...(runtimeTimeline ? { runtime_timeline: runtimeTimeline } : {}),
     ...(hasRuntimeQuality ? { runtime_quality: runtimeQuality } : {}),
   };
 }
@@ -299,6 +393,11 @@ function buildFeatureManifest(
   const featureKeys = new Set<string>(BASE_FEATURE_KEYS);
   if (analysis?.runtime_flow_series && analysis.runtime_flow_series.length > 0) {
     featureKeys.add("runtime_flow_series.flow_ml_s");
+  }
+  if (analysis?.runtime_timeline) {
+    Object.keys(analysis.runtime_timeline).forEach((key) => {
+      featureKeys.add(`runtime_timeline.${key}`);
+    });
   }
   if (analysis?.runtime_quality) {
     Object.keys(analysis.runtime_quality).forEach((key) => {
@@ -395,7 +494,7 @@ export function buildCaptureContractPayloadFromSamples(
       },
     ];
   }
-  const analysis = sanitizeAnalysis(input.analysis);
+  const analysis = sanitizeAnalysis(input.analysis, deriveRuntimeTimeline(safeSamples));
 
   const payload: CaptureContractPayload = {
     schema_version: APP_CAPTURE_SCHEMA_VERSION,

--- a/apps/field-mobile/tests/captureContract.test.js
+++ b/apps/field-mobile/tests/captureContract.test.js
@@ -81,7 +81,16 @@ test("buildCaptureContractPayloadFromSamples creates fallback samples for empty 
     payload.samples.map((sample) => sample.t_s),
     [0, 0.5],
   );
-  assert.equal(payload.analysis, undefined);
+  assert.deepEqual(payload.analysis.runtime_timeline, {
+    clock_source: "elapsed_wall_clock_ms",
+    sample_count: 2,
+    duration_s: 0.5,
+    median_sample_step_s: 0.5,
+    max_sample_gap_s: 0.5,
+    max_sample_gap_ratio: 1,
+    monotonic: true,
+    gap_warning: false,
+  });
   assertDerivativesOnlyFeatureManifest(payload, "runtime-audio-imu");
 });
 
@@ -247,6 +256,75 @@ test("buildCaptureContractPayloadFromSamples sanitizes runtime analysis", () => 
   );
   assert.equal(
     payload.feature_manifest.feature_keys.includes("runtime_quality.high_motion_ratio"),
+    true,
+  );
+});
+
+test("buildCaptureContractPayloadFromSamples adds runtime timeline analysis", () => {
+  const payload = capture.buildCaptureContractPayloadFromSamples({
+    sessionId: "SESSION-TIMELINE",
+    syncId: "SYNC-TIMELINE",
+    startedAtIso: "2026-06-04T01:02:03Z",
+    captureMode: "water_impact",
+    deviceModel: "Pixel",
+    iosVersion: "android-16",
+    appVersion: "0.1.0",
+    samples: [
+      {
+        t_s: 0,
+        depth_level_mm: 0,
+        rgb_level_mm: 0,
+        depth_confidence: 0.9,
+        audio_rms_dbfs: -45,
+        motion_norm: 0.02,
+        roi_valid: true,
+      },
+      {
+        t_s: 0.5,
+        depth_level_mm: 0.2,
+        rgb_level_mm: 0.19,
+        depth_confidence: 0.8,
+        audio_rms_dbfs: -44,
+        motion_norm: 0.03,
+        roi_valid: true,
+      },
+      {
+        t_s: 0.99,
+        depth_level_mm: 0.3,
+        rgb_level_mm: 0.28,
+        depth_confidence: 0.82,
+        audio_rms_dbfs: -42,
+        motion_norm: 0.04,
+        roi_valid: true,
+      },
+      {
+        t_s: 3.5,
+        depth_level_mm: 0.8,
+        rgb_level_mm: 0.76,
+        depth_confidence: 0.78,
+        audio_rms_dbfs: -41,
+        motion_norm: 0.05,
+        roi_valid: true,
+      },
+    ],
+  });
+
+  assert.deepEqual(payload.analysis.runtime_timeline, {
+    clock_source: "elapsed_wall_clock_ms",
+    sample_count: 4,
+    duration_s: 3.5,
+    median_sample_step_s: 0.5,
+    max_sample_gap_s: 2.51,
+    max_sample_gap_ratio: 5.02,
+    monotonic: true,
+    gap_warning: true,
+  });
+  assert.equal(
+    payload.feature_manifest.feature_keys.includes("runtime_timeline.max_sample_gap_s"),
+    true,
+  );
+  assert.equal(
+    payload.feature_manifest.feature_keys.includes("runtime_timeline.clock_source"),
     true,
   );
 });

--- a/docs/mobile-install-and-field-test-runbook-v0.1.md
+++ b/docs/mobile-install-and-field-test-runbook-v0.1.md
@@ -111,6 +111,8 @@ Per subject/attempt:
    - `quality score/status`
    - `roi_valid_ratio` and `low_confidence_ratio`
    - `Runtime Q(t) Preview`
+   - after export, `capture_payload.analysis.runtime_timeline.gap_warning=false`
+     or an operator note explaining the timing interruption
 6. Enter reference metrics (`Qmax/Qavg/Vvoid` and optional time metrics).
 7. Submit paired measurement.
 8. If network failed, ensure queue item exists and run `Sync Queue` later.
@@ -208,6 +210,7 @@ GitHub Actions automation:
 - Flag run for review if:
   - `roi_valid_ratio < 0.80`
   - `low_confidence_ratio > 0.35`
+  - `analysis.runtime_timeline.gap_warning=true`
   - capture package missing in joined export.
 
 ## 8. Security And Privacy Minimum

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -13,6 +13,8 @@ Implemented now:
 - Runtime capture quality gates for ROI validity, low-confidence depth, and high-motion IMU artifacts.
 - Runtime capture preflight blocks start until camera permission, camera preview readiness,
   ROI lock, and a valid ROI frame are confirmed on device.
+- Runtime capture contracts include `analysis.runtime_timeline` timing integrity metadata
+  for duration, sample count, median sample step, max gap, and gap warnings.
 - Derivatives-only feature/media manifest in mobile `ios_capture_v1` payloads, with backend validation that raw media storage/upload flags remain disabled.
 - Release manifest traceability for app version, git SHA, model/schema, runtime config, capture contract feature-manifest evidence, and readiness gate summary.
 - Mobile API response, submit exception outcome, and runtime exception redaction gates for raw body, PHI-like subject/site/operator IDs, and secret-like error details.
@@ -35,6 +37,8 @@ Not yet implemented:
 
 ### G1. Sensor capture gap
 - Native sensor capture exists as a pilot runtime path, but still needs physical-device calibration against target iPhone/Android models.
+- Runtime sample timing is summarized in payload metadata, but native-grade timestamp
+  synchronization still needs device calibration against target iPhone/Android models.
 - ROI-only processing pipeline is proxy-based with pre-capture ROI frame validation, and still
   needs native-grade ROI extraction on device.
 - IMU motion gating is implemented in runtime quality scoring, but threshold calibration needs real device smoke evidence.
@@ -73,7 +77,7 @@ DoD:
 
 ## B1: Real capture MVP (water-impact only)
 1. Implement capture start/stop session service.
-2. Record audio envelope + ROI motion/texture + IMU jitter over unified timeline.
+2. Record audio envelope + ROI motion/texture + IMU jitter over unified timeline. Status: implemented with runtime timeline integrity metadata; native-grade timestamp synchronization still needs device calibration.
 3. Build live `ios_capture_v1` payload from runtime samples.
 4. Add quality pre-checks before submit (`roi_valid_ratio`, motion threshold, depth confidence ratio). Status: implemented in runtime payload scoring plus pre-capture camera/ROI readiness guard; needs physical-device threshold calibration.
 5. Add feature/media manifest for derived mobile capture features. Status: implemented as derivatives-only manifest with raw media disabled in payload and backend validator.

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -76,6 +76,8 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - Clinical Hub preflight guard evidence proving the app blocks missing/unsupported URLs and obvious cross-region Hub targets before Test API, Submit, or Sync Queue,
 - Clinical Hub request trace header evidence proving app/model/schema, runtime mode, endpoint set, and data-residency policy are sent as non-secret `x-uroflow-*` headers on API checks, submissions, summaries, and sync replay; backend audit stores these headers and rejects explicit region/runtime/endpoint mismatches,
 - runtime quality evidence for ROI validity, low-confidence depth ratio, and high-motion IMU artifact ratio in `capture_payload.analysis.runtime_quality`,
+- runtime timeline integrity evidence in `capture_payload.analysis.runtime_timeline`,
+  including sample count, duration, median sample step, max sample gap, and gap warning,
 - source-backed derivatives-only feature/media manifest evidence in `capture_contract.feature_manifest`, including manifest version, feature keys, `sample_count` source, `raw_media.*=false`, and `privacy.media_scope=roi_derivatives_only`,
 - readiness gate summary in `readiness`, including local/external/EAS/Clinical Hub statuses, local check counts, failed check IDs, external blocker statuses, and next-action IDs without secret values or detailed evidence strings,
 - runtime defaults such as `DEFAULT_API_BASE_URL` to prove release builds do not point field devices at localhost,
@@ -85,7 +87,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, EAS build/submit profile shape, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, Clinical Hub preflight guard, Clinical Hub runtime trace headers, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, EAS build/submit profile shape, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, Clinical Hub preflight guard, Clinical Hub runtime trace headers, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, runtime timeline integrity metadata, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
@@ -210,7 +212,8 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 4. Clinical Hub request logs include non-secret `x-uroflow-*` release/runtime/data-residency trace headers, and backend contract tests reject a deliberate mismatched region header.
 5. `Device Model` is auto-filled from the physical device model or a platform fallback, and matches the smoke-log device entry after any field correction.
 6. `Start Capture` and `Stop Capture` work on real device.
-7. `Contract payload: ready` after stop.
+7. `Contract payload: ready` after stop, with `analysis.runtime_timeline.gap_warning=false`
+   unless the runbook explicitly records a foreground/device-load interruption.
 8. Submit produces `paired-measurements` and `capture-packages` records.
 9. Offline mode queues both endpoint jobs.
 10. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
@@ -227,4 +230,6 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 7. Validated smoke summary JSON from `scripts/validate_mobile_device_smoke_log.py`.
 8. Clinical Hub sample export (paired + capture package rows).
    - For `capture-packages`, archive `capture_payload.feature_manifest` and confirm `derivatives_only=true`, `raw_media.store_raw_video=false`, `raw_media.store_raw_audio=false`, `raw_media.upload_raw_video=false`, and `raw_media.upload_raw_audio=false`.
+   - Archive `capture_payload.analysis.runtime_timeline` and investigate runs with
+     `gap_warning=true` or unexpectedly large `max_sample_gap_s`.
 9. Go/No-Go note for pilot usage.

--- a/scripts/build_mobile_release_manifest.py
+++ b/scripts/build_mobile_release_manifest.py
@@ -192,6 +192,14 @@ def _capture_contract_evidence(
             "roi_valid",
             "runtime_flow_series.flow_ml_s",
             "runtime_quality.high_motion_ratio",
+            "runtime_timeline.clock_source",
+            "runtime_timeline.duration_s",
+            "runtime_timeline.gap_warning",
+            "runtime_timeline.max_sample_gap_ratio",
+            "runtime_timeline.max_sample_gap_s",
+            "runtime_timeline.median_sample_step_s",
+            "runtime_timeline.monotonic",
+            "runtime_timeline.sample_count",
             "t_s",
         )
         if key in source
@@ -202,6 +210,20 @@ def _capture_contract_evidence(
         and "runtime_quality.high_motion_ratio" not in feature_keys
     ):
         feature_keys.append("runtime_quality.high_motion_ratio")
+    if "runtime_timeline" in source:
+        for timeline_key in (
+            "clock_source",
+            "duration_s",
+            "gap_warning",
+            "max_sample_gap_ratio",
+            "max_sample_gap_s",
+            "median_sample_step_s",
+            "monotonic",
+            "sample_count",
+        ):
+            feature_key = f"runtime_timeline.{timeline_key}"
+            if timeline_key in source and feature_key not in feature_keys:
+                feature_keys.append(feature_key)
     return {
         "path": str(path),
         "feature_manifest": {

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -1209,6 +1209,29 @@ def build_readiness_report(
     )
     _check(
         checks,
+        "runtime_timeline_analysis_sources",
+        "runtime_timeline" in capture_contract_source
+        and "deriveRuntimeTimeline" in capture_contract_source
+        and "elapsed_wall_clock_ms" in capture_contract_source
+        and "max_sample_gap_ratio" in capture_contract_source
+        and "runtime_timeline" in backend_capture_contract_source
+        and "analysis.runtime_timeline.sample_count must match samples length"
+        in backend_capture_contract_source,
+        (
+            f"mobile_capture_contract={capture_contract_source_path}, "
+            f"backend_capture_contract={backend_capture_contract_path}"
+        ),
+    )
+    _check(
+        checks,
+        "runtime_timeline_analysis_unit_tests_present",
+        "adds runtime timeline analysis" in capture_tests_source
+        and "rejects_invalid_runtime_timeline" in backend_capture_tests_source
+        and "elapsed_wall_clock_ms" in backend_capture_tests_source,
+        f"paths={[str(capture_tests_path), str(backend_capture_tests_path)]}",
+    )
+    _check(
+        checks,
         "pending_sync_queue_unit_tests_present",
         pending_sync_queue_tests_path.is_file(),
         f"path={pending_sync_queue_tests_path}",

--- a/src/uroflow_mobile/capture_contract.py
+++ b/src/uroflow_mobile/capture_contract.py
@@ -109,6 +109,80 @@ def _validate_feature_manifest(
             )
 
 
+def _validate_nullable_non_negative_number(
+    value: Any,
+    *,
+    field_name: str,
+    errors: list[str],
+) -> None:
+    if value is None:
+        return
+    if not _is_finite_number(value) or float(value) < 0:
+        errors.append(f"{field_name} must be null or a non-negative finite number")
+
+
+def _validate_analysis(
+    analysis: Any,
+    *,
+    sample_count: int,
+    errors: list[str],
+) -> None:
+    if analysis is None:
+        return
+    if not isinstance(analysis, dict):
+        errors.append("analysis must be an object when provided")
+        return
+
+    runtime_timeline = analysis.get("runtime_timeline")
+    if runtime_timeline is None:
+        return
+    if not isinstance(runtime_timeline, dict):
+        errors.append("analysis.runtime_timeline must be an object when provided")
+        return
+
+    if runtime_timeline.get("clock_source") != "elapsed_wall_clock_ms":
+        errors.append(
+            "analysis.runtime_timeline.clock_source must be 'elapsed_wall_clock_ms'"
+        )
+
+    timeline_sample_count = runtime_timeline.get("sample_count")
+    if not isinstance(timeline_sample_count, int) or isinstance(
+        timeline_sample_count, bool
+    ):
+        errors.append("analysis.runtime_timeline.sample_count must be an integer")
+    elif timeline_sample_count != sample_count:
+        errors.append(
+            "analysis.runtime_timeline.sample_count must match samples length"
+        )
+
+    duration_s = runtime_timeline.get("duration_s")
+    if not _is_finite_number(duration_s) or float(duration_s) < 0:
+        errors.append(
+            "analysis.runtime_timeline.duration_s must be a non-negative finite number"
+        )
+
+    _validate_nullable_non_negative_number(
+        runtime_timeline.get("median_sample_step_s"),
+        field_name="analysis.runtime_timeline.median_sample_step_s",
+        errors=errors,
+    )
+    _validate_nullable_non_negative_number(
+        runtime_timeline.get("max_sample_gap_s"),
+        field_name="analysis.runtime_timeline.max_sample_gap_s",
+        errors=errors,
+    )
+    _validate_nullable_non_negative_number(
+        runtime_timeline.get("max_sample_gap_ratio"),
+        field_name="analysis.runtime_timeline.max_sample_gap_ratio",
+        errors=errors,
+    )
+
+    if not isinstance(runtime_timeline.get("monotonic"), bool):
+        errors.append("analysis.runtime_timeline.monotonic must be boolean")
+    if not isinstance(runtime_timeline.get("gap_warning"), bool):
+        errors.append("analysis.runtime_timeline.gap_warning must be boolean")
+
+
 def validate_capture_payload(payload: dict[str, Any]) -> CaptureValidationReport:
     errors: list[str] = []
     warnings: list[str] = []
@@ -227,6 +301,11 @@ def validate_capture_payload(payload: dict[str, Any]) -> CaptureValidationReport
 
     _validate_feature_manifest(
         payload.get("feature_manifest"),
+        sample_count=sample_count,
+        errors=errors,
+    )
+    _validate_analysis(
+        payload.get("analysis"),
         sample_count=sample_count,
         errors=errors,
     )

--- a/tests/test_capture_contract.py
+++ b/tests/test_capture_contract.py
@@ -128,12 +128,62 @@ def test_validate_capture_payload_allows_optional_analysis_block() -> None:
             "roi_valid_ratio": 0.94,
             "low_confidence_ratio": 0.08,
         },
+        "runtime_timeline": {
+            "clock_source": "elapsed_wall_clock_ms",
+            "sample_count": 3,
+            "duration_s": 1.0,
+            "median_sample_step_s": 0.5,
+            "max_sample_gap_s": 0.5,
+            "max_sample_gap_ratio": 1.0,
+            "monotonic": True,
+            "gap_warning": False,
+        },
     }
 
     report = validate_capture_payload(payload)
 
     assert report.valid is True
     assert report.errors == []
+
+
+def test_validate_capture_payload_rejects_invalid_runtime_timeline() -> None:
+    payload = _valid_payload()
+    payload["analysis"] = {
+        "runtime_timeline": {
+            "clock_source": "device_wall_clock",
+            "sample_count": 99,
+            "duration_s": -1,
+            "median_sample_step_s": "0.5",
+            "max_sample_gap_s": -0.1,
+            "max_sample_gap_ratio": None,
+            "monotonic": "yes",
+            "gap_warning": "no",
+        },
+    }
+
+    report = validate_capture_payload(payload)
+
+    assert report.valid is False
+    assert (
+        "analysis.runtime_timeline.clock_source must be 'elapsed_wall_clock_ms'"
+        in report.errors
+    )
+    assert "analysis.runtime_timeline.sample_count must match samples length" in report.errors
+    assert (
+        "analysis.runtime_timeline.duration_s must be a non-negative finite number"
+        in report.errors
+    )
+    assert (
+        "analysis.runtime_timeline.median_sample_step_s must be null "
+        "or a non-negative finite number"
+        in report.errors
+    )
+    assert (
+        "analysis.runtime_timeline.max_sample_gap_s must be null or a non-negative finite number"
+        in report.errors
+    )
+    assert "analysis.runtime_timeline.monotonic must be boolean" in report.errors
+    assert "analysis.runtime_timeline.gap_warning must be boolean" in report.errors
 
 
 def test_validate_capture_payload_allows_derivatives_only_feature_manifest() -> None:

--- a/tests/test_mobile_release_manifest_script.py
+++ b/tests/test_mobile_release_manifest_script.py
@@ -133,6 +133,8 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
                 '  "depth_confidence", "audio_rms_dbfs", "motion_norm", "roi_valid"];',
                 'featureKeys.add("runtime_flow_series.flow_ml_s");',
                 'featureKeys.add("runtime_quality.high_motion_ratio");',
+                'featureKeys.add("runtime_timeline.max_sample_gap_s");',
+                'featureKeys.add("runtime_timeline.gap_warning");',
                 "const featureManifest = {",
                 "  derivatives_only: true,",
                 "  sample_count: samples.length,",
@@ -303,6 +305,8 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     }
     assert "audio_rms_dbfs" in feature_manifest["feature_keys"]
     assert "runtime_quality.high_motion_ratio" in feature_manifest["feature_keys"]
+    assert "runtime_timeline.max_sample_gap_s" in feature_manifest["feature_keys"]
+    assert "runtime_timeline.gap_warning" in feature_manifest["feature_keys"]
     assert payload["readiness"] == {
         "source_path": str(readiness_json),
         "status": "ready_except_external_credentials",

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -144,6 +144,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "runtime_capture_preflight_unit_tests_present",
         "runtime_motion_quality_gate_sources",
         "runtime_motion_quality_gate_unit_tests_present",
+        "runtime_timeline_analysis_sources",
+        "runtime_timeline_analysis_unit_tests_present",
         "release_metadata_capture_schema_version",
         "release_metadata_model_id",
         "release_metadata_module",


### PR DESCRIPTION
## Summary
- add `analysis.runtime_timeline` to runtime capture contracts with duration, sample count, median sample step, max gap, gap ratio, monotonicity, and gap warning
- validate runtime timeline metadata in the backend capture contract checker
- include runtime timeline keys in release manifest evidence and add readiness gates/tests/docs

## Validation
- npm run typecheck && npm run test:unit (apps/field-mobile)
- npm run validate:ci (apps/field-mobile)
- python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-runtime-timeline.json
- python3 scripts/build_mobile_release_manifest.py --app-json apps/field-mobile/app.json --readiness-json /tmp/mobile-readiness-runtime-timeline.json --output /tmp/mobile-manifest-runtime-timeline.json --profile preview --channel preview
- .venv/bin/ruff check .
- .venv/bin/pytest -q
- git diff --check