### PR TITLE
Require runtime timeline smoke evidence

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -99,6 +99,8 @@ Notes:
 - Runtime quality scoring includes `roi_valid_ratio`, `low_confidence_ratio`, and `high_motion_ratio`.
 - Runtime contract analysis includes `runtime_timeline` so Clinical Hub evidence can flag
   timing gaps caused by foreground stalls or device load.
+- Physical-device smoke logs must copy `capture_payload.analysis.runtime_timeline` and
+  pass with `gap_warning=false` for release handoff.
 - Raw media is not stored by default (privacy-by-default behavior).
 - Capture contract payloads include a derivatives-only `feature_manifest` with sample count,
   derived feature keys, and raw media storage/upload flags pinned to `false`.

--- a/docs/mobile-device-smoke-log-template-v0.1.json
+++ b/docs/mobile-device-smoke-log-template-v0.1.json
@@ -20,6 +20,16 @@
       "install_source": "TestFlight or EAS preview link",
       "app_build": "1",
       "network_profile": "clinic_wifi",
+      "runtime_timeline": {
+        "source_payload_path": "capture_payload.analysis.runtime_timeline",
+        "clock_source": "elapsed_wall_clock_ms",
+        "sample_count": 12,
+        "duration_s": 5.5,
+        "median_sample_step_s": 0.5,
+        "max_sample_gap_s": 0.55,
+        "max_sample_gap_ratio": 1.1,
+        "gap_warning": false
+      },
       "checks": [
         {
           "id": "app_launch",
@@ -40,6 +50,11 @@
           "id": "contract_payload_ready",
           "status": "pass",
           "evidence": "Contract payload shows ready after Stop Capture."
+        },
+        {
+          "id": "runtime_timeline_integrity",
+          "status": "pass",
+          "evidence": "capture_payload.analysis.runtime_timeline has gap_warning=false and max_sample_gap_s=0.55."
         },
         {
           "id": "paired_measurement_submit",
@@ -80,6 +95,16 @@
       "install_source": "Play Internal Testing or EAS preview APK",
       "app_build": "1",
       "network_profile": "clinic_wifi",
+      "runtime_timeline": {
+        "source_payload_path": "capture_payload.analysis.runtime_timeline",
+        "clock_source": "elapsed_wall_clock_ms",
+        "sample_count": 12,
+        "duration_s": 5.5,
+        "median_sample_step_s": 0.5,
+        "max_sample_gap_s": 0.55,
+        "max_sample_gap_ratio": 1.1,
+        "gap_warning": false
+      },
       "checks": [
         {
           "id": "app_launch",
@@ -100,6 +125,11 @@
           "id": "contract_payload_ready",
           "status": "pass",
           "evidence": "Contract payload shows ready after Stop Capture."
+        },
+        {
+          "id": "runtime_timeline_integrity",
+          "status": "pass",
+          "evidence": "capture_payload.analysis.runtime_timeline has gap_warning=false and max_sample_gap_s=0.55."
         },
         {
           "id": "paired_measurement_submit",

--- a/docs/mobile-install-and-field-test-runbook-v0.1.md
+++ b/docs/mobile-install-and-field-test-runbook-v0.1.md
@@ -111,8 +111,8 @@ Per subject/attempt:
    - `quality score/status`
    - `roi_valid_ratio` and `low_confidence_ratio`
    - `Runtime Q(t) Preview`
-   - after export, `capture_payload.analysis.runtime_timeline.gap_warning=false`
-     or an operator note explaining the timing interruption
+   - after export, `capture_payload.analysis.runtime_timeline.gap_warning=false`;
+     repeat or mark the run for review when timing gaps are reported
 6. Enter reference metrics (`Qmax/Qavg/Vvoid` and optional time metrics).
 7. Submit paired measurement.
 8. If network failed, ensure queue item exists and run `Sync Queue` later.
@@ -207,6 +207,8 @@ GitHub Actions automation:
 
 - Reject run if app cannot detect event or operator moved phone heavily.
 - Repeat run if app `quality_status=repeat`.
+- Copy `capture_payload.analysis.runtime_timeline` into the device smoke log and keep
+  `gap_warning=false` for release handoff evidence.
 - Flag run for review if:
   - `roi_valid_ratio < 0.80`
   - `low_confidence_ratio > 0.35`

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -23,6 +23,8 @@ Implemented now:
 - Deterministic mobile sync smoke covering queued paired+capture replay after network restore.
 - Mobile Build release notes artifact and manifest traceability for operator-facing build handoff.
 - Physical-device smoke evidence JSON template and validator for iOS+Android release handoff.
+- Physical-device smoke evidence requires per-device runtime timeline integrity metadata
+  with `gap_warning=false`.
 - Store rollout handoff JSON template, validator, and Mobile Build artifact for TestFlight/Play Internal traceability.
 - Mobile release bundle verifier for manifest/readiness/notes/store-handoff artifact consistency.
 - In-app Release Identity panel for app/model/schema/runtime/privacy/data-residency evidence on device.
@@ -61,7 +63,9 @@ Not yet implemented:
 ### G5. Verification gap
 - Mobile tests include TypeScript, unit, export, and deterministic sync replay coverage.
 - Deterministic replay tests cover capture contract generation and queued paired+capture sync; physical-device evidence now has a validator/template but still needs real-device execution.
-- Device-matrix smoke evidence requires at least one iPhone and one Android run in `mobile_device_smoke_log_v0.1`.
+- Device-matrix smoke evidence requires at least one iPhone and one Android run in
+  `mobile_device_smoke_log_v0.1`, including runtime timeline evidence from
+  `capture_payload.analysis.runtime_timeline`.
 
 ## 3) Backlog (implementation order)
 

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -212,8 +212,8 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 4. Clinical Hub request logs include non-secret `x-uroflow-*` release/runtime/data-residency trace headers, and backend contract tests reject a deliberate mismatched region header.
 5. `Device Model` is auto-filled from the physical device model or a platform fallback, and matches the smoke-log device entry after any field correction.
 6. `Start Capture` and `Stop Capture` work on real device.
-7. `Contract payload: ready` after stop, with `analysis.runtime_timeline.gap_warning=false`
-   unless the runbook explicitly records a foreground/device-load interruption.
+7. `Contract payload: ready` after stop, with `analysis.runtime_timeline.gap_warning=false`.
+   Repeat or mark the run failed if foreground/device load creates a timing gap warning.
 8. Submit produces `paired-measurements` and `capture-packages` records.
 9. Offline mode queues both endpoint jobs.
 10. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
@@ -228,6 +228,8 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 5. Build links (iOS + Android).
 6. Smoke test log with device model and OS version.
 7. Validated smoke summary JSON from `scripts/validate_mobile_device_smoke_log.py`.
+   - The smoke log must include per-device `runtime_timeline` evidence copied from
+     `capture_payload.analysis.runtime_timeline`, with `gap_warning=false`.
 8. Clinical Hub sample export (paired + capture package rows).
    - For `capture-packages`, archive `capture_payload.feature_manifest` and confirm `derivatives_only=true`, `raw_media.store_raw_video=false`, `raw_media.store_raw_audio=false`, `raw_media.upload_raw_video=false`, and `raw_media.upload_raw_audio=false`.
    - Archive `capture_payload.analysis.runtime_timeline` and investigate runs with

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -1312,6 +1312,11 @@ def build_readiness_report(
         "restore_sync_check": "connectivity_restore_sync" in mobile_device_smoke_template_source,
         "log_phi_review_check": "device_logs_reviewed_no_phi"
         in mobile_device_smoke_template_source,
+        "runtime_timeline_evidence": "runtime_timeline"
+        in mobile_device_smoke_template_source
+        and "runtime_timeline_integrity" in mobile_device_smoke_template_source
+        and "capture_payload.analysis.runtime_timeline"
+        in mobile_device_smoke_template_source,
     }
     _check(
         checks,
@@ -1327,6 +1332,10 @@ def build_readiness_report(
         in mobile_device_smoke_validator_source,
         "no_phi_log_review": "device_logs_reviewed_no_phi"
         in mobile_device_smoke_validator_source,
+        "runtime_timeline_validation": "_validate_runtime_timeline"
+        in mobile_device_smoke_validator_source
+        and "runtime_timeline_integrity" in mobile_device_smoke_validator_source
+        and "gap_warning must be false" in mobile_device_smoke_validator_source,
     }
     _check(
         checks,
@@ -1340,6 +1349,10 @@ def build_readiness_report(
         "ios_android_matrix_test": "requires_ios_and_android"
         in mobile_device_smoke_validator_tests_source,
         "required_checks_test": "requires_passing_required_checks"
+        in mobile_device_smoke_validator_tests_source,
+        "runtime_timeline_required_test": "requires_runtime_timeline"
+        in mobile_device_smoke_validator_tests_source,
+        "runtime_timeline_gap_warning_test": "rejects_timeline_gap_warning"
         in mobile_device_smoke_validator_tests_source,
     }
     _check(

--- a/scripts/validate_mobile_device_smoke_log.py
+++ b/scripts/validate_mobile_device_smoke_log.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 from datetime import datetime
 from pathlib import Path
@@ -15,6 +16,7 @@ REQUIRED_SMOKE_CHECK_IDS = (
     "api_connection_check",
     "capture_start_stop",
     "contract_payload_ready",
+    "runtime_timeline_integrity",
     "paired_measurement_submit",
     "capture_package_submit",
     "offline_queue_retains_jobs",
@@ -47,6 +49,15 @@ def _is_iso_timestamp(value: str) -> bool:
     return True
 
 
+def _is_non_negative_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+        and value >= 0
+    )
+
+
 def _validate_release(release: dict[str, Any], errors: list[str]) -> None:
     required_text_fields = (
         "git_sha",
@@ -76,6 +87,56 @@ def _check_map(device: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return checks
 
 
+def _validate_runtime_timeline(
+    device: dict[str, Any],
+    prefix: str,
+    errors: list[str],
+) -> None:
+    timeline = _as_dict(device.get("runtime_timeline"))
+    if not timeline:
+        errors.append(f"{prefix}.runtime_timeline is required")
+        return
+
+    source_payload_path = _read_text(timeline.get("source_payload_path"))
+    if source_payload_path != "capture_payload.analysis.runtime_timeline":
+        errors.append(
+            f"{prefix}.runtime_timeline.source_payload_path must be "
+            "'capture_payload.analysis.runtime_timeline'"
+        )
+
+    if timeline.get("clock_source") != "elapsed_wall_clock_ms":
+        errors.append(
+            f"{prefix}.runtime_timeline.clock_source must be 'elapsed_wall_clock_ms'"
+        )
+
+    sample_count = timeline.get("sample_count")
+    if not isinstance(sample_count, int) or isinstance(sample_count, bool):
+        errors.append(f"{prefix}.runtime_timeline.sample_count must be an integer")
+    elif sample_count < 2:
+        errors.append(f"{prefix}.runtime_timeline.sample_count must be >= 2")
+
+    for field in (
+        "duration_s",
+        "median_sample_step_s",
+        "max_sample_gap_s",
+        "max_sample_gap_ratio",
+    ):
+        if not _is_non_negative_number(timeline.get(field)):
+            errors.append(
+                f"{prefix}.runtime_timeline.{field} must be a non-negative number"
+            )
+
+    if timeline.get("duration_s") == 0:
+        errors.append(f"{prefix}.runtime_timeline.duration_s must be > 0")
+    if timeline.get("median_sample_step_s") == 0:
+        errors.append(f"{prefix}.runtime_timeline.median_sample_step_s must be > 0")
+
+    if timeline.get("gap_warning") is not False:
+        errors.append(
+            f"{prefix}.runtime_timeline.gap_warning must be false for release smoke evidence"
+        )
+
+
 def _validate_device(device: dict[str, Any], index: int, errors: list[str]) -> str:
     prefix = f"devices[{index}]"
     platform = _read_text(device.get("platform")).lower()
@@ -85,6 +146,8 @@ def _validate_device(device: dict[str, Any], index: int, errors: list[str]) -> s
     for field in ("device_model", "os_version", "install_source", "app_build"):
         if not _read_text(device.get(field)):
             errors.append(f"{prefix}.{field} is required")
+
+    _validate_runtime_timeline(device, prefix, errors)
 
     checks = _check_map(device)
     for check_id in REQUIRED_SMOKE_CHECK_IDS:

--- a/tests/test_mobile_device_smoke_log.py
+++ b/tests/test_mobile_device_smoke_log.py
@@ -46,6 +46,7 @@ def test_mobile_device_smoke_log_template_validates(tmp_path: Path) -> None:
     assert summary["platforms_seen"] == ["android", "ios"]
     assert "connectivity_restore_sync" in summary["required_check_ids"]
     assert "device_logs_reviewed_no_phi" in summary["required_check_ids"]
+    assert "runtime_timeline_integrity" in summary["required_check_ids"]
     assert json.loads((tmp_path / "summary.json").read_text(encoding="utf-8")) == summary
 
 
@@ -76,3 +77,32 @@ def test_mobile_device_smoke_log_requires_passing_required_checks(tmp_path: Path
     assert result.returncode == 1
     assert summary["status"] == "fail"
     assert "devices[0].checks[app_launch].status must be 'pass'" in summary["errors"]
+
+
+def test_mobile_device_smoke_log_requires_runtime_timeline(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload = copy.deepcopy(payload)
+    del payload["devices"][0]["runtime_timeline"]
+
+    result = _run_validator(tmp_path, payload, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert "devices[0].runtime_timeline is required" in summary["errors"]
+
+
+def test_mobile_device_smoke_log_rejects_timeline_gap_warning(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload = copy.deepcopy(payload)
+    payload["devices"][0]["runtime_timeline"]["gap_warning"] = True
+
+    result = _run_validator(tmp_path, payload, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert (
+        "devices[0].runtime_timeline.gap_warning must be false for release smoke evidence"
+        in summary["errors"]
+    )


### PR DESCRIPTION
## Summary
- require per-device `runtime_timeline` evidence in the physical mobile smoke log template
- validate timeline source path, clock source, sample count, timing metrics, and `gap_warning=false` for release smoke handoff
- update readiness source gates, docs, and validator tests for runtime timeline smoke evidence

## Validation
- python3 scripts/validate_mobile_device_smoke_log.py docs/mobile-device-smoke-log-template-v0.1.json --output /tmp/mobile-device-smoke-summary-timeline.json
- python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-smoke-timeline.json
- .venv/bin/ruff check .
- .venv/bin/pytest -q
- git diff --check