### PR TITLE
Gate runtime quality on timeline gaps

### DIFF
--- a/apps/field-mobile/App.tsx
+++ b/apps/field-mobile/App.tsx
@@ -151,6 +151,7 @@ export default function App() {
   const [captureRoiValidRatio, setCaptureRoiValidRatio] = useState(0);
   const [captureLowConfidenceRatio, setCaptureLowConfidenceRatio] = useState(0);
   const [captureHighMotionRatio, setCaptureHighMotionRatio] = useState(0);
+  const [captureTimingGapWarning, setCaptureTimingGapWarning] = useState(false);
   const [runtimeFlowSeries, setRuntimeFlowSeries] = useState<RuntimeFlowPoint[]>([]);
   const [cameraPreviewReady, setCameraPreviewReady] = useState(false);
   const [roiLocked, setRoiLocked] = useState(false);
@@ -482,6 +483,7 @@ export default function App() {
       setCaptureRoiValidRatio(stopResult.quality.roiValidRatio);
       setCaptureLowConfidenceRatio(stopResult.quality.lowConfidenceRatio);
       setCaptureHighMotionRatio(stopResult.quality.highMotionRatio);
+      setCaptureTimingGapWarning(stopResult.quality.timingGapWarning);
       setRuntimeFlowSeries(stopResult.flowSeries);
       setDeviceModel(stopResult.deviceModel);
       if (!manualAppMetricsOverride) {
@@ -513,12 +515,13 @@ export default function App() {
             roi_valid_ratio: stopResult.quality.roiValidRatio,
             low_confidence_ratio: stopResult.quality.lowConfidenceRatio,
             high_motion_ratio: stopResult.quality.highMotionRatio,
+            timing_gap_warning: stopResult.quality.timingGapWarning,
           },
         },
       });
       setRuntimeCaptureContractPayload(contractPayload as unknown as Record<string, unknown>);
       setCaptureStatus(
-        `Capture stopped. samples=${stopResult.sampleCount}, quality=${stopResult.quality.qualityStatus}, score=${stopResult.quality.qualityScore.toFixed(1)}, high_motion_ratio=${stopResult.quality.highMotionRatio.toFixed(3)}`,
+        `Capture stopped. samples=${stopResult.sampleCount}, quality=${stopResult.quality.qualityStatus}, score=${stopResult.quality.qualityScore.toFixed(1)}, high_motion_ratio=${stopResult.quality.highMotionRatio.toFixed(3)}, timing_gap_warning=${stopResult.quality.timingGapWarning ? "yes" : "no"}`,
       );
       if (stopResult.derived.eventStartTs != null && stopResult.derived.eventEndTs != null) {
         const runtimeNote =
@@ -867,6 +870,7 @@ export default function App() {
           captureHighMotionRatio={captureHighMotionRatio}
           captureLowConfidenceRatio={captureLowConfidenceRatio}
           captureRoiValidRatio={captureRoiValidRatio}
+          captureTimingGapWarning={captureTimingGapWarning}
           captureRunning={captureRunning}
           captureSampleCount={captureSampleCount}
           captureStatus={captureStatus}

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -96,7 +96,8 @@ Notes:
 Notes:
 - Runtime capture currently logs sampled audio metering + motion, and derives proxy level traces.
 - Camera preview + ROI lock state are included in runtime quality gating.
-- Runtime quality scoring includes `roi_valid_ratio`, `low_confidence_ratio`, and `high_motion_ratio`.
+- Runtime quality scoring includes `roi_valid_ratio`, `low_confidence_ratio`,
+  `high_motion_ratio`, and `timing_gap_warning`; timing gaps force at least `repeat`.
 - Runtime contract analysis includes `runtime_timeline` so Clinical Hub evidence can flag
   timing gaps caused by foreground stalls or device load.
 - Physical-device smoke logs must copy `capture_payload.analysis.runtime_timeline` and

--- a/apps/field-mobile/src/capture/buildCaptureContract.ts
+++ b/apps/field-mobile/src/capture/buildCaptureContract.ts
@@ -41,6 +41,7 @@ export type CaptureContractAnalysis = {
     roi_valid_ratio?: number;
     low_confidence_ratio?: number;
     high_motion_ratio?: number;
+    timing_gap_warning?: boolean;
   };
 };
 
@@ -327,6 +328,9 @@ function sanitizeAnalysis(
       runtimeQuality.high_motion_ratio = round4(
         clamp(runtimeQualityRaw.high_motion_ratio as number, 0, 1),
       );
+    }
+    if (typeof runtimeQualityRaw.timing_gap_warning === "boolean") {
+      runtimeQuality.timing_gap_warning = runtimeQualityRaw.timing_gap_warning;
     }
   }
   const hasRuntimeQuality = Object.keys(runtimeQuality).length > 0;

--- a/apps/field-mobile/src/capture/runtimeCaptureSession.ts
+++ b/apps/field-mobile/src/capture/runtimeCaptureSession.ts
@@ -10,7 +10,7 @@ import {
 import { Accelerometer } from "expo-sensors";
 import { Camera } from "expo-camera";
 import * as Device from "expo-device";
-import type { CaptureContractSample } from "./buildCaptureContract";
+import { deriveRuntimeTimeline, type CaptureContractSample } from "./buildCaptureContract";
 import {
   calculateAverageMotionNorm,
   clamp,
@@ -209,6 +209,7 @@ export class RuntimeCaptureSession {
     }
 
     const avgMotionNorm = calculateAverageMotionNorm(this.samples);
+    const runtimeTimeline = deriveRuntimeTimeline(this.samples);
     const derived = deriveRuntimeCaptureMetrics({
       samples: this.samples,
       flowSeries: this.flowSeries,
@@ -217,6 +218,7 @@ export class RuntimeCaptureSession {
     const quality = scoreRuntimeCaptureQuality({
       samples: this.samples,
       averageMotionNorm: avgMotionNorm,
+      timingGapWarning: runtimeTimeline.gap_warning,
     });
 
     return {

--- a/apps/field-mobile/src/capture/runtimeMetrics.ts
+++ b/apps/field-mobile/src/capture/runtimeMetrics.ts
@@ -22,6 +22,7 @@ export type RuntimeCaptureQuality = {
   roiValidRatio: number;
   lowConfidenceRatio: number;
   highMotionRatio: number;
+  timingGapWarning: boolean;
 };
 
 export type RuntimeFlowPoint = {
@@ -226,6 +227,7 @@ export function deriveRuntimeCaptureMetrics(input: {
 export function scoreRuntimeCaptureQuality(input: {
   samples: CaptureContractSample[];
   averageMotionNorm: number;
+  timingGapWarning?: boolean;
 }): RuntimeCaptureQuality {
   const sampleCount = Math.max(1, input.samples.length);
   const roiValidCount = input.samples.filter((sample) => sample.roi_valid).length;
@@ -243,6 +245,9 @@ export function scoreRuntimeCaptureQuality(input: {
   score -= clamp((1 - roiValidRatio) * 70, 0, 50);
   score -= clamp(lowConfidenceRatio * 40, 0, 25);
   score -= clamp(highMotionRatio * 50, 0, 30);
+  if (input.timingGapWarning === true) {
+    score -= 15;
+  }
   score = clamp(score, 0, 100);
 
   let qualityStatus: RuntimeCaptureQuality["qualityStatus"] = "valid";
@@ -256,6 +261,9 @@ export function scoreRuntimeCaptureQuality(input: {
   ) {
     qualityStatus = "repeat";
   }
+  if (input.timingGapWarning === true && qualityStatus === "valid") {
+    qualityStatus = "repeat";
+  }
 
   return {
     qualityScore: round4(score),
@@ -263,5 +271,6 @@ export function scoreRuntimeCaptureQuality(input: {
     roiValidRatio: round4(roiValidRatio),
     lowConfidenceRatio: round4(lowConfidenceRatio),
     highMotionRatio: round4(highMotionRatio),
+    timingGapWarning: input.timingGapWarning === true,
   };
 }

--- a/apps/field-mobile/src/components/RuntimeCaptureSection.tsx
+++ b/apps/field-mobile/src/components/RuntimeCaptureSection.tsx
@@ -17,6 +17,7 @@ type RuntimeCaptureSectionProps = {
   captureRunning: boolean;
   captureSampleCount: number;
   captureStatus: string;
+  captureTimingGapWarning: boolean;
   flowSeries: RuntimeFlowPoint[];
   manualAppMetricsOverride: boolean;
   roiFrameCount: number;
@@ -45,6 +46,7 @@ export function RuntimeCaptureSection({
   captureRunning,
   captureSampleCount,
   captureStatus,
+  captureTimingGapWarning,
   flowSeries,
   manualAppMetricsOverride,
   roiFrameCount,
@@ -75,7 +77,8 @@ export function RuntimeCaptureSection({
       <Text style={styles.captureStatusText}>
         quality flags: roi_valid_ratio={captureRoiValidRatio.toFixed(3)}, low_confidence_ratio=
         {captureLowConfidenceRatio.toFixed(3)}, high_motion_ratio=
-        {captureHighMotionRatio.toFixed(3)}
+        {captureHighMotionRatio.toFixed(3)}, timing_gap_warning=
+        {captureTimingGapWarning ? "yes" : "no"}
       </Text>
       <Text style={styles.captureStatusText}>
         Contract payload:{" "}

--- a/apps/field-mobile/tests/captureContract.test.js
+++ b/apps/field-mobile/tests/captureContract.test.js
@@ -228,6 +228,7 @@ test("buildCaptureContractPayloadFromSamples sanitizes runtime analysis", () => 
         roi_valid_ratio: 2,
         low_confidence_ratio: -1,
         high_motion_ratio: 1.5,
+        timing_gap_warning: true,
       },
     },
   });
@@ -248,6 +249,7 @@ test("buildCaptureContractPayloadFromSamples sanitizes runtime analysis", () => 
     roi_valid_ratio: 1,
     low_confidence_ratio: 0,
     high_motion_ratio: 1,
+    timing_gap_warning: true,
   });
   assertDerivativesOnlyFeatureManifest(payload, "runtime-audio-imu-camera-proxy");
   assert.equal(
@@ -256,6 +258,10 @@ test("buildCaptureContractPayloadFromSamples sanitizes runtime analysis", () => 
   );
   assert.equal(
     payload.feature_manifest.feature_keys.includes("runtime_quality.high_motion_ratio"),
+    true,
+  );
+  assert.equal(
+    payload.feature_manifest.feature_keys.includes("runtime_quality.timing_gap_warning"),
     true,
   );
 });

--- a/apps/field-mobile/tests/runtimeMetrics.test.js
+++ b/apps/field-mobile/tests/runtimeMetrics.test.js
@@ -167,6 +167,18 @@ test("scoreRuntimeCaptureQuality repeats high low-confidence captures", () => {
   assert.equal(quality.highMotionRatio, 0);
 });
 
+test("scoreRuntimeCaptureQuality repeats timing-gap captures", () => {
+  const quality = runtime.scoreRuntimeCaptureQuality({
+    averageMotionNorm: 0.02,
+    samples: [sample(), sample(), sample(), sample()],
+    timingGapWarning: true,
+  });
+
+  assert.equal(quality.qualityStatus, "repeat");
+  assert.equal(quality.timingGapWarning, true);
+  assert.equal(quality.qualityScore, 83.4);
+});
+
 test("calculateAverageMotionNorm handles empty samples", () => {
   assert.equal(runtime.calculateAverageMotionNorm([]), 0);
   assert.equal(

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -15,6 +15,8 @@ Implemented now:
   ROI lock, and a valid ROI frame are confirmed on device.
 - Runtime capture contracts include `analysis.runtime_timeline` timing integrity metadata
   for duration, sample count, median sample step, max gap, and gap warnings.
+- Runtime quality scoring gates timing gaps with `runtime_quality.timing_gap_warning`,
+  forcing at least `repeat` when capture sampling stalls.
 - Derivatives-only feature/media manifest in mobile `ios_capture_v1` payloads, with backend validation that raw media storage/upload flags remain disabled.
 - Release manifest traceability for app version, git SHA, model/schema, runtime config, capture contract feature-manifest evidence, and readiness gate summary.
 - Mobile API response, submit exception outcome, and runtime exception redaction gates for raw body, PHI-like subject/site/operator IDs, and secret-like error details.
@@ -39,8 +41,9 @@ Not yet implemented:
 
 ### G1. Sensor capture gap
 - Native sensor capture exists as a pilot runtime path, but still needs physical-device calibration against target iPhone/Android models.
-- Runtime sample timing is summarized in payload metadata, but native-grade timestamp
-  synchronization still needs device calibration against target iPhone/Android models.
+- Runtime sample timing is summarized in payload metadata and gated in quality scoring,
+  but native-grade timestamp synchronization still needs device calibration against
+  target iPhone/Android models.
 - ROI-only processing pipeline is proxy-based with pre-capture ROI frame validation, and still
   needs native-grade ROI extraction on device.
 - IMU motion gating is implemented in runtime quality scoring, but threshold calibration needs real device smoke evidence.
@@ -81,7 +84,7 @@ DoD:
 
 ## B1: Real capture MVP (water-impact only)
 1. Implement capture start/stop session service.
-2. Record audio envelope + ROI motion/texture + IMU jitter over unified timeline. Status: implemented with runtime timeline integrity metadata; native-grade timestamp synchronization still needs device calibration.
+2. Record audio envelope + ROI motion/texture + IMU jitter over unified timeline. Status: implemented with runtime timeline integrity metadata and timing-gap quality gating; native-grade timestamp synchronization still needs device calibration.
 3. Build live `ios_capture_v1` payload from runtime samples.
 4. Add quality pre-checks before submit (`roi_valid_ratio`, motion threshold, depth confidence ratio). Status: implemented in runtime payload scoring plus pre-capture camera/ROI readiness guard; needs physical-device threshold calibration.
 5. Add feature/media manifest for derived mobile capture features. Status: implemented as derivatives-only manifest with raw media disabled in payload and backend validator.

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -78,6 +78,8 @@ Workflow generates artifact `mobile-release-manifest` containing:
 - runtime quality evidence for ROI validity, low-confidence depth ratio, and high-motion IMU artifact ratio in `capture_payload.analysis.runtime_quality`,
 - runtime timeline integrity evidence in `capture_payload.analysis.runtime_timeline`,
   including sample count, duration, median sample step, max sample gap, and gap warning,
+- runtime quality gating evidence that `runtime_quality.timing_gap_warning=true`
+  forces at least `repeat`,
 - source-backed derivatives-only feature/media manifest evidence in `capture_contract.feature_manifest`, including manifest version, feature keys, `sample_count` source, `raw_media.*=false`, and `privacy.media_scope=roi_derivatives_only`,
 - readiness gate summary in `readiness`, including local/external/EAS/Clinical Hub statuses, local check counts, failed check IDs, external blocker statuses, and next-action IDs without secret values or detailed evidence strings,
 - runtime defaults such as `DEFAULT_API_BASE_URL` to prove release builds do not point field devices at localhost,
@@ -87,7 +89,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, EAS build/submit profile shape, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, Clinical Hub preflight guard, Clinical Hub runtime trace headers, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, runtime timeline integrity metadata, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, EAS build/submit profile shape, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, Clinical Hub preflight guard, Clinical Hub runtime trace headers, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, runtime timeline integrity metadata and quality gating, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),

--- a/scripts/build_mobile_release_manifest.py
+++ b/scripts/build_mobile_release_manifest.py
@@ -192,6 +192,7 @@ def _capture_contract_evidence(
             "roi_valid",
             "runtime_flow_series.flow_ml_s",
             "runtime_quality.high_motion_ratio",
+            "runtime_quality.timing_gap_warning",
             "runtime_timeline.clock_source",
             "runtime_timeline.duration_s",
             "runtime_timeline.gap_warning",
@@ -210,6 +211,12 @@ def _capture_contract_evidence(
         and "runtime_quality.high_motion_ratio" not in feature_keys
     ):
         feature_keys.append("runtime_quality.high_motion_ratio")
+    if (
+        "runtime_quality" in source
+        and "timing_gap_warning" in source
+        and "runtime_quality.timing_gap_warning" not in feature_keys
+    ):
+        feature_keys.append("runtime_quality.timing_gap_warning")
     if "runtime_timeline" in source:
         for timeline_key in (
             "clock_source",

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -814,6 +814,8 @@ def build_readiness_report(
     repo_root = package_json.resolve().parent.parent.parent
     backend_capture_contract_path = repo_root / "src" / "uroflow_mobile" / "capture_contract.py"
     backend_capture_tests_path = repo_root / "tests" / "test_capture_contract.py"
+    backend_session_path = repo_root / "src" / "uroflow_mobile" / "session.py"
+    backend_session_tests_path = repo_root / "tests" / "test_session.py"
     mobile_device_smoke_template_path = (
         repo_root / "docs" / "mobile-device-smoke-log-template-v0.1.json"
     )
@@ -882,6 +884,8 @@ def build_readiness_report(
     capture_tests_source = _read_file_text(capture_tests_path)
     backend_capture_contract_source = _read_file_text(backend_capture_contract_path)
     backend_capture_tests_source = _read_file_text(backend_capture_tests_path)
+    backend_session_source = _read_file_text(backend_session_path)
+    backend_session_tests_source = _read_file_text(backend_session_tests_path)
     runtime_metrics_source = _read_file_text(runtime_metrics_source_path)
     runtime_metrics_tests_source = _read_file_text(runtime_metrics_tests_path)
     mobile_device_smoke_template_source = _read_file_text(mobile_device_smoke_template_path)
@@ -1229,6 +1233,36 @@ def build_readiness_report(
         and "rejects_invalid_runtime_timeline" in backend_capture_tests_source
         and "elapsed_wall_clock_ms" in backend_capture_tests_source,
         f"paths={[str(capture_tests_path), str(backend_capture_tests_path)]}",
+    )
+    _check(
+        checks,
+        "runtime_timeline_quality_gate_sources",
+        "timingGapWarning" in runtime_metrics_source
+        and "timing_gap_warning" in capture_contract_source
+        and "timing_gap_warning" in app_ts_source
+        and "runtime_timeline_gap_warning" in backend_session_source
+        and "analysis.runtime_quality.timing_gap_warning must be boolean"
+        in backend_capture_contract_source,
+        (
+            f"runtime_metrics={runtime_metrics_source_path}, "
+            f"capture_contract={capture_contract_source_path}, "
+            f"backend_session={backend_session_path}"
+        ),
+    )
+    runtime_timeline_quality_test_paths = [
+        str(runtime_metrics_tests_path),
+        str(capture_tests_path),
+        str(backend_capture_tests_path),
+        str(backend_session_tests_path),
+    ]
+    _check(
+        checks,
+        "runtime_timeline_quality_gate_unit_tests_present",
+        "repeats timing-gap captures" in runtime_metrics_tests_source
+        and "runtime_quality.timing_gap_warning" in capture_tests_source
+        and "rejects_invalid_runtime_quality_timing_gap" in backend_capture_tests_source
+        and "marks_repeat_for_runtime_timeline_gap" in backend_session_tests_source,
+        f"paths={runtime_timeline_quality_test_paths}",
     )
     _check(
         checks,

--- a/src/uroflow_mobile/capture_contract.py
+++ b/src/uroflow_mobile/capture_contract.py
@@ -134,6 +134,14 @@ def _validate_analysis(
         return
 
     runtime_timeline = analysis.get("runtime_timeline")
+    runtime_quality = analysis.get("runtime_quality")
+    if (
+        isinstance(runtime_quality, dict)
+        and "timing_gap_warning" in runtime_quality
+        and not isinstance(runtime_quality.get("timing_gap_warning"), bool)
+    ):
+        errors.append("analysis.runtime_quality.timing_gap_warning must be boolean")
+
     if runtime_timeline is None:
         return
     if not isinstance(runtime_timeline, dict):

--- a/src/uroflow_mobile/cli.py
+++ b/src/uroflow_mobile/cli.py
@@ -117,6 +117,7 @@ def _session_quality_to_dict(quality: CaptureSessionQuality) -> dict[str, object
         "roi_valid_ratio": quality.roi_valid_ratio,
         "low_depth_confidence_ratio": quality.low_depth_confidence_ratio,
         "high_motion_ratio": quality.high_motion_ratio,
+        "runtime_timeline_gap_warning": quality.runtime_timeline_gap_warning,
         "motion_coverage_ratio": quality.motion_coverage_ratio,
         "audio_clipping_ratio": quality.audio_clipping_ratio,
         "audio_coverage_ratio": quality.audio_coverage_ratio,

--- a/src/uroflow_mobile/session.py
+++ b/src/uroflow_mobile/session.py
@@ -46,6 +46,7 @@ class CaptureSessionConfig:
     max_low_depth_confidence_ratio: float = 0.25
     high_motion_threshold: float = 0.2
     max_high_motion_ratio: float = 0.15
+    runtime_timeline_gap_penalty: float = 15.0
     audio_clip_dbfs: float = -3.0
     max_audio_clipping_ratio: float = 0.05
     min_representative_volume_ml: float = 150.0
@@ -65,6 +66,7 @@ class CaptureSessionQuality:
     roi_valid_ratio: float
     low_depth_confidence_ratio: float
     high_motion_ratio: float
+    runtime_timeline_gap_warning: bool
     motion_coverage_ratio: float
     audio_clipping_ratio: float
     audio_coverage_ratio: float
@@ -164,6 +166,16 @@ def _resolve_min_depth_confidence(payload: dict[str, Any], default_value: float)
     return candidate
 
 
+def _runtime_timeline_gap_warning(payload: dict[str, Any]) -> bool:
+    analysis = payload.get("analysis")
+    if not isinstance(analysis, dict):
+        return False
+    runtime_timeline = analysis.get("runtime_timeline")
+    if not isinstance(runtime_timeline, dict):
+        return False
+    return runtime_timeline.get("gap_warning") is True
+
+
 def _slice_fusion_result(
     fusion_result: FusionEstimationResult,
     indices: list[int],
@@ -210,6 +222,7 @@ def _compute_quality(
     event_detection: EventDetectionResult,
     validation: CaptureValidationReport,
     samples: list[dict[str, Any]],
+    runtime_timeline_gap_warning: bool,
     config: CaptureSessionConfig,
 ) -> CaptureSessionQuality:
     if config.reject_quality_score >= config.valid_quality_score:
@@ -257,6 +270,10 @@ def _compute_quality(
             "high_motion_ratio_above_threshold"
             f"({high_motion_ratio:.3f} > {config.max_high_motion_ratio:.3f})"
         )
+
+    if runtime_timeline_gap_warning:
+        score -= max(0.0, config.runtime_timeline_gap_penalty)
+        reasons.append("runtime_timeline_gap_warning")
 
     if audio_clipping_ratio > config.max_audio_clipping_ratio:
         excess = (audio_clipping_ratio - config.max_audio_clipping_ratio) / max(
@@ -321,6 +338,8 @@ def _compute_quality(
 
     if not event_detection.detected and status == "valid":
         status = "repeat"
+    if runtime_timeline_gap_warning and status == "valid":
+        status = "repeat"
 
     if not reasons:
         reasons.append("quality_within_limits")
@@ -332,6 +351,7 @@ def _compute_quality(
         roi_valid_ratio=validation.roi_valid_ratio,
         low_depth_confidence_ratio=validation.low_depth_confidence_ratio,
         high_motion_ratio=high_motion_ratio,
+        runtime_timeline_gap_warning=runtime_timeline_gap_warning,
         motion_coverage_ratio=motion_coverage_ratio,
         audio_clipping_ratio=audio_clipping_ratio,
         audio_coverage_ratio=audio_coverage_ratio,
@@ -390,6 +410,7 @@ def analyze_capture_session(
     samples = payload.get("samples", [])
     if not isinstance(samples, list):
         raise ValueError("samples must be an array")
+    runtime_timeline_gap_warning = _runtime_timeline_gap_warning(payload)
 
     roi_valid = [bool(sample["roi_valid"]) for sample in samples]
     audio_rms_dbfs = _extract_audio_series(samples)
@@ -434,6 +455,7 @@ def analyze_capture_session(
         event_detection=event_detection,
         validation=validation,
         samples=samples,
+        runtime_timeline_gap_warning=runtime_timeline_gap_warning,
         config=cfg,
     )
 

--- a/tests/test_capture_contract.py
+++ b/tests/test_capture_contract.py
@@ -127,6 +127,7 @@ def test_validate_capture_payload_allows_optional_analysis_block() -> None:
             "quality_status": "valid",
             "roi_valid_ratio": 0.94,
             "low_confidence_ratio": 0.08,
+            "timing_gap_warning": False,
         },
         "runtime_timeline": {
             "clock_source": "elapsed_wall_clock_ms",
@@ -184,6 +185,20 @@ def test_validate_capture_payload_rejects_invalid_runtime_timeline() -> None:
     )
     assert "analysis.runtime_timeline.monotonic must be boolean" in report.errors
     assert "analysis.runtime_timeline.gap_warning must be boolean" in report.errors
+
+
+def test_validate_capture_payload_rejects_invalid_runtime_quality_timing_gap() -> None:
+    payload = _valid_payload()
+    payload["analysis"] = {
+        "runtime_quality": {
+            "timing_gap_warning": "false",
+        },
+    }
+
+    report = validate_capture_payload(payload)
+
+    assert report.valid is False
+    assert "analysis.runtime_quality.timing_gap_warning must be boolean" in report.errors
 
 
 def test_validate_capture_payload_allows_derivatives_only_feature_manifest() -> None:

--- a/tests/test_mobile_release_manifest_script.py
+++ b/tests/test_mobile_release_manifest_script.py
@@ -133,6 +133,7 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
                 '  "depth_confidence", "audio_rms_dbfs", "motion_norm", "roi_valid"];',
                 'featureKeys.add("runtime_flow_series.flow_ml_s");',
                 'featureKeys.add("runtime_quality.high_motion_ratio");',
+                'featureKeys.add("runtime_quality.timing_gap_warning");',
                 'featureKeys.add("runtime_timeline.max_sample_gap_s");',
                 'featureKeys.add("runtime_timeline.gap_warning");',
                 "const featureManifest = {",
@@ -305,6 +306,7 @@ def test_build_mobile_release_manifest_script(tmp_path: Path) -> None:
     }
     assert "audio_rms_dbfs" in feature_manifest["feature_keys"]
     assert "runtime_quality.high_motion_ratio" in feature_manifest["feature_keys"]
+    assert "runtime_quality.timing_gap_warning" in feature_manifest["feature_keys"]
     assert "runtime_timeline.max_sample_gap_s" in feature_manifest["feature_keys"]
     assert "runtime_timeline.gap_warning" in feature_manifest["feature_keys"]
     assert payload["readiness"] == {

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -146,6 +146,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "runtime_motion_quality_gate_unit_tests_present",
         "runtime_timeline_analysis_sources",
         "runtime_timeline_analysis_unit_tests_present",
+        "runtime_timeline_quality_gate_sources",
+        "runtime_timeline_quality_gate_unit_tests_present",
         "release_metadata_capture_schema_version",
         "release_metadata_model_id",
         "release_metadata_module",

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -143,6 +143,35 @@ def test_analyze_capture_session_marks_repeat_for_motion_and_roi_issues() -> Non
     assert any("high_motion_ratio_above_threshold" in reason for reason in analysis.quality.reasons)
 
 
+def test_analyze_capture_session_marks_repeat_for_runtime_timeline_gap() -> None:
+    payload = _base_payload()
+    payload["analysis"] = {
+        "runtime_timeline": {
+            "clock_source": "elapsed_wall_clock_ms",
+            "sample_count": 9,
+            "duration_s": 8.0,
+            "median_sample_step_s": 1.0,
+            "max_sample_gap_s": 3.0,
+            "max_sample_gap_ratio": 3.0,
+            "monotonic": True,
+            "gap_warning": True,
+        },
+    }
+
+    analysis = analyze_capture_session(
+        payload,
+        config=CaptureSessionConfig(
+            ml_per_mm_override=10.0,
+            max_level_noise_mm=4.0,
+            event_min_audio_delta_db=8.0,
+        ),
+    )
+
+    assert analysis.quality.status == "repeat"
+    assert analysis.quality.runtime_timeline_gap_warning is True
+    assert "runtime_timeline_gap_warning" in analysis.quality.reasons
+
+
 def test_analyze_capture_session_raises_for_invalid_payload() -> None:
     payload = _base_payload()
     samples = payload["samples"]


### PR DESCRIPTION
## Summary
- make runtime timeline gaps affect mobile quality scoring and force at least `repeat`
- propagate `runtime_quality.timing_gap_warning` into capture contracts, feature evidence, UI, and CLI/session quality summaries
- add backend validation/session gating plus readiness and manifest coverage for the timing-gap quality gate

## Validation
- npm run validate:ci (apps/field-mobile)
- python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-timeline-quality.json
- python3 scripts/build_mobile_release_manifest.py --app-json apps/field-mobile/app.json --readiness-json /tmp/mobile-readiness-timeline-quality.json --output /tmp/mobile-manifest-timeline-quality.json --profile preview --channel preview
- .venv/bin/ruff check .
- .venv/bin/pytest -q
- git diff --check