### PR TITLE
Keep mobile auth failures queued for retry

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -13,7 +13,8 @@ Cross-platform mobile client (Expo React Native) for collecting paired measureme
 - Coverage ratio is color-coded against target 90% (`>=90%` green, `<90%` red)
 - Offline pending queue with manual sync (`Sync Queue`)
 - Offline pending queue stores both endpoint jobs: `paired-measurements` and `capture-packages`
-- Retry policy: non-retryable API errors are not re-queued
+- Retry policy: network/transient and Clinical Hub auth/permission failures stay queued for retry
+  after credential repair; validation/conflict errors are not re-queued
 - Pending items store request header context (`x-api-key`, `x-site-id`, `x-actor-role`, `x-operator-id`)
 - Pending retries reuse a stable `x-request-id` per endpoint job to reduce duplicate risk after timeout/retry
 - Sync reuses stored header context per item (prevents wrong-site replay after settings change)

--- a/apps/field-mobile/src/api/clinicalHub.ts
+++ b/apps/field-mobile/src/api/clinicalHub.ts
@@ -19,7 +19,7 @@ import {
 } from "../config/releaseMetadata";
 import {
   clampTimeoutMs,
-  classifyRetryable,
+  classifyEndpointRetryable,
   createRequestId,
   summarizeSafeExceptionCategory,
 } from "../utils/appHelpers";
@@ -115,7 +115,9 @@ export async function attemptSubmitEndpoint(options: {
       ok: response.ok,
       statusCode: response.status,
       body,
-      retryable: !response.ok ? classifyRetryable(response.status) : false,
+      retryable: !response.ok
+        ? classifyEndpointRetryable(options.endpoint, response.status)
+        : false,
     };
   } catch (error) {
     return {

--- a/apps/field-mobile/src/utils/appHelpers.ts
+++ b/apps/field-mobile/src/utils/appHelpers.ts
@@ -68,6 +68,21 @@ export function classifyRetryable(statusCode: number | null): boolean {
   return statusCode === 408 || statusCode === 425 || statusCode === 429;
 }
 
+export function classifyEndpointRetryable(
+  endpoint: PendingEndpoint,
+  statusCode: number | null,
+): boolean {
+  if (classifyRetryable(statusCode)) {
+    return true;
+  }
+
+  if (endpoint === "paired_measurements" || endpoint === "capture_packages") {
+    return statusCode === 401 || statusCode === 403;
+  }
+
+  return false;
+}
+
 const SAFE_PENDING_ERROR_CATEGORIES = new Set([
   "network_or_timeout",
   "auth_or_permission",

--- a/apps/field-mobile/tests/appHelpers.test.js
+++ b/apps/field-mobile/tests/appHelpers.test.js
@@ -53,6 +53,16 @@ test("classifyRetryable separates transient and non-retryable statuses", () => {
   assert.equal(helpers.classifyRetryable(422), false);
 });
 
+test("classifyEndpointRetryable keeps auth failures queued for clinical payloads", () => {
+  assert.equal(helpers.classifyEndpointRetryable("paired_measurements", 401), true);
+  assert.equal(helpers.classifyEndpointRetryable("capture_packages", 403), true);
+  assert.equal(helpers.classifyEndpointRetryable("paired_measurements", 429), true);
+  assert.equal(helpers.classifyEndpointRetryable("capture_packages", 503), true);
+  assert.equal(helpers.classifyEndpointRetryable("paired_measurements", 400), false);
+  assert.equal(helpers.classifyEndpointRetryable("capture_packages", 422), false);
+  assert.equal(helpers.classifyEndpointRetryable("capture_packages", 409), false);
+});
+
 test("summarizePendingError redacts raw response bodies into safe categories", () => {
   assert.equal(helpers.summarizePendingError(null), null);
   assert.equal(helpers.summarizePendingError("validation"), "validation");

--- a/apps/field-mobile/tests/clinicalHub.test.js
+++ b/apps/field-mobile/tests/clinicalHub.test.js
@@ -136,6 +136,36 @@ test("attemptSubmitEndpoint marks validation responses non-retryable", async () 
   }
 });
 
+test("attemptSubmitEndpoint keeps auth failures retryable for queued clinical payloads", async () => {
+  const originalFetch = global.fetch;
+  try {
+    global.fetch = async () => new Response("bad api key", { status: 401 });
+
+    const result = await clinicalHub.attemptSubmitEndpoint({
+      apiBaseUrl: "https://clinical.example.test",
+      requestTimeoutMs: "15000",
+      endpoint: "paired_measurements",
+      endpointPayload: buildPayload(),
+      headerContext: {
+        api_key: "expired-key",
+        actor_role: "operator",
+        site_id: "SITE-001",
+        operator_id: "OP-001",
+        request_id: "REQ-AUTH",
+      },
+    });
+
+    assert.deepEqual(result, {
+      ok: false,
+      statusCode: 401,
+      body: "bad api key",
+      retryable: true,
+    });
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
 test("attemptSubmitEndpoint keeps network failures retryable", async () => {
   const originalFetch = global.fetch;
   try {

--- a/apps/field-mobile/tests/pendingSyncQueue.test.js
+++ b/apps/field-mobile/tests/pendingSyncQueue.test.js
@@ -342,6 +342,34 @@ test("buildPendingSyncAttempt keeps retryable failures queued with attempt metad
   assert.equal(attempt.attemptedItem.last_error, "server_or_client_response");
 });
 
+test("buildPendingSyncAttempt keeps auth failures queued for credential repair", () => {
+  const attempt = pending.buildPendingSyncAttempt({
+    item: buildPendingSubmission({
+      endpoint: "capture_packages",
+      payload: buildCapturePackagePayload("SYNC-AUTH"),
+    }),
+    headerContext: {
+      api_key: "fixed-later",
+      actor_role: "operator",
+      site_id: "SITE-CURRENT",
+      operator_id: "OP-CURRENT",
+      request_id: "REQ-AUTH",
+    },
+    result: {
+      ok: false,
+      statusCode: 403,
+      body: "Forbidden: site scope mismatch for operator_id=OP-001",
+      retryable: true,
+    },
+    attemptedAtIso: "2026-06-04T01:02:03.000Z",
+  });
+
+  assert.equal(attempt.outcome, "retryable");
+  assert.equal(attempt.attemptedItem.attempt_count, 1);
+  assert.equal(attempt.attemptedItem.last_status_code, 403);
+  assert.equal(attempt.attemptedItem.last_error, "auth_or_permission");
+});
+
 test("buildPendingSyncAttempt drops non-retryable failed paired submissions", () => {
   const attempt = pending.buildPendingSyncAttempt({
     item: buildPendingSubmission(),

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -22,6 +22,8 @@ Implemented now:
 - Mobile API response, submit exception outcome, and runtime exception redaction gates for raw body, PHI-like subject/site/operator IDs, and secret-like error details.
 - Mobile release readiness gate for single-region data residency policy (`us`, no cross-region sync, region-matched Clinical Hub required).
 - Pending queue auto-sync on connectivity restore via NetInfo, with interval/AppState fallback.
+- Pending sync retry policy keeps network/transient and Clinical Hub auth/permission failures
+  queued for credential repair while dropping validation/conflict errors.
 - Deterministic mobile sync smoke covering queued paired+capture replay after network restore.
 - Mobile Build release notes artifact and manifest traceability for operator-facing build handoff.
 - Physical-device smoke evidence JSON template and validator for iOS+Android release handoff.
@@ -95,8 +97,8 @@ DoD:
 - Measurement marked `repeat/reject` when capture quality fails thresholds.
 
 ## B2: Sync and resilience
-1. Extend offline queue to support both `paired-measurements` and `capture-packages` as independent jobs.
-2. Add idempotent retry policies per endpoint and per status code.
+1. Extend offline queue to support both `paired-measurements` and `capture-packages` as independent jobs. Status: implemented.
+2. Add idempotent retry policies per endpoint and per status code. Status: implemented for network/transient retry, Clinical Hub auth/permission credential-repair retry, and validation/conflict non-retryable handling.
 3. Add background sync trigger on connectivity restore. Status: implemented for foreground app connectivity restore via NetInfo, plus interval and AppState fallback; OS background task scheduling remains out of scope until native/background execution policy is chosen.
 
 DoD:

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -89,7 +89,7 @@ Workflow generates artifact `mobile-release-manifest` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, EAS build/submit profile shape, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, Clinical Hub preflight guard, Clinical Hub runtime trace headers, in-app release identity evidence, pending sync connectivity restore, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, runtime timeline integrity metadata and quality gating, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, EAS build/submit profile shape, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, Expo Device identity defaults, Clinical Hub preflight guard, Clinical Hub runtime trace headers, in-app release identity evidence, pending sync connectivity restore, pending sync auth/permission retry policy, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, runtime timeline integrity metadata and quality gating, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
@@ -218,7 +218,7 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
    Repeat or mark the run failed if foreground/device load creates a timing gap warning.
 8. Submit produces `paired-measurements` and `capture-packages` records.
 9. Offline mode queues both endpoint jobs.
-10. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback.
+10. Returning online triggers successful auto-sync through connectivity restore, interval, or AppState fallback; if Clinical Hub returns `401/403`, fix API key/site/role credentials and retry without clearing queued payloads.
 11. Repository-level deterministic smoke confirms queued paired+capture replay drains after network restore.
 
 ## 6) Evidence to archive per build

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -1299,6 +1299,42 @@ def build_readiness_report(
         all(connectivity_restore_test_requirements.values()),
         f"requirements={connectivity_restore_test_requirements!r}",
     )
+    auth_retry_policy_requirements = {
+        "endpoint_policy_helper": "classifyEndpointRetryable" in app_helpers_source,
+        "clinical_hub_uses_endpoint_policy": (
+            "classifyEndpointRetryable(options.endpoint, response.status)"
+        )
+        in clinical_hub_source,
+        "auth_statuses_recoverable": (
+            "statusCode === 401 || statusCode === 403" in app_helpers_source
+        ),
+        "validation_statuses_still_non_retryable": (
+            "classifyEndpointRetryable(\"capture_packages\", 422)" in helper_tests_source
+        ),
+    }
+    _check(
+        checks,
+        "pending_sync_auth_retry_policy_sources",
+        all(auth_retry_policy_requirements.values()),
+        f"requirements={auth_retry_policy_requirements!r}",
+    )
+    auth_retry_policy_test_requirements = {
+        "helper_policy_test": "keeps auth failures queued for clinical payloads"
+        in helper_tests_source,
+        "clinical_hub_auth_retry_test": (
+            "keeps auth failures retryable for queued clinical payloads"
+        )
+        in clinical_hub_tests_source,
+        "queue_auth_retry_test": "keeps auth failures queued for credential repair"
+        in pending_sync_queue_tests_source,
+        "auth_error_redacted": "auth_or_permission" in pending_sync_queue_tests_source,
+    }
+    _check(
+        checks,
+        "pending_sync_auth_retry_policy_unit_tests_present",
+        all(auth_retry_policy_test_requirements.values()),
+        f"requirements={auth_retry_policy_test_requirements!r}",
+    )
     mobile_e2e_sync_smoke_requirements = {
         "batch_replay_helper": "runPendingSyncBatch" in pending_sync_queue_source,
         "submitter_injection": "submitEndpoint" in pending_sync_queue_source,

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -135,6 +135,8 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "mobile_store_rollout_handoff_validator_sources",
         "mobile_store_rollout_handoff_validator_unit_tests_present",
         "pending_submission_storage_unit_tests_present",
+        "pending_sync_auth_retry_policy_sources",
+        "pending_sync_auth_retry_policy_unit_tests_present",
         "pending_sync_connectivity_restore_sources",
         "pending_sync_connectivity_restore_unit_tests_present",
         "pending_sync_queue_unit_tests_present",


### PR DESCRIPTION
## Summary
- add endpoint-aware mobile retry policy for Clinical Hub submissions
- keep 401/403 paired and capture payload failures queued for credential repair
- add readiness checks and docs for auth/permission retry behavior while validation/conflict errors remain non-retryable

## Validation
- npm run typecheck && npm run test:unit
- python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-auth-retry.json
- .venv/bin/ruff check . && .venv/bin/pytest -q
- npm run validate:ci