### PR TITLE
Require raw media storage evidence in smoke logs

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -107,7 +107,7 @@ Notes:
   pass with `gap_warning=false` for release handoff.
 - Raw media is not stored by default (privacy-by-default behavior).
 - Temporary runtime audio files created by the native recorder are deleted after each stop/reset;
-  field handoff evidence should still include device-log/storage review on physical devices.
+  field handoff evidence must include `raw_media_temp_files_absent` device storage review.
 - Capture contract payloads include a derivatives-only `feature_manifest` with sample count,
   derived feature keys, and raw media storage/upload flags pinned to `false`.
 

--- a/docs/mobile-device-smoke-log-template-v0.1.json
+++ b/docs/mobile-device-smoke-log-template-v0.1.json
@@ -82,6 +82,11 @@
           "evidence": "Capture payload raw_media flags remain false and derivatives_only is true."
         },
         {
+          "id": "raw_media_temp_files_absent",
+          "status": "pass",
+          "evidence": "Post-capture storage review found no recorder temp audio files, raw video files, or exported media artifacts."
+        },
+        {
           "id": "device_logs_reviewed_no_phi",
           "status": "pass",
           "evidence": "Device logs reviewed; no subject/site/operator IDs, API keys, or raw response bodies observed."
@@ -155,6 +160,11 @@
           "id": "raw_media_disabled",
           "status": "pass",
           "evidence": "Capture payload raw_media flags remain false and derivatives_only is true."
+        },
+        {
+          "id": "raw_media_temp_files_absent",
+          "status": "pass",
+          "evidence": "Post-capture storage review found no recorder temp audio files, raw video files, or exported media artifacts."
         },
         {
           "id": "device_logs_reviewed_no_phi",

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -234,6 +234,9 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 7. Validated smoke summary JSON from `scripts/validate_mobile_device_smoke_log.py`.
    - The smoke log must include per-device `runtime_timeline` evidence copied from
      `capture_payload.analysis.runtime_timeline`, with `gap_warning=false`.
+   - The smoke log must include `raw_media_temp_files_absent` evidence after device storage
+     review, confirming no recorder temp audio files, raw video files, or exported media
+     artifacts remain after stop/reset.
 8. Clinical Hub sample export (paired + capture package rows).
    - For `capture-packages`, archive `capture_payload.feature_manifest` and confirm `derivatives_only=true`, `raw_media.store_raw_video=false`, `raw_media.store_raw_audio=false`, `raw_media.upload_raw_video=false`, and `raw_media.upload_raw_audio=false`.
    - Archive `capture_payload.analysis.runtime_timeline` and investigate runs with

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -1430,6 +1430,8 @@ def build_readiness_report(
         "ios_platform": '"platform": "ios"' in mobile_device_smoke_template_source,
         "android_platform": '"platform": "android"' in mobile_device_smoke_template_source,
         "restore_sync_check": "connectivity_restore_sync" in mobile_device_smoke_template_source,
+        "raw_media_temp_cleanup_check": "raw_media_temp_files_absent"
+        in mobile_device_smoke_template_source,
         "log_phi_review_check": "device_logs_reviewed_no_phi"
         in mobile_device_smoke_template_source,
         "runtime_timeline_evidence": "runtime_timeline"
@@ -1452,6 +1454,8 @@ def build_readiness_report(
         in mobile_device_smoke_validator_source,
         "no_phi_log_review": "device_logs_reviewed_no_phi"
         in mobile_device_smoke_validator_source,
+        "raw_media_temp_cleanup_required": "raw_media_temp_files_absent"
+        in mobile_device_smoke_validator_source,
         "runtime_timeline_validation": "_validate_runtime_timeline"
         in mobile_device_smoke_validator_source
         and "runtime_timeline_integrity" in mobile_device_smoke_validator_source
@@ -1469,6 +1473,8 @@ def build_readiness_report(
         "ios_android_matrix_test": "requires_ios_and_android"
         in mobile_device_smoke_validator_tests_source,
         "required_checks_test": "requires_passing_required_checks"
+        in mobile_device_smoke_validator_tests_source,
+        "raw_media_temp_cleanup_test": "requires_raw_media_temp_cleanup_check"
         in mobile_device_smoke_validator_tests_source,
         "runtime_timeline_required_test": "requires_runtime_timeline"
         in mobile_device_smoke_validator_tests_source,

--- a/scripts/validate_mobile_device_smoke_log.py
+++ b/scripts/validate_mobile_device_smoke_log.py
@@ -22,6 +22,7 @@ REQUIRED_SMOKE_CHECK_IDS = (
     "offline_queue_retains_jobs",
     "connectivity_restore_sync",
     "raw_media_disabled",
+    "raw_media_temp_files_absent",
     "device_logs_reviewed_no_phi",
 )
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")

--- a/tests/test_mobile_device_smoke_log.py
+++ b/tests/test_mobile_device_smoke_log.py
@@ -46,6 +46,7 @@ def test_mobile_device_smoke_log_template_validates(tmp_path: Path) -> None:
     assert summary["platforms_seen"] == ["android", "ios"]
     assert "connectivity_restore_sync" in summary["required_check_ids"]
     assert "device_logs_reviewed_no_phi" in summary["required_check_ids"]
+    assert "raw_media_temp_files_absent" in summary["required_check_ids"]
     assert "runtime_timeline_integrity" in summary["required_check_ids"]
     assert json.loads((tmp_path / "summary.json").read_text(encoding="utf-8")) == summary
 
@@ -77,6 +78,26 @@ def test_mobile_device_smoke_log_requires_passing_required_checks(tmp_path: Path
     assert result.returncode == 1
     assert summary["status"] == "fail"
     assert "devices[0].checks[app_launch].status must be 'pass'" in summary["errors"]
+
+
+def test_mobile_device_smoke_log_requires_raw_media_temp_cleanup_check(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload = copy.deepcopy(payload)
+    payload["devices"][0]["checks"] = [
+        check
+        for check in payload["devices"][0]["checks"]
+        if check["id"] != "raw_media_temp_files_absent"
+    ]
+
+    result = _run_validator(tmp_path, payload, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert (
+        "devices[0].checks missing required check 'raw_media_temp_files_absent'"
+        in summary["errors"]
+    )
 
 
 def test_mobile_device_smoke_log_requires_runtime_timeline(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- require per-device raw_media_temp_files_absent evidence in mobile smoke logs
- update smoke-log template, validator, readiness static checks, and release docs
- add validator regression test for missing raw media temp cleanup evidence

## Validation
- python3 scripts/validate_mobile_device_smoke_log.py docs/mobile-device-smoke-log-template-v0.1.json --output /tmp/mobile-device-smoke-summary-raw-media-storage.json
- python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-smoke-storage.json
- .venv/bin/ruff check . && .venv/bin/pytest -q