### PR TITLE
Require SOP evidence in mobile smoke log

### DIFF
--- a/docs/mobile-device-smoke-log-template-v0.1.json
+++ b/docs/mobile-device-smoke-log-template-v0.1.json
@@ -51,6 +51,11 @@
           "evidence": "Test API returns auth context for site/operator."
         },
         {
+          "id": "operator_sop_checklist_gate",
+          "status": "pass",
+          "evidence": "Start Capture is blocked until the operator SOP checklist is fully confirmed; reference ready, phone stable, water-impact SOP, and metadata/privacy items were checked before capture."
+        },
+        {
           "id": "capture_start_stop",
           "status": "pass",
           "evidence": "Start Capture and Stop Capture complete without runtime exception."
@@ -143,6 +148,11 @@
           "id": "api_connection_check",
           "status": "pass",
           "evidence": "Test API returns auth context for site/operator."
+        },
+        {
+          "id": "operator_sop_checklist_gate",
+          "status": "pass",
+          "evidence": "Start Capture is blocked until the operator SOP checklist is fully confirmed; reference ready, phone stable, water-impact SOP, and metadata/privacy items were checked before capture."
         },
         {
           "id": "capture_start_stop",

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -45,7 +45,8 @@ Implemented now:
 - Clinical Hub capture package records include canonical `capture_payload_sha256` in
   detail/list/CSV exports, with migration backfill for existing SQLite rows.
 - Mobile Build release notes artifact and manifest traceability for operator-facing build handoff.
-- Physical-device smoke evidence JSON template and validator for iOS+Android release handoff.
+- Physical-device smoke evidence JSON template and validator for iOS+Android release handoff,
+  including per-device operator SOP checklist gate evidence.
 - Physical-device smoke evidence requires per-device runtime timeline integrity metadata
   with `gap_warning=false`.
 - Store rollout handoff JSON template, validator, and Mobile Build artifact for TestFlight/Play Internal traceability.
@@ -108,7 +109,7 @@ Not yet implemented:
 - Deterministic replay tests cover capture contract generation and queued paired+capture sync; physical-device evidence now has a validator/template but still needs real-device execution.
 - Device-matrix smoke evidence requires at least one iPhone and one Android run in
   `mobile_device_smoke_log_v0.1`, including runtime timeline evidence from
-  `capture_payload.analysis.runtime_timeline`.
+  `capture_payload.analysis.runtime_timeline` and operator SOP checklist gate evidence.
 
 ## 3) Backlog (implementation order)
 

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -271,6 +271,8 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
    - The smoke log must include `raw_media_temp_files_absent` evidence after device storage
      review, confirming no recorder temp audio files, raw video files, or exported media
      artifacts remain after stop/reset.
+   - The smoke log must include per-device `operator_sop_checklist_gate` evidence proving
+     `Start Capture` stayed blocked until all operator SOP confirmations were checked.
 9. Clinical Hub sample export (paired + capture package rows).
    - For `capture-packages`, archive `capture_payload.feature_manifest` and confirm `derivatives_only=true`, `raw_media.store_raw_video=false`, `raw_media.store_raw_audio=false`, `raw_media.upload_raw_video=false`, and `raw_media.upload_raw_audio=false`.
    - Archive `capture_payload_sha256` from Clinical Hub detail/list/CSV exports and verify

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -1932,6 +1932,8 @@ def build_readiness_report(
         "ios_platform": '"platform": "ios"' in mobile_device_smoke_template_source,
         "android_platform": '"platform": "android"' in mobile_device_smoke_template_source,
         "restore_sync_check": "connectivity_restore_sync" in mobile_device_smoke_template_source,
+        "operator_sop_checklist_gate": "operator_sop_checklist_gate"
+        in mobile_device_smoke_template_source,
         "raw_media_temp_cleanup_check": "raw_media_temp_files_absent"
         in mobile_device_smoke_template_source,
         "log_phi_review_check": "device_logs_reviewed_no_phi"
@@ -1952,6 +1954,8 @@ def build_readiness_report(
         "validator_file": mobile_device_smoke_validator_path.is_file(),
         "required_platforms": "REQUIRED_PLATFORMS" in mobile_device_smoke_validator_source,
         "required_checks": "REQUIRED_SMOKE_CHECK_IDS" in mobile_device_smoke_validator_source,
+        "operator_sop_checklist_gate": "operator_sop_checklist_gate"
+        in mobile_device_smoke_validator_source,
         "sha256_traceability": "mobile_release_manifest_sha256"
         in mobile_device_smoke_validator_source,
         "no_phi_log_review": "device_logs_reviewed_no_phi"
@@ -1977,6 +1981,8 @@ def build_readiness_report(
         "required_checks_test": "requires_passing_required_checks"
         in mobile_device_smoke_validator_tests_source,
         "raw_media_temp_cleanup_test": "requires_raw_media_temp_cleanup_check"
+        in mobile_device_smoke_validator_tests_source,
+        "operator_sop_checklist_gate_test": "requires_operator_sop_checklist_gate"
         in mobile_device_smoke_validator_tests_source,
         "runtime_timeline_required_test": "requires_runtime_timeline"
         in mobile_device_smoke_validator_tests_source,

--- a/scripts/validate_mobile_device_smoke_log.py
+++ b/scripts/validate_mobile_device_smoke_log.py
@@ -14,6 +14,7 @@ REQUIRED_PLATFORMS = ("ios", "android")
 REQUIRED_SMOKE_CHECK_IDS = (
     "app_launch",
     "api_connection_check",
+    "operator_sop_checklist_gate",
     "capture_start_stop",
     "contract_payload_ready",
     "runtime_timeline_integrity",

--- a/tests/test_mobile_device_smoke_log.py
+++ b/tests/test_mobile_device_smoke_log.py
@@ -46,6 +46,7 @@ def test_mobile_device_smoke_log_template_validates(tmp_path: Path) -> None:
     assert summary["platforms_seen"] == ["android", "ios"]
     assert "connectivity_restore_sync" in summary["required_check_ids"]
     assert "device_logs_reviewed_no_phi" in summary["required_check_ids"]
+    assert "operator_sop_checklist_gate" in summary["required_check_ids"]
     assert "raw_media_temp_files_absent" in summary["required_check_ids"]
     assert "runtime_timeline_integrity" in summary["required_check_ids"]
     assert "runtime_alignment_integrity" in summary["required_check_ids"]
@@ -97,6 +98,28 @@ def test_mobile_device_smoke_log_requires_raw_media_temp_cleanup_check(tmp_path:
     assert summary["status"] == "fail"
     assert (
         "devices[0].checks missing required check 'raw_media_temp_files_absent'"
+        in summary["errors"]
+    )
+
+
+def test_mobile_device_smoke_log_requires_operator_sop_checklist_gate(
+    tmp_path: Path,
+) -> None:
+    payload = _valid_payload()
+    payload = copy.deepcopy(payload)
+    payload["devices"][0]["checks"] = [
+        check
+        for check in payload["devices"][0]["checks"]
+        if check["id"] != "operator_sop_checklist_gate"
+    ]
+
+    result = _run_validator(tmp_path, payload, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert (
+        "devices[0].checks missing required check 'operator_sop_checklist_gate'"
         in summary["errors"]
     )
 


### PR DESCRIPTION
## Summary
- require `operator_sop_checklist_gate` in the physical-device smoke log template and validator
- make readiness assert the smoke template, validator, and validator tests all include SOP checklist gate coverage
- document that archived smoke evidence must prove `Start Capture` stayed blocked until SOP confirmations were checked

## Validation
- `.venv/bin/ruff check scripts/validate_mobile_device_smoke_log.py scripts/check_mobile_release_readiness.py tests/test_mobile_device_smoke_log.py tests/test_mobile_release_readiness_script.py`
- `.venv/bin/pytest -q tests/test_mobile_device_smoke_log.py tests/test_mobile_release_readiness_script.py`
- `python3 scripts/validate_mobile_device_smoke_log.py docs/mobile-device-smoke-log-template-v0.1.json --output /tmp/mobile-device-smoke-summary-ops001-sop-evidence.json`
- `python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-ops001-smoke-sop-evidence.json`
- `.venv/bin/pytest -q`
- `npm run validate:ci`
- `git diff --check`
