### PR TITLE
Publish mobile smoke template validation artifact

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -282,6 +282,43 @@ jobs:
               handle.write("\n".join(lines) + "\n")
           PY
 
+      - name: Build smoke template validation artifact
+        shell: bash
+        run: |
+          set +e
+          python3 ../../scripts/validate_mobile_device_smoke_log.py \
+            ../../docs/mobile-device-smoke-log-template-v0.1.json \
+            --output /tmp/mobile-device-smoke-template-summary.json
+          smoke_template_exit_code=$?
+          set -e
+          echo "$smoke_template_exit_code" > /tmp/mobile-device-smoke-template-exit-code
+
+      - name: Publish smoke template validation summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads(
+              Path("/tmp/mobile-device-smoke-template-summary.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          lines = [
+              "## Mobile Device Smoke Template Validation",
+              f"- Status: `{payload.get('status')}`",
+              f"- Device count: `{payload.get('device_count')}`",
+              f"- Platforms: `{', '.join(payload.get('platforms_seen', [])) or 'none'}`",
+              f"- Required check IDs: `{', '.join(payload.get('required_check_ids', []))}`",
+              f"- Errors: `{', '.join(payload.get('errors', [])) if payload.get('errors') else 'none'}`",
+          ]
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as handle:
+              handle.write("\n".join(lines) + "\n")
+          PY
+
       - name: Build release notes artifact
         env:
           WORKFLOW_BUILD_PROFILE: ${{ github.event.inputs.build_profile || 'preview' }}
@@ -324,6 +361,7 @@ jobs:
               "- Download `mobile-release-readiness`.",
               "- Download `mobile-release-bundle-verification`.",
               "- Download `mobile-dependency-review`.",
+              "- Download `mobile-device-smoke-template-validation` before filling real-device smoke evidence.",
               "- Download `mobile-store-rollout-handoff` and fill in TestFlight/Play evidence after external account setup.",
               "- Archive iOS/Android EAS build links when authenticated EAS build runs.",
               "- Archive physical-device smoke log with device model and OS version.",
@@ -459,6 +497,27 @@ jobs:
           path: |
             /tmp/mobile-store-rollout-handoff.json
             /tmp/mobile-store-rollout-handoff-summary.json
+
+      - name: Upload smoke template validation
+        uses: actions/upload-artifact@v7
+        with:
+          name: mobile-device-smoke-template-validation
+          path: |
+            docs/mobile-device-smoke-log-template-v0.1.json
+            /tmp/mobile-device-smoke-template-summary.json
+            /tmp/mobile-device-smoke-template-exit-code
+          if-no-files-found: error
+
+      - name: Fail on smoke template validation errors
+        shell: bash
+        run: |
+          set -euo pipefail
+          smoke_template_exit_code="$(cat /tmp/mobile-device-smoke-template-exit-code 2>/dev/null || echo 1)"
+          if [[ "$smoke_template_exit_code" != "0" ]]; then
+            echo "Mobile device smoke template validation failed with exit code $smoke_template_exit_code."
+            echo "See the mobile-device-smoke-template-validation artifact for template summary details."
+            exit "$smoke_template_exit_code"
+          fi
 
       - name: Fail on local release readiness errors
         shell: bash

--- a/docs/mobile-install-and-field-test-runbook-v0.1.md
+++ b/docs/mobile-install-and-field-test-runbook-v0.1.md
@@ -118,8 +118,9 @@ Per subject/attempt:
 8. If network failed, ensure queue item exists and run `Sync Queue` later.
 9. For retry/audit troubleshooting, match the pending item `request_id` to Clinical Hub request logs.
 
-For release handoff, copy `docs/mobile-device-smoke-log-template-v0.1.json`, fill one
-iPhone and one Android run, then validate it:
+For release handoff, download the Mobile Build `mobile-device-smoke-template-validation`
+artifact, copy `docs/mobile-device-smoke-log-template-v0.1.json`, fill one iPhone and
+one Android run, then validate it:
 
 ```bash
 python3 scripts/validate_mobile_device_smoke_log.py \
@@ -128,8 +129,8 @@ python3 scripts/validate_mobile_device_smoke_log.py \
 ```
 
 The validator requires all mandatory smoke checks to pass on both platforms, including
-offline queue retention, connectivity-restore sync, raw media disabled, and device-log
-review for PHI/secret leakage.
+operator SOP checklist gating, offline queue retention, connectivity-restore sync, raw
+media disabled, and device-log review for PHI/secret leakage.
 
 ## 6. Daily Export For Analysis
 

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -47,6 +47,8 @@ Implemented now:
 - Mobile Build release notes artifact and manifest traceability for operator-facing build handoff.
 - Physical-device smoke evidence JSON template and validator for iOS+Android release handoff,
   including per-device operator SOP checklist gate evidence.
+- Mobile Build publishes a smoke-template validation artifact with the current template and
+  validator summary before real-device smoke evidence is filled in.
 - Physical-device smoke evidence requires per-device runtime timeline integrity metadata
   with `gap_warning=false`.
 - Store rollout handoff JSON template, validator, and Mobile Build artifact for TestFlight/Play Internal traceability.

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -105,7 +105,7 @@ Workflow also generates artifact `mobile-dependency-review` containing:
 
 Workflow also generates artifact `mobile-release-readiness` containing:
 - git SHA/ref/run-id/workflow traceability,
-- local mobile readiness checks (`app.json`, `eas.json`, EAS build/submit profile shape, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, runtime release guard, Expo Device identity defaults, Clinical Hub preflight guard, Clinical Hub RBAC/site/operator scope, Clinical Hub runtime trace headers, Clinical Hub nightly comparison/gate snapshot wiring, mobile dependency review artifact wiring, pilot gate report mobile build/schema traceability, in-app release identity evidence, in-app claims notice, operator SOP checklist gate, runtime quality submission guard, capture mode submission guard, paired submission contract guard, pending sync connectivity restore, pending sync auth/permission retry policy, deterministic mobile E2E sync smoke, physical-device smoke log template/validator, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, runtime timeline integrity metadata and quality gating, runtime raw-media temp-file cleanup, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
+- local mobile readiness checks (`app.json`, `eas.json`, EAS build/submit profile shape, runtime release metadata/config/defaults, endpoint set/data residency/debug gates, runtime release guard, Expo Device identity defaults, Clinical Hub preflight guard, Clinical Hub RBAC/site/operator scope, Clinical Hub runtime trace headers, Clinical Hub nightly comparison/gate snapshot wiring, mobile dependency review artifact wiring, pilot gate report mobile build/schema traceability, in-app release identity evidence, in-app claims notice, operator SOP checklist gate, runtime quality submission guard, capture mode submission guard, paired submission contract guard, pending sync connectivity restore, pending sync auth/permission retry policy, deterministic mobile E2E sync smoke, physical-device smoke log template/validator/CI artifact, store rollout handoff template/validator, release bundle verifier, runtime motion quality gates, runtime timeline integrity metadata and quality gating, runtime raw-media temp-file cleanup, derivatives-only feature/media manifest gates, package scripts, lockfile, pinned tooling, API response + submit exception + runtime exception PHI redaction, unit-test coverage wiring),
 - external credential state without secret values,
 - authenticated EAS readiness status and specific EAS blockers,
 - live Clinical Hub API readiness status (`present`, `missing`, or `invalid`),
@@ -117,7 +117,14 @@ Workflow also generates artifact `mobile-release-notes` containing:
 - selected build profile/platform,
 - selected store-submit request/platform,
 - operator-facing release notes from workflow input or an explicit placeholder when not supplied,
-- required evidence reminders for manifest, readiness, EAS build links, and physical-device smoke logs.
+- required evidence reminders for manifest, readiness, smoke-template validation, EAS build links, and physical-device smoke logs.
+
+Workflow also generates artifact `mobile-device-smoke-template-validation` containing:
+- the repository smoke log template used for the run,
+- validator summary JSON proving the template currently satisfies
+  `mobile_device_smoke_log_v0.1` before clinic operators replace placeholder values with
+  real iPhone/Android smoke evidence,
+- validator exit code for diagnosis if the template contract breaks.
 
 Workflow also generates artifact `mobile-store-rollout-handoff` containing:
 - per-run git SHA, app version, build profile/channel, and SHA-256 digests for `mobile-release-manifest`, `mobile-release-readiness`, and `mobile-release-notes`,
@@ -260,9 +267,10 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 3. Mobile release bundle verification JSON.
 4. Mobile store rollout handoff JSON and validation summary.
 5. Mobile dependency review JSON.
-6. Build links (iOS + Android).
-7. Smoke test log with device model and OS version.
-8. Validated smoke summary JSON from `scripts/validate_mobile_device_smoke_log.py`.
+6. Mobile device smoke template validation artifact.
+7. Build links (iOS + Android).
+8. Smoke test log with device model and OS version.
+9. Validated real-device smoke summary JSON from `scripts/validate_mobile_device_smoke_log.py`.
    - The smoke log must include per-device `runtime_timeline` evidence copied from
      `capture_payload.analysis.runtime_timeline`, with `gap_warning=false`.
    - The smoke log must include per-device `runtime_alignment` evidence copied from
@@ -273,7 +281,7 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
      artifacts remain after stop/reset.
    - The smoke log must include per-device `operator_sop_checklist_gate` evidence proving
      `Start Capture` stayed blocked until all operator SOP confirmations were checked.
-9. Clinical Hub sample export (paired + capture package rows).
+10. Clinical Hub sample export (paired + capture package rows).
    - For `capture-packages`, archive `capture_payload.feature_manifest` and confirm `derivatives_only=true`, `raw_media.store_raw_video=false`, `raw_media.store_raw_audio=false`, `raw_media.upload_raw_video=false`, and `raw_media.upload_raw_audio=false`.
    - Archive `capture_payload_sha256` from Clinical Hub detail/list/CSV exports and verify
      it stays stable across idempotent replay.
@@ -281,4 +289,4 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
      `gap_warning=true` or unexpectedly large `max_sample_gap_s`.
    - Archive `capture_payload.analysis.runtime_alignment` and reject runs with
      `drift_warning=true` or `max_stream_drift_ms > 50`.
-10. Go/No-Go note for pilot usage.
+11. Go/No-Go note for pilot usage.

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -1995,6 +1995,29 @@ def build_readiness_report(
         all(mobile_device_smoke_validator_test_requirements.values()),
         f"requirements={mobile_device_smoke_validator_test_requirements!r}",
     )
+    mobile_device_smoke_ci_requirements = {
+        "workflow_file": mobile_build_workflow_path.is_file(),
+        "trigger_template_path": "docs/mobile-device-smoke-log-template-v0.1.json"
+        in mobile_build_workflow_source,
+        "trigger_validator_path": "scripts/validate_mobile_device_smoke_log.py"
+        in mobile_build_workflow_source,
+        "build_step": "Build smoke template validation artifact"
+        in mobile_build_workflow_source,
+        "summary_step": "Publish smoke template validation summary"
+        in mobile_build_workflow_source,
+        "summary_json": "mobile-device-smoke-template-summary.json"
+        in mobile_build_workflow_source,
+        "upload_artifact": "mobile-device-smoke-template-validation"
+        in mobile_build_workflow_source,
+        "failure_gate": "Fail on smoke template validation errors"
+        in mobile_build_workflow_source,
+    }
+    _check(
+        checks,
+        "mobile_device_smoke_log_ci_artifact",
+        all(mobile_device_smoke_ci_requirements.values()),
+        f"requirements={mobile_device_smoke_ci_requirements!r}",
+    )
     mobile_store_rollout_template_requirements = {
         "template_file": mobile_store_rollout_template_path.is_file(),
         "schema_version": "mobile_store_rollout_handoff_v0.1"

--- a/tests/test_mobile_build_workflow.py
+++ b/tests/test_mobile_build_workflow.py
@@ -17,10 +17,13 @@ def test_mobile_build_workflow_runs_for_release_script_changes() -> None:
     triggers = _workflow_triggers()
     required_paths = {
         "apps/field-mobile/**",
+        "docs/mobile-device-smoke-log-template-v0.1.json",
         "scripts/build_mobile_dependency_review.py",
         "scripts/build_mobile_release_manifest.py",
         "scripts/check_mobile_release_readiness.py",
+        "scripts/validate_mobile_device_smoke_log.py",
         "tests/test_mobile_dependency_review.py",
+        "tests/test_mobile_device_smoke_log.py",
         ".github/workflows/mobile-build.yml",
     }
 
@@ -63,6 +66,30 @@ def test_mobile_build_workflow_uploads_dependency_review_before_validation() -> 
     assert "mobile-dependency-review artifact" in steps[fail_index]["run"]
 
 
+def test_mobile_build_workflow_uploads_smoke_template_validation_before_failure() -> None:
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = payload["jobs"]["preflight"]["steps"]
+    step_names = [step.get("name") for step in steps]
+
+    build_index = step_names.index("Build smoke template validation artifact")
+    summary_index = step_names.index("Publish smoke template validation summary")
+    notes_index = step_names.index("Build release notes artifact")
+    upload_index = step_names.index("Upload smoke template validation")
+    smoke_fail_index = step_names.index("Fail on smoke template validation errors")
+    readiness_fail_index = step_names.index("Fail on local release readiness errors")
+    upload_step = steps[upload_index]
+
+    assert build_index < summary_index < notes_index < upload_index
+    assert upload_index < smoke_fail_index < readiness_fail_index
+    assert "validate_mobile_device_smoke_log.py" in steps[build_index]["run"]
+    assert "mobile-device-smoke-template-summary.json" in steps[build_index]["run"]
+    assert "mobile-device-smoke-template-summary.json" in steps[summary_index]["run"]
+    assert upload_step["with"]["name"] == "mobile-device-smoke-template-validation"
+    assert "docs/mobile-device-smoke-log-template-v0.1.json" in upload_step["with"]["path"]
+    assert "/tmp/mobile-device-smoke-template-summary.json" in upload_step["with"]["path"]
+    assert "mobile-device-smoke-template-validation artifact" in steps[smoke_fail_index]["run"]
+
+
 def test_mobile_build_workflow_embeds_readiness_summary_in_release_manifest() -> None:
     payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     steps = payload["jobs"]["preflight"]["steps"]
@@ -86,6 +113,7 @@ def test_mobile_build_workflow_uploads_release_notes_artifact() -> None:
     assert "WORKFLOW_RELEASE_NOTES" in steps[notes_index]["env"]
     assert notes_upload_step["with"]["name"] == "mobile-release-notes"
     assert notes_upload_step["with"]["path"] == "/tmp/mobile-release-notes.md"
+    assert "mobile-device-smoke-template-validation" in steps[notes_index]["run"]
 
 
 def test_mobile_build_workflow_summary_reports_invalid_external_items() -> None:

--- a/tests/test_mobile_release_readiness_script.py
+++ b/tests/test_mobile_release_readiness_script.py
@@ -146,6 +146,7 @@ def test_mobile_release_readiness_reports_external_blockers(tmp_path: Path) -> N
         "mobile_device_smoke_log_template_present",
         "mobile_device_smoke_log_validator_sources",
         "mobile_device_smoke_log_validator_unit_tests_present",
+        "mobile_device_smoke_log_ci_artifact",
         "mobile_dependency_review_sources",
         "mobile_dependency_review_ci_artifact",
         "mobile_dependency_review_unit_tests_present",


### PR DESCRIPTION
## Summary
- add a Mobile Build artifact that validates and uploads the current physical-device smoke log template plus summary JSON
- add a readiness guard proving Mobile Build wires the smoke-template validation artifact, upload, and failure gate
- update workflow/readiness tests and operator/release docs to include the new artifact in the evidence chain

## Validation
- `.venv/bin/ruff check scripts/check_mobile_release_readiness.py tests/test_mobile_build_workflow.py tests/test_mobile_release_readiness_script.py`
- `.venv/bin/pytest -q tests/test_mobile_build_workflow.py tests/test_mobile_release_readiness_script.py`
- `python3 scripts/validate_mobile_device_smoke_log.py docs/mobile-device-smoke-log-template-v0.1.json --output /tmp/mobile-device-smoke-template-summary-local.json`
- `python3 scripts/check_mobile_release_readiness.py --app-json apps/field-mobile/app.json --eas-json apps/field-mobile/eas.json --package-json apps/field-mobile/package.json --package-lock apps/field-mobile/package-lock.json --output /tmp/mobile-readiness-smoke-template-artifact.json`
- `.venv/bin/pytest -q`
- `npm run validate:ci`
- `git diff --check`
