### PR TITLE
Trace smoke template digest in release bundle

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -441,6 +441,9 @@ jobs:
                   "mobile_release_notes_sha256": sha256_file(
                       Path("/tmp/mobile-release-notes.md")
                   ),
+                  "mobile_device_smoke_template_summary_sha256": sha256_file(
+                      Path("/tmp/mobile-device-smoke-template-summary.json")
+                  ),
               }
           )
           Path("/tmp/mobile-store-rollout-handoff.json").write_text(
@@ -460,6 +463,7 @@ jobs:
             --manifest-json /tmp/mobile-release-manifest.json \
             --readiness-json /tmp/mobile-release-readiness.json \
             --release-notes /tmp/mobile-release-notes.md \
+            --smoke-template-summary-json /tmp/mobile-device-smoke-template-summary.json \
             --store-rollout-handoff-json /tmp/mobile-store-rollout-handoff.json \
             --store-rollout-summary-json /tmp/mobile-store-rollout-handoff-summary.json \
             --expect-git-sha "$GITHUB_SHA" \

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -48,7 +48,8 @@ Implemented now:
 - Physical-device smoke evidence JSON template and validator for iOS+Android release handoff,
   including per-device operator SOP checklist gate evidence.
 - Mobile Build publishes a smoke-template validation artifact with the current template and
-  validator summary before real-device smoke evidence is filled in.
+  validator summary before real-device smoke evidence is filled in, and store rollout
+  handoff/bundle verification trace its SHA-256 digest.
 - Physical-device smoke evidence requires per-device runtime timeline integrity metadata
   with `gap_warning=false`.
 - Store rollout handoff JSON template, validator, and Mobile Build artifact for TestFlight/Play Internal traceability.

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -127,16 +127,16 @@ Workflow also generates artifact `mobile-device-smoke-template-validation` conta
 - validator exit code for diagnosis if the template contract breaks.
 
 Workflow also generates artifact `mobile-store-rollout-handoff` containing:
-- per-run git SHA, app version, build profile/channel, and SHA-256 digests for `mobile-release-manifest`, `mobile-release-readiness`, and `mobile-release-notes`,
+- per-run git SHA, app version, build profile/channel, and SHA-256 digests for `mobile-release-manifest`, `mobile-release-readiness`, `mobile-release-notes`, and `mobile-device-smoke-template-validation` summary,
 - iOS TestFlight internal handoff checklist and current external blockers,
 - Android Play Internal Testing handoff checklist and current external blockers,
 - validation summary from `scripts/validate_mobile_store_rollout_handoff.py`.
 
 Workflow also generates artifact `mobile-release-bundle-verification` containing:
 - git/run traceability shared by manifest, readiness, and store rollout handoff,
-- SHA-256 fingerprints for manifest, readiness, release notes, store rollout handoff, and store rollout summary,
+- SHA-256 fingerprints for manifest, readiness, release notes, smoke-template validation summary, store rollout handoff, and store rollout summary,
 - consistency checks proving the manifest readiness summary matches raw readiness JSON,
-- digest checks proving the store rollout handoff references the exact manifest/readiness/notes files from the same run.
+- digest checks proving the store rollout handoff references the exact manifest/readiness/notes/smoke-template summary files from the same run.
 
 Manifest script:
 
@@ -186,6 +186,7 @@ python3 scripts/verify_mobile_release_bundle.py \
   --manifest-json /tmp/mobile-release-manifest.json \
   --readiness-json /tmp/mobile-release-readiness.json \
   --release-notes /tmp/mobile-release-notes.md \
+  --smoke-template-summary-json /tmp/mobile-device-smoke-template-summary.json \
   --store-rollout-handoff-json /tmp/mobile-store-rollout-handoff.json \
   --store-rollout-summary-json /tmp/mobile-store-rollout-summary.json \
   --output /tmp/mobile-release-bundle-verification.json

--- a/docs/mobile-store-rollout-handoff-template-v0.1.json
+++ b/docs/mobile-store-rollout-handoff-template-v0.1.json
@@ -9,7 +9,8 @@
     "build_channel": "preview",
     "mobile_release_manifest_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
     "mobile_release_readiness_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-    "mobile_release_notes_sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    "mobile_release_notes_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "mobile_device_smoke_template_summary_sha256": "0000000000000000000000000000000000000000000000000000000000000000"
   },
   "handoff_checks": [
     {
@@ -26,6 +27,11 @@
       "id": "mobile_release_notes_archived",
       "status": "pass",
       "evidence": "Mobile release notes artifact is archived for this run."
+    },
+    {
+      "id": "mobile_device_smoke_template_validation_archived",
+      "status": "pass",
+      "evidence": "Mobile device smoke template validation artifact is archived for this run."
     },
     {
       "id": "device_smoke_evidence_linked",

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -2030,6 +2030,8 @@ def build_readiness_report(
         in mobile_store_rollout_template_source,
         "release_manifest_traceability": "mobile_release_manifest_sha256"
         in mobile_store_rollout_template_source,
+        "smoke_template_traceability": "mobile_device_smoke_template_summary_sha256"
+        in mobile_store_rollout_template_source,
     }
     _check(
         checks,
@@ -2044,6 +2046,12 @@ def build_readiness_report(
         "play_internal_testing": "play_internal_testing" in mobile_store_rollout_validator_source,
         "sha256_traceability": "mobile_release_manifest_sha256"
         in mobile_store_rollout_validator_source,
+        "smoke_template_sha": "mobile_device_smoke_template_summary_sha256"
+        in mobile_store_rollout_validator_source,
+        "smoke_template_handoff_check": (
+            "mobile_device_smoke_template_validation_archived"
+            in mobile_store_rollout_validator_source
+        ),
         "blocked_external_support": "BLOCKED_STATUS" in mobile_store_rollout_validator_source,
     }
     _check(
@@ -2061,6 +2069,8 @@ def build_readiness_report(
         in mobile_store_rollout_validator_tests_source,
         "release_sha_test": "rejects_invalid_release_sha"
         in mobile_store_rollout_validator_tests_source,
+        "smoke_template_sha_test": "rejects_invalid_smoke_template_sha"
+        in mobile_store_rollout_validator_tests_source,
     }
     _check(
         checks,
@@ -2075,6 +2085,12 @@ def build_readiness_report(
         "readiness_count_validation": "local_check_counts"
         in mobile_release_bundle_verifier_source,
         "store_handoff_digest_validation": "mobile_release_manifest_sha256"
+        in mobile_release_bundle_verifier_source,
+        "smoke_template_summary_digest_validation": (
+            "mobile_device_smoke_template_summary_sha256"
+            in mobile_release_bundle_verifier_source
+        ),
+        "smoke_template_summary_input": "smoke_template_summary_json"
         in mobile_release_bundle_verifier_source,
         "expected_run_validation": "expect_run_id" in mobile_release_bundle_verifier_source,
     }
@@ -2093,6 +2109,14 @@ def build_readiness_report(
         in mobile_release_bundle_verifier_tests_source,
         "expected_git_sha_mismatch_test": "rejects_expected_git_sha_mismatch"
         in mobile_release_bundle_verifier_tests_source,
+        "smoke_template_digest_mismatch_test": (
+            "rejects_smoke_template_digest_mismatch"
+            in mobile_release_bundle_verifier_tests_source
+        ),
+        "failed_smoke_template_summary_test": (
+            "rejects_failed_smoke_template_summary"
+            in mobile_release_bundle_verifier_tests_source
+        ),
     }
     _check(
         checks,

--- a/scripts/validate_mobile_store_rollout_handoff.py
+++ b/scripts/validate_mobile_store_rollout_handoff.py
@@ -17,6 +17,7 @@ REQUIRED_HANDOFF_CHECK_IDS = (
     "mobile_release_manifest_archived",
     "mobile_release_readiness_archived",
     "mobile_release_notes_archived",
+    "mobile_device_smoke_template_validation_archived",
     "device_smoke_evidence_linked",
     "no_secrets_in_handoff",
 )
@@ -99,6 +100,7 @@ def _validate_release(release: dict[str, Any], errors: list[str]) -> None:
         "mobile_release_manifest_sha256",
         "mobile_release_readiness_sha256",
         "mobile_release_notes_sha256",
+        "mobile_device_smoke_template_summary_sha256",
     )
     for field in required_text_fields:
         if not _read_text(release.get(field)):
@@ -108,6 +110,7 @@ def _validate_release(release: dict[str, Any], errors: list[str]) -> None:
         "mobile_release_manifest_sha256",
         "mobile_release_readiness_sha256",
         "mobile_release_notes_sha256",
+        "mobile_device_smoke_template_summary_sha256",
     ):
         digest = _read_text(release.get(field))
         if digest and not _is_sha256(digest):

--- a/scripts/verify_mobile_release_bundle.py
+++ b/scripts/verify_mobile_release_bundle.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 TRACEABILITY_FIELDS = ("git_sha", "git_ref", "git_run_id", "workflow")
+SMOKE_TEMPLATE_SUMMARY_SCHEMA_VERSION = "mobile_device_smoke_log_v0.1"
 READINESS_SUMMARY_FIELDS = (
     "status",
     "local_checks_status",
@@ -237,11 +238,28 @@ def _validate_release_notes(
     return actual_sha
 
 
+def _validate_smoke_template_summary(
+    smoke_template_summary: Path, errors: list[str]
+) -> str:
+    summary = _load_json(smoke_template_summary)
+    if summary.get("schema_version") != SMOKE_TEMPLATE_SUMMARY_SCHEMA_VERSION:
+        errors.append(
+            "mobile_device_smoke_template_summary.schema_version must be "
+            f"{SMOKE_TEMPLATE_SUMMARY_SCHEMA_VERSION!r}"
+        )
+    if summary.get("status") != "pass":
+        errors.append("mobile_device_smoke_template_summary.status must be 'pass'")
+    if summary.get("errors") not in ([], None):
+        errors.append("mobile_device_smoke_template_summary.errors must be empty")
+    return _sha256_file(smoke_template_summary)
+
+
 def _validate_store_rollout_handoff(
     manifest: dict[str, Any],
     readiness: Path,
     manifest_path: Path,
     release_notes_sha: str,
+    smoke_template_summary_sha: str,
     handoff: dict[str, Any],
     handoff_summary: dict[str, Any],
     errors: list[str],
@@ -283,6 +301,13 @@ def _validate_store_rollout_handoff(
         handoff_release.get("mobile_release_notes_sha256"),
         release_notes_sha,
     )
+    _compare_field(
+        errors,
+        "store_rollout_handoff.release",
+        "mobile_device_smoke_template_summary_sha256",
+        handoff_release.get("mobile_device_smoke_template_summary_sha256"),
+        smoke_template_summary_sha,
+    )
 
     if handoff_summary.get("status") != "pass":
         errors.append("store_rollout_handoff.summary.status must be 'pass'")
@@ -298,6 +323,7 @@ def verify_release_bundle(
     manifest_json: Path,
     readiness_json: Path,
     release_notes: Path,
+    smoke_template_summary_json: Path,
     store_rollout_handoff_json: Path,
     store_rollout_summary_json: Path,
     expect_git_sha: str | None = None,
@@ -319,11 +345,15 @@ def verify_release_bundle(
     )
     _validate_manifest_readiness_summary(manifest, readiness, errors)
     release_notes_sha = _validate_release_notes(manifest, release_notes, errors)
+    smoke_template_summary_sha = _validate_smoke_template_summary(
+        smoke_template_summary_json, errors
+    )
     _validate_store_rollout_handoff(
         manifest,
         readiness_json,
         manifest_json,
         release_notes_sha,
+        smoke_template_summary_sha,
         handoff,
         handoff_summary,
         errors,
@@ -341,6 +371,7 @@ def verify_release_bundle(
             "mobile_release_manifest": _sha256_file(manifest_json),
             "mobile_release_readiness": _sha256_file(readiness_json),
             "mobile_release_notes": release_notes_sha,
+            "mobile_device_smoke_template_summary": smoke_template_summary_sha,
             "mobile_store_rollout_handoff": _sha256_file(store_rollout_handoff_json),
             "mobile_store_rollout_handoff_summary": _sha256_file(
                 store_rollout_summary_json
@@ -357,6 +388,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--manifest-json", type=Path, required=True)
     parser.add_argument("--readiness-json", type=Path, required=True)
     parser.add_argument("--release-notes", type=Path, required=True)
+    parser.add_argument("--smoke-template-summary-json", type=Path, required=True)
     parser.add_argument("--store-rollout-handoff-json", type=Path, required=True)
     parser.add_argument("--store-rollout-summary-json", type=Path, required=True)
     parser.add_argument("--expect-git-sha")
@@ -371,6 +403,7 @@ def main() -> int:
         manifest_json=args.manifest_json,
         readiness_json=args.readiness_json,
         release_notes=args.release_notes,
+        smoke_template_summary_json=args.smoke_template_summary_json,
         store_rollout_handoff_json=args.store_rollout_handoff_json,
         store_rollout_summary_json=args.store_rollout_summary_json,
         expect_git_sha=args.expect_git_sha,

--- a/tests/test_mobile_build_workflow.py
+++ b/tests/test_mobile_build_workflow.py
@@ -99,6 +99,24 @@ def test_mobile_build_workflow_embeds_readiness_summary_in_release_manifest() ->
     assert "--release-notes /tmp/mobile-release-notes.md" in manifest_step["run"]
 
 
+def test_mobile_build_workflow_traces_smoke_template_summary_digest() -> None:
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = payload["jobs"]["preflight"]["steps"]
+    handoff_step = next(
+        step for step in steps if step.get("name") == "Build store rollout handoff artifact"
+    )
+    verifier_step = next(
+        step for step in steps if step.get("name") == "Verify release artifact bundle"
+    )
+
+    assert "mobile_device_smoke_template_summary_sha256" in handoff_step["run"]
+    assert "/tmp/mobile-device-smoke-template-summary.json" in handoff_step["run"]
+    assert (
+        "--smoke-template-summary-json /tmp/mobile-device-smoke-template-summary.json"
+        in verifier_step["run"]
+    )
+
+
 def test_mobile_build_workflow_uploads_release_notes_artifact() -> None:
     payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     steps = payload["jobs"]["preflight"]["steps"]

--- a/tests/test_mobile_release_bundle_verifier.py
+++ b/tests/test_mobile_release_bundle_verifier.py
@@ -26,6 +26,16 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
         "# Uroflow Field Mobile Release Notes\n\nBundle verifier test notes.\n",
         encoding="utf-8",
     )
+    smoke_template_summary = {
+        "schema_version": "mobile_device_smoke_log_v0.1",
+        "status": "pass",
+        "device_count": 2,
+        "platforms_seen": ["android", "ios"],
+        "required_check_ids": ["app_launch"],
+        "errors": [],
+    }
+    smoke_template_summary_path = tmp_path / "mobile-device-smoke-template-summary.json"
+    _write_json(smoke_template_summary_path, smoke_template_summary)
 
     readiness = {
         "status": "ready_except_external_credentials",
@@ -110,6 +120,9 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
             "mobile_release_manifest_sha256": _sha256(manifest_path),
             "mobile_release_readiness_sha256": _sha256(readiness_path),
             "mobile_release_notes_sha256": _sha256(notes_path),
+            "mobile_device_smoke_template_summary_sha256": _sha256(
+                smoke_template_summary_path
+            ),
         }
     }
     handoff_path = tmp_path / "mobile-store-rollout-handoff.json"
@@ -134,6 +147,7 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
         "manifest": manifest_path,
         "readiness": readiness_path,
         "notes": notes_path,
+        "smoke_template_summary": smoke_template_summary_path,
         "handoff": handoff_path,
         "handoff_summary": handoff_summary_path,
     }
@@ -155,6 +169,8 @@ def _run_verifier(
         str(paths["readiness"]),
         "--release-notes",
         str(paths["notes"]),
+        "--smoke-template-summary-json",
+        str(paths["smoke_template_summary"]),
         "--store-rollout-handoff-json",
         str(paths["handoff"]),
         "--store-rollout-summary-json",
@@ -183,6 +199,7 @@ def test_mobile_release_bundle_verifier_accepts_consistent_bundle(tmp_path: Path
         "android:play_internal_testing",
         "ios:testflight_internal",
     ]
+    assert "mobile_device_smoke_template_summary" in summary["artifact_sha256"]
     assert json.loads((tmp_path / "bundle-summary.json").read_text()) == summary
 
 
@@ -216,6 +233,48 @@ def test_mobile_release_bundle_verifier_rejects_readiness_count_mismatch(
     assert result.returncode == 1
     assert summary["status"] == "fail"
     assert any("local_check_counts mismatch" in error for error in summary["errors"])
+
+
+def test_mobile_release_bundle_verifier_rejects_smoke_template_digest_mismatch(
+    tmp_path: Path,
+) -> None:
+    paths = _valid_bundle(tmp_path)
+    handoff = json.loads(paths["handoff"].read_text(encoding="utf-8"))
+    handoff["release"]["mobile_device_smoke_template_summary_sha256"] = "0" * 64
+    _write_json(paths["handoff"], handoff)
+
+    result = _run_verifier(paths, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert any(
+        "mobile_device_smoke_template_summary_sha256 mismatch" in error
+        for error in summary["errors"]
+    )
+
+
+def test_mobile_release_bundle_verifier_rejects_failed_smoke_template_summary(
+    tmp_path: Path,
+) -> None:
+    paths = _valid_bundle(tmp_path)
+    summary_payload = json.loads(paths["smoke_template_summary"].read_text(encoding="utf-8"))
+    summary_payload["status"] = "fail"
+    summary_payload["errors"] = ["template failure"]
+    _write_json(paths["smoke_template_summary"], summary_payload)
+    handoff = json.loads(paths["handoff"].read_text(encoding="utf-8"))
+    handoff["release"]["mobile_device_smoke_template_summary_sha256"] = _sha256(
+        paths["smoke_template_summary"]
+    )
+    _write_json(paths["handoff"], handoff)
+
+    result = _run_verifier(paths, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert "mobile_device_smoke_template_summary.status must be 'pass'" in summary["errors"]
+    assert "mobile_device_smoke_template_summary.errors must be empty" in summary["errors"]
 
 
 def test_mobile_release_bundle_verifier_rejects_expected_git_sha_mismatch(

--- a/tests/test_mobile_store_rollout_handoff.py
+++ b/tests/test_mobile_store_rollout_handoff.py
@@ -53,6 +53,10 @@ def test_mobile_store_rollout_handoff_template_validates(tmp_path: Path) -> None
         "ios:testflight_internal",
     ]
     assert "mobile_release_manifest_archived" in summary["required_handoff_check_ids"]
+    assert (
+        "mobile_device_smoke_template_validation_archived"
+        in summary["required_handoff_check_ids"]
+    )
     assert "eas_ios_build_uploaded" in summary["required_channel_check_ids"][
         "ios:testflight_internal"
     ]
@@ -122,3 +126,20 @@ def test_mobile_store_rollout_handoff_rejects_invalid_release_sha(
         "release.mobile_release_manifest_sha256 must be a lowercase SHA-256 hex digest"
         in summary["errors"]
     )
+
+
+def test_mobile_store_rollout_handoff_rejects_invalid_smoke_template_sha(
+    tmp_path: Path,
+) -> None:
+    payload = _valid_payload()
+    payload["release"]["mobile_device_smoke_template_summary_sha256"] = "A" * 64
+
+    result = _run_validator(tmp_path, payload, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert (
+        "release.mobile_device_smoke_template_summary_sha256 must be a lowercase "
+        "SHA-256 hex digest"
+    ) in summary["errors"]


### PR DESCRIPTION
## Summary
- add `mobile_device_smoke_template_summary_sha256` to the store rollout handoff release traceability block
- make the store rollout validator require the smoke-template validation archive check and digest shape
- make release bundle verification require `--smoke-template-summary-json`, verify it passed, and compare its digest against the handoff
- update Mobile Build, readiness checks, tests, and release docs for the new digest chain

## Validation
- `.venv/bin/ruff check scripts/validate_mobile_store_rollout_handoff.py scripts/verify_mobile_release_bundle.py scripts/check_mobile_release_readiness.py tests/test_mobile_store_rollout_handoff.py tests/test_mobile_release_bundle_verifier.py tests/test_mobile_build_workflow.py tests/test_mobile_release_readiness_script.py`
- `.venv/bin/pytest -q tests/test_mobile_store_rollout_handoff.py tests/test_mobile_release_bundle_verifier.py tests/test_mobile_build_workflow.py tests/test_mobile_release_readiness_script.py`
- `python3 scripts/validate_mobile_store_rollout_handoff.py docs/mobile-store-rollout-handoff-template-v0.1.json --output /tmp/mobile-store-rollout-summary-digest-traceability.json`
- local mini-bundle chain: smoke template summary -> readiness -> manifest -> handoff -> `scripts/verify_mobile_release_bundle.py --smoke-template-summary-json ...`
- `.venv/bin/pytest -q`
- `npm run validate:ci`
- `git diff --check`
