### PR TITLE
Flatten smoke template validation artifact

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -285,9 +285,11 @@ jobs:
       - name: Build smoke template validation artifact
         shell: bash
         run: |
+          cp ../../docs/mobile-device-smoke-log-template-v0.1.json \
+            /tmp/mobile-device-smoke-log-template-v0.1.json
           set +e
           python3 ../../scripts/validate_mobile_device_smoke_log.py \
-            ../../docs/mobile-device-smoke-log-template-v0.1.json \
+            /tmp/mobile-device-smoke-log-template-v0.1.json \
             --output /tmp/mobile-device-smoke-template-summary.json
           smoke_template_exit_code=$?
           set -e
@@ -507,7 +509,7 @@ jobs:
         with:
           name: mobile-device-smoke-template-validation
           path: |
-            docs/mobile-device-smoke-log-template-v0.1.json
+            /tmp/mobile-device-smoke-log-template-v0.1.json
             /tmp/mobile-device-smoke-template-summary.json
             /tmp/mobile-device-smoke-template-exit-code
           if-no-files-found: error

--- a/tests/test_mobile_build_workflow.py
+++ b/tests/test_mobile_build_workflow.py
@@ -81,11 +81,15 @@ def test_mobile_build_workflow_uploads_smoke_template_validation_before_failure(
 
     assert build_index < summary_index < notes_index < upload_index
     assert upload_index < smoke_fail_index < readiness_fail_index
+    assert "cp ../../docs/mobile-device-smoke-log-template-v0.1.json" in steps[build_index][
+        "run"
+    ]
     assert "validate_mobile_device_smoke_log.py" in steps[build_index]["run"]
+    assert "/tmp/mobile-device-smoke-log-template-v0.1.json" in steps[build_index]["run"]
     assert "mobile-device-smoke-template-summary.json" in steps[build_index]["run"]
     assert "mobile-device-smoke-template-summary.json" in steps[summary_index]["run"]
     assert upload_step["with"]["name"] == "mobile-device-smoke-template-validation"
-    assert "docs/mobile-device-smoke-log-template-v0.1.json" in upload_step["with"]["path"]
+    assert "/tmp/mobile-device-smoke-log-template-v0.1.json" in upload_step["with"]["path"]
     assert "/tmp/mobile-device-smoke-template-summary.json" in upload_step["with"]["path"]
     assert "mobile-device-smoke-template-validation artifact" in steps[smoke_fail_index]["run"]
 


### PR DESCRIPTION
## Summary
- copy the mobile smoke log template to `/tmp` before validation so the uploaded artifact has a flat layout
- validate the same copied template that is archived in `mobile-device-smoke-template-validation`
- update workflow tests to guard the flat artifact path

## Validation
- `.venv/bin/ruff check tests/test_mobile_build_workflow.py`
- `.venv/bin/pytest -q tests/test_mobile_build_workflow.py`
- `.venv/bin/pytest -q`
- `npm run validate:ci`
- local `/tmp` template copy + `scripts/validate_mobile_device_smoke_log.py`
- `git diff --check`
