### PR TITLE
Trace dependency review in release bundle

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -443,6 +443,9 @@ jobs:
                   "mobile_release_notes_sha256": sha256_file(
                       Path("/tmp/mobile-release-notes.md")
                   ),
+                  "mobile_dependency_review_sha256": sha256_file(
+                      Path("/tmp/mobile-dependency-review.json")
+                  ),
                   "mobile_device_smoke_template_summary_sha256": sha256_file(
                       Path("/tmp/mobile-device-smoke-template-summary.json")
                   ),
@@ -465,6 +468,7 @@ jobs:
             --manifest-json /tmp/mobile-release-manifest.json \
             --readiness-json /tmp/mobile-release-readiness.json \
             --release-notes /tmp/mobile-release-notes.md \
+            --dependency-review-json /tmp/mobile-dependency-review.json \
             --smoke-template-summary-json /tmp/mobile-device-smoke-template-summary.json \
             --store-rollout-handoff-json /tmp/mobile-store-rollout-handoff.json \
             --store-rollout-summary-json /tmp/mobile-store-rollout-handoff-summary.json \

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -55,7 +55,8 @@ Implemented now:
 - Store rollout handoff JSON template, validator, and Mobile Build artifact for TestFlight/Play Internal traceability.
 - Mobile release bundle verifier for manifest/readiness/notes/store-handoff artifact consistency.
 - Mobile dependency review artifact for direct dependency lockfile integrity, production
-  `npm audit` summary, native sensitive dependency surface review, and SEC-003 remediation hints.
+  `npm audit` summary, native sensitive dependency surface review, SEC-003 remediation
+  hints, and release bundle SHA-256 traceability.
 - In-app Release Identity panel for app/model/schema/runtime/privacy/data-residency evidence on device.
 - Runtime release guard blocks capture/API/submit/sync actions when app/model/schema/runtime
   config, endpoint set, privacy, data-residency, or debug gates are incompatible.

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -127,16 +127,16 @@ Workflow also generates artifact `mobile-device-smoke-template-validation` conta
 - validator exit code for diagnosis if the template contract breaks.
 
 Workflow also generates artifact `mobile-store-rollout-handoff` containing:
-- per-run git SHA, app version, build profile/channel, and SHA-256 digests for `mobile-release-manifest`, `mobile-release-readiness`, `mobile-release-notes`, and `mobile-device-smoke-template-validation` summary,
+- per-run git SHA, app version, build profile/channel, and SHA-256 digests for `mobile-release-manifest`, `mobile-release-readiness`, `mobile-release-notes`, `mobile-dependency-review`, and `mobile-device-smoke-template-validation` summary,
 - iOS TestFlight internal handoff checklist and current external blockers,
 - Android Play Internal Testing handoff checklist and current external blockers,
 - validation summary from `scripts/validate_mobile_store_rollout_handoff.py`.
 
 Workflow also generates artifact `mobile-release-bundle-verification` containing:
 - git/run traceability shared by manifest, readiness, and store rollout handoff,
-- SHA-256 fingerprints for manifest, readiness, release notes, smoke-template validation summary, store rollout handoff, and store rollout summary,
+- SHA-256 fingerprints for manifest, readiness, release notes, dependency review, smoke-template validation summary, store rollout handoff, and store rollout summary,
 - consistency checks proving the manifest readiness summary matches raw readiness JSON,
-- digest checks proving the store rollout handoff references the exact manifest/readiness/notes/smoke-template summary files from the same run.
+- digest checks proving the store rollout handoff references the exact manifest/readiness/notes/dependency-review/smoke-template summary files from the same run.
 
 Manifest script:
 
@@ -186,6 +186,7 @@ python3 scripts/verify_mobile_release_bundle.py \
   --manifest-json /tmp/mobile-release-manifest.json \
   --readiness-json /tmp/mobile-release-readiness.json \
   --release-notes /tmp/mobile-release-notes.md \
+  --dependency-review-json /tmp/mobile-dependency-review.json \
   --smoke-template-summary-json /tmp/mobile-device-smoke-template-summary.json \
   --store-rollout-handoff-json /tmp/mobile-store-rollout-handoff.json \
   --store-rollout-summary-json /tmp/mobile-store-rollout-summary.json \

--- a/docs/mobile-store-rollout-handoff-template-v0.1.json
+++ b/docs/mobile-store-rollout-handoff-template-v0.1.json
@@ -10,6 +10,7 @@
     "mobile_release_manifest_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
     "mobile_release_readiness_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
     "mobile_release_notes_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "mobile_dependency_review_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
     "mobile_device_smoke_template_summary_sha256": "0000000000000000000000000000000000000000000000000000000000000000"
   },
   "handoff_checks": [
@@ -27,6 +28,11 @@
       "id": "mobile_release_notes_archived",
       "status": "pass",
       "evidence": "Mobile release notes artifact is archived for this run."
+    },
+    {
+      "id": "mobile_dependency_review_archived",
+      "status": "pass",
+      "evidence": "Mobile dependency review artifact is archived for this run."
     },
     {
       "id": "mobile_device_smoke_template_validation_archived",

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -2030,6 +2030,8 @@ def build_readiness_report(
         in mobile_store_rollout_template_source,
         "release_manifest_traceability": "mobile_release_manifest_sha256"
         in mobile_store_rollout_template_source,
+        "dependency_review_traceability": "mobile_dependency_review_sha256"
+        in mobile_store_rollout_template_source,
         "smoke_template_traceability": "mobile_device_smoke_template_summary_sha256"
         in mobile_store_rollout_template_source,
     }
@@ -2045,6 +2047,10 @@ def build_readiness_report(
         "testflight_internal": "testflight_internal" in mobile_store_rollout_validator_source,
         "play_internal_testing": "play_internal_testing" in mobile_store_rollout_validator_source,
         "sha256_traceability": "mobile_release_manifest_sha256"
+        in mobile_store_rollout_validator_source,
+        "dependency_review_sha": "mobile_dependency_review_sha256"
+        in mobile_store_rollout_validator_source,
+        "dependency_review_handoff_check": "mobile_dependency_review_archived"
         in mobile_store_rollout_validator_source,
         "smoke_template_sha": "mobile_device_smoke_template_summary_sha256"
         in mobile_store_rollout_validator_source,
@@ -2069,6 +2075,8 @@ def build_readiness_report(
         in mobile_store_rollout_validator_tests_source,
         "release_sha_test": "rejects_invalid_release_sha"
         in mobile_store_rollout_validator_tests_source,
+        "dependency_review_sha_test": "rejects_invalid_dependency_review_sha"
+        in mobile_store_rollout_validator_tests_source,
         "smoke_template_sha_test": "rejects_invalid_smoke_template_sha"
         in mobile_store_rollout_validator_tests_source,
     }
@@ -2085,6 +2093,10 @@ def build_readiness_report(
         "readiness_count_validation": "local_check_counts"
         in mobile_release_bundle_verifier_source,
         "store_handoff_digest_validation": "mobile_release_manifest_sha256"
+        in mobile_release_bundle_verifier_source,
+        "dependency_review_digest_validation": "mobile_dependency_review_sha256"
+        in mobile_release_bundle_verifier_source,
+        "dependency_review_input": "dependency_review_json"
         in mobile_release_bundle_verifier_source,
         "smoke_template_summary_digest_validation": (
             "mobile_device_smoke_template_summary_sha256"
@@ -2111,6 +2123,14 @@ def build_readiness_report(
         in mobile_release_bundle_verifier_tests_source,
         "smoke_template_digest_mismatch_test": (
             "rejects_smoke_template_digest_mismatch"
+            in mobile_release_bundle_verifier_tests_source
+        ),
+        "dependency_review_digest_mismatch_test": (
+            "rejects_dependency_review_digest_mismatch"
+            in mobile_release_bundle_verifier_tests_source
+        ),
+        "failed_dependency_review_test": (
+            "rejects_failed_dependency_review"
             in mobile_release_bundle_verifier_tests_source
         ),
         "failed_smoke_template_summary_test": (

--- a/scripts/validate_mobile_store_rollout_handoff.py
+++ b/scripts/validate_mobile_store_rollout_handoff.py
@@ -17,6 +17,7 @@ REQUIRED_HANDOFF_CHECK_IDS = (
     "mobile_release_manifest_archived",
     "mobile_release_readiness_archived",
     "mobile_release_notes_archived",
+    "mobile_dependency_review_archived",
     "mobile_device_smoke_template_validation_archived",
     "device_smoke_evidence_linked",
     "no_secrets_in_handoff",
@@ -100,6 +101,7 @@ def _validate_release(release: dict[str, Any], errors: list[str]) -> None:
         "mobile_release_manifest_sha256",
         "mobile_release_readiness_sha256",
         "mobile_release_notes_sha256",
+        "mobile_dependency_review_sha256",
         "mobile_device_smoke_template_summary_sha256",
     )
     for field in required_text_fields:
@@ -110,6 +112,7 @@ def _validate_release(release: dict[str, Any], errors: list[str]) -> None:
         "mobile_release_manifest_sha256",
         "mobile_release_readiness_sha256",
         "mobile_release_notes_sha256",
+        "mobile_dependency_review_sha256",
         "mobile_device_smoke_template_summary_sha256",
     ):
         digest = _read_text(release.get(field))

--- a/scripts/verify_mobile_release_bundle.py
+++ b/scripts/verify_mobile_release_bundle.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 TRACEABILITY_FIELDS = ("git_sha", "git_ref", "git_run_id", "workflow")
+DEPENDENCY_REVIEW_SCHEMA_VERSION = "mobile_dependency_review_v0.1"
 SMOKE_TEMPLATE_SUMMARY_SCHEMA_VERSION = "mobile_device_smoke_log_v0.1"
 READINESS_SUMMARY_FIELDS = (
     "status",
@@ -254,11 +255,46 @@ def _validate_smoke_template_summary(
     return _sha256_file(smoke_template_summary)
 
 
+def _validate_dependency_review(
+    dependency_review_json: Path, expected_traceability: dict[str, Any], errors: list[str]
+) -> str:
+    payload = _load_json(dependency_review_json)
+    if payload.get("schema_version") != DEPENDENCY_REVIEW_SCHEMA_VERSION:
+        errors.append(
+            "mobile_dependency_review.schema_version must be "
+            f"{DEPENDENCY_REVIEW_SCHEMA_VERSION!r}"
+        )
+    if payload.get("status") != "pass":
+        errors.append("mobile_dependency_review.status must be 'pass'")
+    if payload.get("failed_checks") != []:
+        errors.append("mobile_dependency_review.failed_checks must be empty")
+
+    dependency_traceability = _as_dict(payload.get("traceability"))
+    for field in TRACEABILITY_FIELDS:
+        _compare_field(
+            errors,
+            "mobile_dependency_review.traceability",
+            field,
+            dependency_traceability.get(field),
+            expected_traceability.get(field),
+        )
+
+    audit = _as_dict(payload.get("audit"))
+    if audit.get("status") != "pass":
+        errors.append("mobile_dependency_review.audit.status must be 'pass'")
+    vulnerabilities = _as_dict(audit.get("vulnerabilities"))
+    if vulnerabilities.get("total") != 0:
+        errors.append("mobile_dependency_review.audit.vulnerabilities.total must be 0")
+
+    return _sha256_file(dependency_review_json)
+
+
 def _validate_store_rollout_handoff(
     manifest: dict[str, Any],
     readiness: Path,
     manifest_path: Path,
     release_notes_sha: str,
+    dependency_review_sha: str,
     smoke_template_summary_sha: str,
     handoff: dict[str, Any],
     handoff_summary: dict[str, Any],
@@ -304,6 +340,13 @@ def _validate_store_rollout_handoff(
     _compare_field(
         errors,
         "store_rollout_handoff.release",
+        "mobile_dependency_review_sha256",
+        handoff_release.get("mobile_dependency_review_sha256"),
+        dependency_review_sha,
+    )
+    _compare_field(
+        errors,
+        "store_rollout_handoff.release",
         "mobile_device_smoke_template_summary_sha256",
         handoff_release.get("mobile_device_smoke_template_summary_sha256"),
         smoke_template_summary_sha,
@@ -323,6 +366,7 @@ def verify_release_bundle(
     manifest_json: Path,
     readiness_json: Path,
     release_notes: Path,
+    dependency_review_json: Path,
     smoke_template_summary_json: Path,
     store_rollout_handoff_json: Path,
     store_rollout_summary_json: Path,
@@ -345,6 +389,9 @@ def verify_release_bundle(
     )
     _validate_manifest_readiness_summary(manifest, readiness, errors)
     release_notes_sha = _validate_release_notes(manifest, release_notes, errors)
+    dependency_review_sha = _validate_dependency_review(
+        dependency_review_json, traceability, errors
+    )
     smoke_template_summary_sha = _validate_smoke_template_summary(
         smoke_template_summary_json, errors
     )
@@ -353,6 +400,7 @@ def verify_release_bundle(
         readiness_json,
         manifest_json,
         release_notes_sha,
+        dependency_review_sha,
         smoke_template_summary_sha,
         handoff,
         handoff_summary,
@@ -371,6 +419,7 @@ def verify_release_bundle(
             "mobile_release_manifest": _sha256_file(manifest_json),
             "mobile_release_readiness": _sha256_file(readiness_json),
             "mobile_release_notes": release_notes_sha,
+            "mobile_dependency_review": dependency_review_sha,
             "mobile_device_smoke_template_summary": smoke_template_summary_sha,
             "mobile_store_rollout_handoff": _sha256_file(store_rollout_handoff_json),
             "mobile_store_rollout_handoff_summary": _sha256_file(
@@ -388,6 +437,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--manifest-json", type=Path, required=True)
     parser.add_argument("--readiness-json", type=Path, required=True)
     parser.add_argument("--release-notes", type=Path, required=True)
+    parser.add_argument("--dependency-review-json", type=Path, required=True)
     parser.add_argument("--smoke-template-summary-json", type=Path, required=True)
     parser.add_argument("--store-rollout-handoff-json", type=Path, required=True)
     parser.add_argument("--store-rollout-summary-json", type=Path, required=True)
@@ -403,6 +453,7 @@ def main() -> int:
         manifest_json=args.manifest_json,
         readiness_json=args.readiness_json,
         release_notes=args.release_notes,
+        dependency_review_json=args.dependency_review_json,
         smoke_template_summary_json=args.smoke_template_summary_json,
         store_rollout_handoff_json=args.store_rollout_handoff_json,
         store_rollout_summary_json=args.store_rollout_summary_json,

--- a/tests/test_mobile_build_workflow.py
+++ b/tests/test_mobile_build_workflow.py
@@ -114,7 +114,10 @@ def test_mobile_build_workflow_traces_smoke_template_summary_digest() -> None:
     )
 
     assert "mobile_device_smoke_template_summary_sha256" in handoff_step["run"]
+    assert "mobile_dependency_review_sha256" in handoff_step["run"]
+    assert "/tmp/mobile-dependency-review.json" in handoff_step["run"]
     assert "/tmp/mobile-device-smoke-template-summary.json" in handoff_step["run"]
+    assert "--dependency-review-json /tmp/mobile-dependency-review.json" in verifier_step["run"]
     assert (
         "--smoke-template-summary-json /tmp/mobile-device-smoke-template-summary.json"
         in verifier_step["run"]

--- a/tests/test_mobile_release_bundle_verifier.py
+++ b/tests/test_mobile_release_bundle_verifier.py
@@ -26,6 +26,30 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
         "# Uroflow Field Mobile Release Notes\n\nBundle verifier test notes.\n",
         encoding="utf-8",
     )
+    dependency_review = {
+        "schema_version": "mobile_dependency_review_v0.1",
+        "status": "pass",
+        "failed_checks": [],
+        "traceability": {
+            "git_sha": GIT_SHA,
+            "git_ref": "refs/heads/main",
+            "git_run_id": RUN_ID,
+            "workflow": "Mobile Build",
+        },
+        "audit": {
+            "status": "pass",
+            "vulnerabilities": {
+                "info": 0,
+                "low": 0,
+                "moderate": 0,
+                "high": 0,
+                "critical": 0,
+                "total": 0,
+            },
+        },
+    }
+    dependency_review_path = tmp_path / "mobile-dependency-review.json"
+    _write_json(dependency_review_path, dependency_review)
     smoke_template_summary = {
         "schema_version": "mobile_device_smoke_log_v0.1",
         "status": "pass",
@@ -120,6 +144,7 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
             "mobile_release_manifest_sha256": _sha256(manifest_path),
             "mobile_release_readiness_sha256": _sha256(readiness_path),
             "mobile_release_notes_sha256": _sha256(notes_path),
+            "mobile_dependency_review_sha256": _sha256(dependency_review_path),
             "mobile_device_smoke_template_summary_sha256": _sha256(
                 smoke_template_summary_path
             ),
@@ -147,6 +172,7 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
         "manifest": manifest_path,
         "readiness": readiness_path,
         "notes": notes_path,
+        "dependency_review": dependency_review_path,
         "smoke_template_summary": smoke_template_summary_path,
         "handoff": handoff_path,
         "handoff_summary": handoff_summary_path,
@@ -169,6 +195,8 @@ def _run_verifier(
         str(paths["readiness"]),
         "--release-notes",
         str(paths["notes"]),
+        "--dependency-review-json",
+        str(paths["dependency_review"]),
         "--smoke-template-summary-json",
         str(paths["smoke_template_summary"]),
         "--store-rollout-handoff-json",
@@ -199,6 +227,7 @@ def test_mobile_release_bundle_verifier_accepts_consistent_bundle(tmp_path: Path
         "android:play_internal_testing",
         "ios:testflight_internal",
     ]
+    assert "mobile_dependency_review" in summary["artifact_sha256"]
     assert "mobile_device_smoke_template_summary" in summary["artifact_sha256"]
     assert json.loads((tmp_path / "bundle-summary.json").read_text()) == summary
 
@@ -252,6 +281,76 @@ def test_mobile_release_bundle_verifier_rejects_smoke_template_digest_mismatch(
         "mobile_device_smoke_template_summary_sha256 mismatch" in error
         for error in summary["errors"]
     )
+
+
+def test_mobile_release_bundle_verifier_rejects_dependency_review_digest_mismatch(
+    tmp_path: Path,
+) -> None:
+    paths = _valid_bundle(tmp_path)
+    handoff = json.loads(paths["handoff"].read_text(encoding="utf-8"))
+    handoff["release"]["mobile_dependency_review_sha256"] = "0" * 64
+    _write_json(paths["handoff"], handoff)
+
+    result = _run_verifier(paths, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert any(
+        "mobile_dependency_review_sha256 mismatch" in error
+        for error in summary["errors"]
+    )
+
+
+def test_mobile_release_bundle_verifier_rejects_failed_dependency_review(
+    tmp_path: Path,
+) -> None:
+    paths = _valid_bundle(tmp_path)
+    review_payload = json.loads(paths["dependency_review"].read_text(encoding="utf-8"))
+    review_payload["status"] = "fail"
+    review_payload["failed_checks"] = ["production_audit_no_known_vulnerabilities"]
+    review_payload["audit"]["status"] = "fail"
+    review_payload["audit"]["vulnerabilities"]["total"] = 1
+    _write_json(paths["dependency_review"], review_payload)
+    handoff = json.loads(paths["handoff"].read_text(encoding="utf-8"))
+    handoff["release"]["mobile_dependency_review_sha256"] = _sha256(
+        paths["dependency_review"]
+    )
+    _write_json(paths["handoff"], handoff)
+
+    result = _run_verifier(paths, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert "mobile_dependency_review.status must be 'pass'" in summary["errors"]
+    assert "mobile_dependency_review.failed_checks must be empty" in summary["errors"]
+    assert "mobile_dependency_review.audit.status must be 'pass'" in summary["errors"]
+    assert (
+        "mobile_dependency_review.audit.vulnerabilities.total must be 0"
+        in summary["errors"]
+    )
+
+
+def test_mobile_release_bundle_verifier_rejects_missing_dependency_failed_checks(
+    tmp_path: Path,
+) -> None:
+    paths = _valid_bundle(tmp_path)
+    review_payload = json.loads(paths["dependency_review"].read_text(encoding="utf-8"))
+    del review_payload["failed_checks"]
+    _write_json(paths["dependency_review"], review_payload)
+    handoff = json.loads(paths["handoff"].read_text(encoding="utf-8"))
+    handoff["release"]["mobile_dependency_review_sha256"] = _sha256(
+        paths["dependency_review"]
+    )
+    _write_json(paths["handoff"], handoff)
+
+    result = _run_verifier(paths, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert "mobile_dependency_review.failed_checks must be empty" in summary["errors"]
 
 
 def test_mobile_release_bundle_verifier_rejects_failed_smoke_template_summary(

--- a/tests/test_mobile_store_rollout_handoff.py
+++ b/tests/test_mobile_store_rollout_handoff.py
@@ -53,6 +53,7 @@ def test_mobile_store_rollout_handoff_template_validates(tmp_path: Path) -> None
         "ios:testflight_internal",
     ]
     assert "mobile_release_manifest_archived" in summary["required_handoff_check_ids"]
+    assert "mobile_dependency_review_archived" in summary["required_handoff_check_ids"]
     assert (
         "mobile_device_smoke_template_validation_archived"
         in summary["required_handoff_check_ids"]
@@ -141,5 +142,22 @@ def test_mobile_store_rollout_handoff_rejects_invalid_smoke_template_sha(
     assert summary["status"] == "fail"
     assert (
         "release.mobile_device_smoke_template_summary_sha256 must be a lowercase "
+        "SHA-256 hex digest"
+    ) in summary["errors"]
+
+
+def test_mobile_store_rollout_handoff_rejects_invalid_dependency_review_sha(
+    tmp_path: Path,
+) -> None:
+    payload = _valid_payload()
+    payload["release"]["mobile_dependency_review_sha256"] = "A" * 64
+
+    result = _run_validator(tmp_path, payload, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert (
+        "release.mobile_dependency_review_sha256 must be a lowercase "
         "SHA-256 hex digest"
     ) in summary["errors"]


### PR DESCRIPTION
## Summary
- add `mobile_dependency_review_sha256` to store rollout handoff release traceability
- require `mobile-dependency-review.json` during release bundle verification
- validate dependency review schema/status/failed checks/audit/traceability and compare its digest against the handoff
- update Mobile Build, readiness gates, tests, and release docs for the SEC-003 artifact chain

## Validation
- local mini-bundle chain with real `mobile-dependency-review.json` -> bundle verifier `status: pass`, readiness `134/134`
- `.venv/bin/pytest -q` -> `154 passed`
- `.venv/bin/ruff check ...` -> pass
- `git diff --check` -> pass
- `npm run audit:prod && npm run export:ios && npm run export:android` -> `0 vulnerabilities`, iOS/Android exports pass
- `npm run validate:ci` attempted locally; typecheck and unit tests passed, but Expo Doctor failed on local network access to `exp.host` / React Native Directory metadata, so the full command did not complete in this environment