### PR TITLE
Trace external readiness packet in release bundle

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -487,6 +487,9 @@ jobs:
                   "mobile_dependency_review_sha256": sha256_file(
                       Path("/tmp/mobile-dependency-review.json")
                   ),
+                  "mobile_external_readiness_packet_sha256": sha256_file(
+                      Path("/tmp/mobile-external-readiness-packet.json")
+                  ),
                   "mobile_device_smoke_template_summary_sha256": sha256_file(
                       Path("/tmp/mobile-device-smoke-template-summary.json")
                   ),
@@ -510,6 +513,7 @@ jobs:
             --readiness-json /tmp/mobile-release-readiness.json \
             --release-notes /tmp/mobile-release-notes.md \
             --dependency-review-json /tmp/mobile-dependency-review.json \
+            --external-readiness-packet-json /tmp/mobile-external-readiness-packet.json \
             --smoke-template-summary-json /tmp/mobile-device-smoke-template-summary.json \
             --store-rollout-handoff-json /tmp/mobile-store-rollout-handoff.json \
             --store-rollout-summary-json /tmp/mobile-store-rollout-handoff-summary.json \

--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -164,10 +164,10 @@ CI:
 - `mobile-build` uploads:
   - `mobile-release-manifest` (version + runtime release metadata/config + release notes digest + capture contract feature-manifest evidence + readiness gate summary + git SHA + model/schema traceability)
   - `mobile-release-readiness` (git traceability + local readiness checks + explicit external credential blockers)
-  - `mobile-external-readiness-packet` (sanitized credential/account handoff checklist with placeholder commands and no secret values)
+  - `mobile-external-readiness-packet` (sanitized credential/account handoff checklist with placeholder commands, no secret values, and bundle SHA-256 traceability)
   - `mobile-release-notes` (operator-facing release notes and required evidence reminders)
   - `mobile-dependency-review` (direct mobile dependency lockfile review, production `npm audit` summary, native sensitive dependency surface, and SEC-003 remediation hints)
-  - `mobile-release-bundle-verification` (manifest/readiness/notes/store-handoff digest and traceability consistency summary)
+  - `mobile-release-bundle-verification` (manifest/readiness/notes/external-readiness/store-handoff digest and traceability consistency summary)
   - `mobile-store-rollout-handoff` (per-run TestFlight/Play Internal handoff template + validation summary with current external blockers)
   - `mobile-eas-build-result-<run_id>` (raw EAS JSON response for build IDs/URLs)
   - `mobile-eas-submit-result-<run_id>` (raw EAS submit log + exit code when `submit_to_store=true`)
@@ -203,7 +203,8 @@ secret blockers. The artifact has separate machine-readable gates:
 When status is `ready_except_external_credentials`, use `next_actions` in the artifact as the
 release handoff checklist. Mobile Build also publishes the same handoff as
 `mobile-external-readiness-packet`, split into JSON and Markdown so account owners can act without
-opening the full readiness report.
+opening the full readiness report. The store rollout handoff and release bundle verifier also trace
+the packet SHA-256 digest, so stale credential handoff data fails the release artifact bundle check.
 
 | next action | Required setup | Verification |
 | --- | --- | --- |

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -58,7 +58,8 @@ Implemented now:
   `npm audit` summary, native sensitive dependency surface review, SEC-003 remediation
   hints, and release bundle SHA-256 traceability.
 - Mobile external readiness packet artifact for sanitized Expo/EAS/Clinical Hub/Apple/Google
-  credential handoff, including placeholder commands without secret values.
+  credential handoff, including placeholder commands without secret values and release bundle
+  SHA-256 traceability.
 - In-app Release Identity panel for app/model/schema/runtime/privacy/data-residency evidence on device.
 - Runtime release guard blocks capture/API/submit/sync actions when app/model/schema/runtime
   config, endpoint set, privacy, data-residency, or debug gates are incompatible.
@@ -152,7 +153,7 @@ DoD:
 
 ## B3: Release and tester delivery
 1. Configure Expo project credentials and EAS secrets.
-2. Wire CI dispatch for preview builds with release notes. Status: release notes input/artifact, manifest digest traceability, and external readiness packet handoff implemented; authenticated EAS trigger still waits for Expo/EAS credentials.
+2. Wire CI dispatch for preview builds with release notes. Status: release notes input/artifact, manifest digest traceability, and external readiness packet handoff with bundle digest traceability implemented; authenticated EAS trigger still waits for Expo/EAS credentials.
 3. Set distribution channels:
 - iOS TestFlight (internal group). Status: SOP/handoff format implemented; actual channel setup remains external to repository automation.
 - Android Internal Testing (Play). Status: SOP/handoff format implemented; actual channel setup remains external to repository automation.

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -134,16 +134,16 @@ Workflow also generates artifact `mobile-device-smoke-template-validation` conta
 - validator exit code for diagnosis if the template contract breaks.
 
 Workflow also generates artifact `mobile-store-rollout-handoff` containing:
-- per-run git SHA, app version, build profile/channel, and SHA-256 digests for `mobile-release-manifest`, `mobile-release-readiness`, `mobile-release-notes`, `mobile-dependency-review`, and `mobile-device-smoke-template-validation` summary,
+- per-run git SHA, app version, build profile/channel, and SHA-256 digests for `mobile-release-manifest`, `mobile-release-readiness`, `mobile-release-notes`, `mobile-dependency-review`, `mobile-external-readiness-packet`, and `mobile-device-smoke-template-validation` summary,
 - iOS TestFlight internal handoff checklist and current external blockers,
 - Android Play Internal Testing handoff checklist and current external blockers,
 - validation summary from `scripts/validate_mobile_store_rollout_handoff.py`.
 
 Workflow also generates artifact `mobile-release-bundle-verification` containing:
 - git/run traceability shared by manifest, readiness, and store rollout handoff,
-- SHA-256 fingerprints for manifest, readiness, release notes, dependency review, smoke-template validation summary, store rollout handoff, and store rollout summary,
+- SHA-256 fingerprints for manifest, readiness, release notes, dependency review, external readiness packet, smoke-template validation summary, store rollout handoff, and store rollout summary,
 - consistency checks proving the manifest readiness summary matches raw readiness JSON,
-- digest checks proving the store rollout handoff references the exact manifest/readiness/notes/dependency-review/smoke-template summary files from the same run.
+- digest checks proving the store rollout handoff references the exact manifest/readiness/notes/dependency-review/external-readiness-packet/smoke-template summary files from the same run.
 
 Manifest script:
 
@@ -194,6 +194,7 @@ python3 scripts/verify_mobile_release_bundle.py \
   --readiness-json /tmp/mobile-release-readiness.json \
   --release-notes /tmp/mobile-release-notes.md \
   --dependency-review-json /tmp/mobile-dependency-review.json \
+  --external-readiness-packet-json /tmp/mobile-external-readiness-packet.json \
   --smoke-template-summary-json /tmp/mobile-device-smoke-template-summary.json \
   --store-rollout-handoff-json /tmp/mobile-store-rollout-handoff.json \
   --store-rollout-summary-json /tmp/mobile-store-rollout-summary.json \

--- a/docs/mobile-store-rollout-handoff-template-v0.1.json
+++ b/docs/mobile-store-rollout-handoff-template-v0.1.json
@@ -11,6 +11,7 @@
     "mobile_release_readiness_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
     "mobile_release_notes_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
     "mobile_dependency_review_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+    "mobile_external_readiness_packet_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
     "mobile_device_smoke_template_summary_sha256": "0000000000000000000000000000000000000000000000000000000000000000"
   },
   "handoff_checks": [
@@ -33,6 +34,11 @@
       "id": "mobile_dependency_review_archived",
       "status": "pass",
       "evidence": "Mobile dependency review artifact is archived for this run."
+    },
+    {
+      "id": "mobile_external_readiness_packet_archived",
+      "status": "pass",
+      "evidence": "Mobile external readiness packet artifact is archived for this run."
     },
     {
       "id": "mobile_device_smoke_template_validation_archived",

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -2044,6 +2044,10 @@ def build_readiness_report(
         in mobile_store_rollout_template_source,
         "dependency_review_traceability": "mobile_dependency_review_sha256"
         in mobile_store_rollout_template_source,
+        "external_readiness_packet_traceability": (
+            "mobile_external_readiness_packet_sha256"
+            in mobile_store_rollout_template_source
+        ),
         "smoke_template_traceability": "mobile_device_smoke_template_summary_sha256"
         in mobile_store_rollout_template_source,
     }
@@ -2064,6 +2068,12 @@ def build_readiness_report(
         in mobile_store_rollout_validator_source,
         "dependency_review_handoff_check": "mobile_dependency_review_archived"
         in mobile_store_rollout_validator_source,
+        "external_readiness_packet_sha": "mobile_external_readiness_packet_sha256"
+        in mobile_store_rollout_validator_source,
+        "external_readiness_packet_handoff_check": (
+            "mobile_external_readiness_packet_archived"
+            in mobile_store_rollout_validator_source
+        ),
         "smoke_template_sha": "mobile_device_smoke_template_summary_sha256"
         in mobile_store_rollout_validator_source,
         "smoke_template_handoff_check": (
@@ -2089,6 +2099,10 @@ def build_readiness_report(
         in mobile_store_rollout_validator_tests_source,
         "dependency_review_sha_test": "rejects_invalid_dependency_review_sha"
         in mobile_store_rollout_validator_tests_source,
+        "external_readiness_packet_sha_test": (
+            "rejects_invalid_external_readiness_packet_sha"
+            in mobile_store_rollout_validator_tests_source
+        ),
         "smoke_template_sha_test": "rejects_invalid_smoke_template_sha"
         in mobile_store_rollout_validator_tests_source,
     }
@@ -2109,6 +2123,12 @@ def build_readiness_report(
         "dependency_review_digest_validation": "mobile_dependency_review_sha256"
         in mobile_release_bundle_verifier_source,
         "dependency_review_input": "dependency_review_json"
+        in mobile_release_bundle_verifier_source,
+        "external_readiness_packet_digest_validation": (
+            "mobile_external_readiness_packet_sha256"
+            in mobile_release_bundle_verifier_source
+        ),
+        "external_readiness_packet_input": "external_readiness_packet_json"
         in mobile_release_bundle_verifier_source,
         "smoke_template_summary_digest_validation": (
             "mobile_device_smoke_template_summary_sha256"
@@ -2139,6 +2159,14 @@ def build_readiness_report(
         ),
         "dependency_review_digest_mismatch_test": (
             "rejects_dependency_review_digest_mismatch"
+            in mobile_release_bundle_verifier_tests_source
+        ),
+        "external_readiness_packet_digest_mismatch_test": (
+            "rejects_external_readiness_packet_digest_mismatch"
+            in mobile_release_bundle_verifier_tests_source
+        ),
+        "external_readiness_packet_status_mismatch_test": (
+            "rejects_external_readiness_packet_status_mismatch"
             in mobile_release_bundle_verifier_tests_source
         ),
         "failed_dependency_review_test": (

--- a/scripts/validate_mobile_store_rollout_handoff.py
+++ b/scripts/validate_mobile_store_rollout_handoff.py
@@ -18,6 +18,7 @@ REQUIRED_HANDOFF_CHECK_IDS = (
     "mobile_release_readiness_archived",
     "mobile_release_notes_archived",
     "mobile_dependency_review_archived",
+    "mobile_external_readiness_packet_archived",
     "mobile_device_smoke_template_validation_archived",
     "device_smoke_evidence_linked",
     "no_secrets_in_handoff",
@@ -102,6 +103,7 @@ def _validate_release(release: dict[str, Any], errors: list[str]) -> None:
         "mobile_release_readiness_sha256",
         "mobile_release_notes_sha256",
         "mobile_dependency_review_sha256",
+        "mobile_external_readiness_packet_sha256",
         "mobile_device_smoke_template_summary_sha256",
     )
     for field in required_text_fields:
@@ -113,6 +115,7 @@ def _validate_release(release: dict[str, Any], errors: list[str]) -> None:
         "mobile_release_readiness_sha256",
         "mobile_release_notes_sha256",
         "mobile_dependency_review_sha256",
+        "mobile_external_readiness_packet_sha256",
         "mobile_device_smoke_template_summary_sha256",
     ):
         digest = _read_text(release.get(field))

--- a/scripts/verify_mobile_release_bundle.py
+++ b/scripts/verify_mobile_release_bundle.py
@@ -10,6 +10,7 @@ from typing import Any
 
 TRACEABILITY_FIELDS = ("git_sha", "git_ref", "git_run_id", "workflow")
 DEPENDENCY_REVIEW_SCHEMA_VERSION = "mobile_dependency_review_v0.1"
+EXTERNAL_READINESS_PACKET_SCHEMA_VERSION = "mobile_external_readiness_packet_v0.1"
 SMOKE_TEMPLATE_SUMMARY_SCHEMA_VERSION = "mobile_device_smoke_log_v0.1"
 READINESS_SUMMARY_FIELDS = (
     "status",
@@ -33,6 +34,10 @@ def _as_dict(value: Any) -> dict[str, Any]:
 
 def _as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
+
+
+def _string_list(value: Any) -> list[str]:
+    return [item for item in _as_list(value) if isinstance(item, str)]
 
 
 def _sha256_file(path: Path) -> str:
@@ -289,12 +294,130 @@ def _validate_dependency_review(
     return _sha256_file(dependency_review_json)
 
 
+def _expected_external_readiness_packet_status(
+    readiness: dict[str, Any], required_actions: list[dict[str, Any]]
+) -> str:
+    if readiness.get("local_checks_status") != "pass":
+        return "not_ready"
+    if required_actions:
+        return "blocked_external"
+    if readiness.get("external_readiness_status") == "pass":
+        return "ready"
+    return "blocked_external"
+
+
+def _required_action_values(
+    required_actions: list[dict[str, Any]], field: str
+) -> list[str]:
+    return sorted(
+        {
+            item
+            for action in required_actions
+            for item in _string_list(action.get(field))
+        }
+    )
+
+
+def _validate_external_readiness_packet(
+    external_readiness_packet_json: Path,
+    readiness: dict[str, Any],
+    expected_traceability: dict[str, Any],
+    errors: list[str],
+) -> str:
+    packet = _load_json(external_readiness_packet_json)
+    if packet.get("schema_version") != EXTERNAL_READINESS_PACKET_SCHEMA_VERSION:
+        errors.append(
+            "mobile_external_readiness_packet.schema_version must be "
+            f"{EXTERNAL_READINESS_PACKET_SCHEMA_VERSION!r}"
+        )
+
+    packet_traceability = _as_dict(packet.get("traceability"))
+    for field in TRACEABILITY_FIELDS:
+        _compare_field(
+            errors,
+            "mobile_external_readiness_packet.traceability",
+            field,
+            packet_traceability.get(field),
+            expected_traceability.get(field),
+        )
+
+    for field in READINESS_SUMMARY_FIELDS:
+        packet_field = "readiness_status" if field == "status" else field
+        _compare_field(
+            errors,
+            "mobile_external_readiness_packet",
+            packet_field,
+            packet.get(packet_field),
+            readiness.get(field),
+        )
+    _compare_field(
+        errors,
+        "mobile_external_readiness_packet",
+        "authenticated_eas_blockers",
+        packet.get("authenticated_eas_blockers"),
+        readiness.get("authenticated_eas_blockers", []),
+    )
+
+    required_actions = [
+        action for action in _as_list(packet.get("required_actions")) if isinstance(action, dict)
+    ]
+    _compare_field(
+        errors,
+        "mobile_external_readiness_packet",
+        "status",
+        packet.get("status"),
+        _expected_external_readiness_packet_status(readiness, required_actions),
+    )
+
+    summary = _as_dict(packet.get("summary"))
+    external_items = [
+        item for item in _as_list(packet.get("external_items")) if isinstance(item, dict)
+    ]
+    manual_external_items = [
+        item
+        for item in _as_list(packet.get("manual_external_items"))
+        if isinstance(item, dict)
+    ]
+    _compare_field(
+        errors,
+        "mobile_external_readiness_packet.summary",
+        "external_item_count",
+        summary.get("external_item_count"),
+        len(external_items),
+    )
+    _compare_field(
+        errors,
+        "mobile_external_readiness_packet.summary",
+        "manual_external_item_count",
+        summary.get("manual_external_item_count"),
+        len(manual_external_items),
+    )
+    _compare_field(
+        errors,
+        "mobile_external_readiness_packet.summary",
+        "required_action_count",
+        summary.get("required_action_count"),
+        len(required_actions),
+    )
+    for field in ("secret_names", "variable_names", "file_paths"):
+        _compare_field(
+            errors,
+            "mobile_external_readiness_packet.summary",
+            field,
+            summary.get(field),
+            _required_action_values(required_actions, field),
+        )
+
+    return _sha256_file(external_readiness_packet_json)
+
+
 def _validate_store_rollout_handoff(
     manifest: dict[str, Any],
     readiness: Path,
     manifest_path: Path,
     release_notes_sha: str,
     dependency_review_sha: str,
+    external_readiness_packet_sha: str,
     smoke_template_summary_sha: str,
     handoff: dict[str, Any],
     handoff_summary: dict[str, Any],
@@ -347,6 +470,13 @@ def _validate_store_rollout_handoff(
     _compare_field(
         errors,
         "store_rollout_handoff.release",
+        "mobile_external_readiness_packet_sha256",
+        handoff_release.get("mobile_external_readiness_packet_sha256"),
+        external_readiness_packet_sha,
+    )
+    _compare_field(
+        errors,
+        "store_rollout_handoff.release",
         "mobile_device_smoke_template_summary_sha256",
         handoff_release.get("mobile_device_smoke_template_summary_sha256"),
         smoke_template_summary_sha,
@@ -367,6 +497,7 @@ def verify_release_bundle(
     readiness_json: Path,
     release_notes: Path,
     dependency_review_json: Path,
+    external_readiness_packet_json: Path,
     smoke_template_summary_json: Path,
     store_rollout_handoff_json: Path,
     store_rollout_summary_json: Path,
@@ -392,6 +523,9 @@ def verify_release_bundle(
     dependency_review_sha = _validate_dependency_review(
         dependency_review_json, traceability, errors
     )
+    external_readiness_packet_sha = _validate_external_readiness_packet(
+        external_readiness_packet_json, readiness, traceability, errors
+    )
     smoke_template_summary_sha = _validate_smoke_template_summary(
         smoke_template_summary_json, errors
     )
@@ -401,6 +535,7 @@ def verify_release_bundle(
         manifest_json,
         release_notes_sha,
         dependency_review_sha,
+        external_readiness_packet_sha,
         smoke_template_summary_sha,
         handoff,
         handoff_summary,
@@ -420,6 +555,7 @@ def verify_release_bundle(
             "mobile_release_readiness": _sha256_file(readiness_json),
             "mobile_release_notes": release_notes_sha,
             "mobile_dependency_review": dependency_review_sha,
+            "mobile_external_readiness_packet": external_readiness_packet_sha,
             "mobile_device_smoke_template_summary": smoke_template_summary_sha,
             "mobile_store_rollout_handoff": _sha256_file(store_rollout_handoff_json),
             "mobile_store_rollout_handoff_summary": _sha256_file(
@@ -438,6 +574,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--readiness-json", type=Path, required=True)
     parser.add_argument("--release-notes", type=Path, required=True)
     parser.add_argument("--dependency-review-json", type=Path, required=True)
+    parser.add_argument("--external-readiness-packet-json", type=Path, required=True)
     parser.add_argument("--smoke-template-summary-json", type=Path, required=True)
     parser.add_argument("--store-rollout-handoff-json", type=Path, required=True)
     parser.add_argument("--store-rollout-summary-json", type=Path, required=True)
@@ -454,6 +591,7 @@ def main() -> int:
         readiness_json=args.readiness_json,
         release_notes=args.release_notes,
         dependency_review_json=args.dependency_review_json,
+        external_readiness_packet_json=args.external_readiness_packet_json,
         smoke_template_summary_json=args.smoke_template_summary_json,
         store_rollout_handoff_json=args.store_rollout_handoff_json,
         store_rollout_summary_json=args.store_rollout_summary_json,

--- a/tests/test_mobile_build_workflow.py
+++ b/tests/test_mobile_build_workflow.py
@@ -139,9 +139,15 @@ def test_mobile_build_workflow_traces_smoke_template_summary_digest() -> None:
 
     assert "mobile_device_smoke_template_summary_sha256" in handoff_step["run"]
     assert "mobile_dependency_review_sha256" in handoff_step["run"]
+    assert "mobile_external_readiness_packet_sha256" in handoff_step["run"]
     assert "/tmp/mobile-dependency-review.json" in handoff_step["run"]
+    assert "/tmp/mobile-external-readiness-packet.json" in handoff_step["run"]
     assert "/tmp/mobile-device-smoke-template-summary.json" in handoff_step["run"]
     assert "--dependency-review-json /tmp/mobile-dependency-review.json" in verifier_step["run"]
+    assert (
+        "--external-readiness-packet-json /tmp/mobile-external-readiness-packet.json"
+        in verifier_step["run"]
+    )
     assert (
         "--smoke-template-summary-json /tmp/mobile-device-smoke-template-summary.json"
         in verifier_step["run"]

--- a/tests/test_mobile_release_bundle_verifier.py
+++ b/tests/test_mobile_release_bundle_verifier.py
@@ -92,8 +92,51 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
             {"id": "google_play_account", "status": "manual_required"},
         ],
         "next_actions": [
-            {"id": "configure_expo_token"},
-            {"id": "configure_eas_project_identity"},
+            {
+                "id": "configure_expo_token",
+                "blocked_item": "expo_token",
+                "status": "required",
+                "secret_names": ["EXPO_TOKEN"],
+                "variable_names": [],
+                "file_paths": [],
+                "doc": "docs/mobile-release-runbook-v0.1.md",
+            },
+            {
+                "id": "configure_eas_project_identity",
+                "blocked_item": "eas_project_identity",
+                "status": "required",
+                "secret_names": [],
+                "variable_names": ["EAS_PROJECT_ID"],
+                "file_paths": ["apps/field-mobile/app.json"],
+                "doc": "docs/mobile-release-runbook-v0.1.md",
+            },
+            {
+                "id": "configure_clinical_hub_live_api",
+                "blocked_item": "clinical_hub_live_api",
+                "status": "required",
+                "secret_names": ["CLINICAL_HUB_URL", "CLINICAL_HUB_API_KEY"],
+                "variable_names": [],
+                "file_paths": [],
+                "doc": "docs/mobile-release-runbook-v0.1.md",
+            },
+            {
+                "id": "provision_apple_developer_account",
+                "blocked_item": "apple_developer_account",
+                "status": "manual_required",
+                "secret_names": [],
+                "variable_names": [],
+                "file_paths": [],
+                "doc": "docs/mobile-release-runbook-v0.1.md",
+            },
+            {
+                "id": "provision_google_play_account",
+                "blocked_item": "google_play_account",
+                "status": "manual_required",
+                "secret_names": ["GOOGLE_SERVICE_ACCOUNT"],
+                "variable_names": [],
+                "file_paths": [],
+                "doc": "docs/mobile-release-runbook-v0.1.md",
+            },
         ],
     }
     readiness_path = tmp_path / "mobile-release-readiness.json"
@@ -124,6 +167,9 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
             "next_action_ids": [
                 "configure_expo_token",
                 "configure_eas_project_identity",
+                "configure_clinical_hub_live_api",
+                "provision_apple_developer_account",
+                "provision_google_play_account",
             ],
         },
         "release_notes": {
@@ -136,6 +182,38 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
     manifest_path = tmp_path / "mobile-release-manifest.json"
     _write_json(manifest_path, manifest)
 
+    external_readiness_packet = {
+        "schema_version": "mobile_external_readiness_packet_v0.1",
+        "generated_at_utc": "2026-06-05T20:00:00Z",
+        "status": "blocked_external",
+        "traceability": copy.deepcopy(readiness["traceability"]),
+        "readiness_status": readiness["status"],
+        "local_checks_status": readiness["local_checks_status"],
+        "external_readiness_status": readiness["external_readiness_status"],
+        "authenticated_eas_status": readiness["authenticated_eas_status"],
+        "authenticated_eas_blockers": readiness["authenticated_eas_blockers"],
+        "clinical_hub_live_api_status": readiness["clinical_hub_live_api_status"],
+        "summary": {
+            "external_item_count": 3,
+            "manual_external_item_count": 2,
+            "required_action_count": 5,
+            "secret_names": [
+                "CLINICAL_HUB_API_KEY",
+                "CLINICAL_HUB_URL",
+                "EXPO_TOKEN",
+                "GOOGLE_SERVICE_ACCOUNT",
+            ],
+            "variable_names": ["EAS_PROJECT_ID"],
+            "file_paths": ["apps/field-mobile/app.json"],
+            "docs": ["docs/mobile-release-runbook-v0.1.md"],
+        },
+        "external_items": copy.deepcopy(readiness["external_items"]),
+        "manual_external_items": copy.deepcopy(readiness["manual_external_items"]),
+        "required_actions": copy.deepcopy(readiness["next_actions"]),
+    }
+    external_readiness_packet_path = tmp_path / "mobile-external-readiness-packet.json"
+    _write_json(external_readiness_packet_path, external_readiness_packet)
+
     handoff = {
         "release": {
             "git_sha": GIT_SHA,
@@ -145,6 +223,9 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
             "mobile_release_readiness_sha256": _sha256(readiness_path),
             "mobile_release_notes_sha256": _sha256(notes_path),
             "mobile_dependency_review_sha256": _sha256(dependency_review_path),
+            "mobile_external_readiness_packet_sha256": _sha256(
+                external_readiness_packet_path
+            ),
             "mobile_device_smoke_template_summary_sha256": _sha256(
                 smoke_template_summary_path
             ),
@@ -173,6 +254,7 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
         "readiness": readiness_path,
         "notes": notes_path,
         "dependency_review": dependency_review_path,
+        "external_readiness_packet": external_readiness_packet_path,
         "smoke_template_summary": smoke_template_summary_path,
         "handoff": handoff_path,
         "handoff_summary": handoff_summary_path,
@@ -197,6 +279,8 @@ def _run_verifier(
         str(paths["notes"]),
         "--dependency-review-json",
         str(paths["dependency_review"]),
+        "--external-readiness-packet-json",
+        str(paths["external_readiness_packet"]),
         "--smoke-template-summary-json",
         str(paths["smoke_template_summary"]),
         "--store-rollout-handoff-json",
@@ -228,6 +312,7 @@ def test_mobile_release_bundle_verifier_accepts_consistent_bundle(tmp_path: Path
         "ios:testflight_internal",
     ]
     assert "mobile_dependency_review" in summary["artifact_sha256"]
+    assert "mobile_external_readiness_packet" in summary["artifact_sha256"]
     assert "mobile_device_smoke_template_summary" in summary["artifact_sha256"]
     assert json.loads((tmp_path / "bundle-summary.json").read_text()) == summary
 
@@ -298,6 +383,49 @@ def test_mobile_release_bundle_verifier_rejects_dependency_review_digest_mismatc
     assert summary["status"] == "fail"
     assert any(
         "mobile_dependency_review_sha256 mismatch" in error
+        for error in summary["errors"]
+    )
+
+
+def test_mobile_release_bundle_verifier_rejects_external_readiness_packet_digest_mismatch(
+    tmp_path: Path,
+) -> None:
+    paths = _valid_bundle(tmp_path)
+    handoff = json.loads(paths["handoff"].read_text(encoding="utf-8"))
+    handoff["release"]["mobile_external_readiness_packet_sha256"] = "0" * 64
+    _write_json(paths["handoff"], handoff)
+
+    result = _run_verifier(paths, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert any(
+        "mobile_external_readiness_packet_sha256 mismatch" in error
+        for error in summary["errors"]
+    )
+
+
+def test_mobile_release_bundle_verifier_rejects_external_readiness_packet_status_mismatch(
+    tmp_path: Path,
+) -> None:
+    paths = _valid_bundle(tmp_path)
+    packet = json.loads(paths["external_readiness_packet"].read_text(encoding="utf-8"))
+    packet["readiness_status"] = "stale"
+    _write_json(paths["external_readiness_packet"], packet)
+    handoff = json.loads(paths["handoff"].read_text(encoding="utf-8"))
+    handoff["release"]["mobile_external_readiness_packet_sha256"] = _sha256(
+        paths["external_readiness_packet"]
+    )
+    _write_json(paths["handoff"], handoff)
+
+    result = _run_verifier(paths, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert any(
+        "mobile_external_readiness_packet.readiness_status mismatch" in error
         for error in summary["errors"]
     )
 

--- a/tests/test_mobile_store_rollout_handoff.py
+++ b/tests/test_mobile_store_rollout_handoff.py
@@ -55,6 +55,10 @@ def test_mobile_store_rollout_handoff_template_validates(tmp_path: Path) -> None
     assert "mobile_release_manifest_archived" in summary["required_handoff_check_ids"]
     assert "mobile_dependency_review_archived" in summary["required_handoff_check_ids"]
     assert (
+        "mobile_external_readiness_packet_archived"
+        in summary["required_handoff_check_ids"]
+    )
+    assert (
         "mobile_device_smoke_template_validation_archived"
         in summary["required_handoff_check_ids"]
     )
@@ -159,5 +163,22 @@ def test_mobile_store_rollout_handoff_rejects_invalid_dependency_review_sha(
     assert summary["status"] == "fail"
     assert (
         "release.mobile_dependency_review_sha256 must be a lowercase "
+        "SHA-256 hex digest"
+    ) in summary["errors"]
+
+
+def test_mobile_store_rollout_handoff_rejects_invalid_external_readiness_packet_sha(
+    tmp_path: Path,
+) -> None:
+    payload = _valid_payload()
+    payload["release"]["mobile_external_readiness_packet_sha256"] = "A" * 64
+
+    result = _run_validator(tmp_path, payload, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert (
+        "release.mobile_external_readiness_packet_sha256 must be a lowercase "
         "SHA-256 hex digest"
     ) in summary["errors"]


### PR DESCRIPTION
## Summary
- add `mobile_external_readiness_packet_sha256` to the store rollout handoff contract
- require `--external-readiness-packet-json` in the release bundle verifier
- validate external readiness packet schema, traceability, readiness status fields, blocker summary counts, and handoff digest consistency
- update Mobile Build wiring, readiness self-checks, tests, and release docs

## Local validation
- `.venv/bin/ruff check`
- `.venv/bin/pytest -q` (`160 passed`)
- `.venv/bin/python scripts/check_mobile_release_readiness.py ...` (`137` local checks, `0` failed)
- local end-to-end release bundle verifier with `mobile_external_readiness_packet` SHA in `artifact_sha256`
- `npm run validate:ci` from `apps/field-mobile` (typecheck, 115 unit tests, Expo Doctor 21/21, `npm audit` 0 vulnerabilities, iOS/Android export)
- `git diff --check`