### PR TITLE
Add device smoke evidence handoff contract

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -168,7 +168,7 @@ CI:
   - `mobile-release-notes` (operator-facing release notes and required evidence reminders)
   - `mobile-dependency-review` (direct mobile dependency lockfile review, production `npm audit` summary, native sensitive dependency surface, and SEC-003 remediation hints)
   - `mobile-release-bundle-verification` (manifest/readiness/notes/external-readiness/store-handoff digest and traceability consistency summary)
-  - `mobile-store-rollout-handoff` (per-run TestFlight/Play Internal handoff template + validation summary with current external blockers)
+  - `mobile-store-rollout-handoff` (per-run TestFlight/Play Internal handoff template + validation summary with current external blockers and physical-device smoke evidence digest placeholders)
   - `mobile-eas-build-result-<run_id>` (raw EAS JSON response for build IDs/URLs)
   - `mobile-eas-submit-result-<run_id>` (raw EAS submit log + exit code when `submit_to_store=true`)
 - Workflow summary includes release readiness status and direct EAS build links for operator/release use.
@@ -190,7 +190,7 @@ secret blockers. The artifact has separate machine-readable gates:
   in-app release identity evidence,
   runtime capture preflight guard, runtime motion quality gates, raw audio temp-file cleanup,
   derivatives-only feature/media manifest gates, pending sync connectivity-restore trigger,
-  device-smoke evidence template/validator,
+  device-smoke evidence template/validator and store-handoff digest placeholders,
   store rollout handoff template/validator, dependency review artifact builder, release bundle verifier,
   API response + submit exception + runtime exception PHI redaction, and non-localhost API URL defaults,
   store privacy declarations,

--- a/docs/mobile-productization-gap-and-backlog-v0.1.md
+++ b/docs/mobile-productization-gap-and-backlog-v0.1.md
@@ -50,6 +50,9 @@ Implemented now:
 - Mobile Build publishes a smoke-template validation artifact with the current template and
   validator summary before real-device smoke evidence is filled in, and store rollout
   handoff/bundle verification trace its SHA-256 digest.
+- Store rollout handoff separates real physical-device smoke evidence as its own
+  `device_smoke_evidence` object with blocked status until the filled smoke log SHA, validator
+  summary SHA, summary URL, and iOS+Android platform evidence are archived.
 - Physical-device smoke evidence requires per-device runtime timeline integrity metadata
   with `gap_warning=false`.
 - Store rollout handoff JSON template, validator, and Mobile Build artifact for TestFlight/Play Internal traceability.
@@ -113,7 +116,7 @@ Not yet implemented:
   training evidence still need real operator execution.
 - Paired submission contract guard is unit-tested and release-gated locally; formal
   data-management QC remains part of pilot operations.
-- Deterministic replay tests cover capture contract generation and queued paired+capture sync; physical-device evidence now has a validator/template but still needs real-device execution.
+- Deterministic replay tests cover capture contract generation and queued paired+capture sync; physical-device evidence now has a validator/template and store-handoff digest slots but still needs real-device execution.
 - Device-matrix smoke evidence requires at least one iPhone and one Android run in
   `mobile_device_smoke_log_v0.1`, including runtime timeline evidence from
   `capture_payload.analysis.runtime_timeline` and operator SOP checklist gate evidence.
@@ -165,7 +168,7 @@ DoD:
 
 ## B4: Quality and validation readiness
 1. Add unit tests for capture payload generation and local validation. Status: implemented for paired payload, capture package payload, capture contract generation, ROI signal, runtime metrics, and backend capture contract validation.
-2. Add E2E mobile smoke tests (session create -> submit -> queue -> sync). Status: implemented as deterministic repository-level paired+capture queue replay after network restore, plus a validated iOS+Android physical-device smoke log schema/template; real physical-device/live Clinical Hub smoke evidence still required.
+2. Add E2E mobile smoke tests (session create -> submit -> queue -> sync). Status: implemented as deterministic repository-level paired+capture queue replay after network restore, plus a validated iOS+Android physical-device smoke log schema/template and handoff digest contract; real physical-device/live Clinical Hub smoke evidence still required.
 3. Export nightly comparison summary and gate snapshot to Clinical Hub. Status: implemented
    as an offline snapshot builder with SHA-256 manifest, a first-class
    `method_comparison_summary` Clinical Hub report type, and optional CI upload when live

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -131,10 +131,12 @@ Workflow also generates artifact `mobile-device-smoke-template-validation` conta
 - validator summary JSON proving the template currently satisfies
   `mobile_device_smoke_log_v0.1` before clinic operators replace placeholder values with
   real iPhone/Android smoke evidence,
+- `smoke_log_sha256` in the validator summary when a filled smoke log is validated,
 - validator exit code for diagnosis if the template contract breaks.
 
 Workflow also generates artifact `mobile-store-rollout-handoff` containing:
 - per-run git SHA, app version, build profile/channel, and SHA-256 digests for `mobile-release-manifest`, `mobile-release-readiness`, `mobile-release-notes`, `mobile-dependency-review`, `mobile-external-readiness-packet`, and `mobile-device-smoke-template-validation` summary,
+- `device_smoke_evidence`, which stays `blocked_external` until a filled physical-device smoke log and validator summary SHA are linked,
 - iOS TestFlight internal handoff checklist and current external blockers,
 - Android Play Internal Testing handoff checklist and current external blockers,
 - validation summary from `scripts/validate_mobile_store_rollout_handoff.py`.
@@ -180,7 +182,8 @@ Store rollout handoff validation:
 
 ```bash
 cp docs/mobile-store-rollout-handoff-template-v0.1.json /tmp/mobile-store-rollout-handoff.json
-# Fill in per-run manifest/readiness/notes SHA values and TestFlight/Play evidence.
+# Fill in per-run manifest/readiness/notes SHA values, TestFlight/Play evidence,
+# and device_smoke_evidence after real iPhone + Android smoke validation.
 python3 scripts/validate_mobile_store_rollout_handoff.py \
   /tmp/mobile-store-rollout-handoff.json \
   --output /tmp/mobile-store-rollout-summary.json
@@ -290,6 +293,13 @@ python3 scripts/validate_mobile_store_rollout_handoff.py \
 7. Build links (iOS + Android).
 8. Smoke test log with device model and OS version.
 9. Validated real-device smoke summary JSON from `scripts/validate_mobile_device_smoke_log.py`.
+   - Copy the filled smoke log SHA from `smoke_log_sha256` into
+     `mobile-store-rollout-handoff.json.device_smoke_evidence.mobile_device_smoke_log_sha256`.
+   - Archive the validator summary JSON and copy its file SHA into
+     `device_smoke_evidence.mobile_device_smoke_summary_sha256`.
+   - Set `device_smoke_evidence.summary_url` to the archived summary URL,
+     `validator_summary_status` to `pass`, and `platforms_seen` to include both `ios` and
+     `android`; otherwise keep `device_smoke_evidence.status` as `blocked_external`.
    - The smoke log must include per-device `runtime_timeline` evidence copied from
      `capture_payload.analysis.runtime_timeline`, with `gap_warning=false`.
    - The smoke log must include per-device `runtime_alignment` evidence copied from

--- a/docs/mobile-store-rollout-handoff-template-v0.1.json
+++ b/docs/mobile-store-rollout-handoff-template-v0.1.json
@@ -48,7 +48,7 @@
     {
       "id": "device_smoke_evidence_linked",
       "status": "blocked_external",
-      "evidence": "Fill with validated mobile_device_smoke_log_v0.1 summary link after iOS and Android device runs."
+      "evidence": "Fill device_smoke_evidence with validated mobile_device_smoke_log_v0.1 log and summary SHA-256 digests plus summary link after iOS and Android device runs."
     },
     {
       "id": "no_secrets_in_handoff",
@@ -56,6 +56,18 @@
       "evidence": "Handoff contains artifact links and IDs only; no API keys, tokens, or patient identifiers."
     }
   ],
+  "device_smoke_evidence": {
+    "status": "blocked_external",
+    "mobile_device_smoke_log_sha256": "",
+    "mobile_device_smoke_summary_sha256": "",
+    "summary_url": "",
+    "validated_at_utc": "",
+    "validator_summary_status": "blocked_external",
+    "platforms_seen": [],
+    "blockers": [
+      "Validated iOS and Android physical-device smoke evidence is not available until installable TestFlight/Play Internal or EAS preview builds are run on real devices."
+    ]
+  },
   "channels": [
     {
       "platform": "ios",

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -1970,6 +1970,8 @@ def build_readiness_report(
         in mobile_device_smoke_validator_source,
         "sha256_traceability": "mobile_release_manifest_sha256"
         in mobile_device_smoke_validator_source,
+        "smoke_log_sha256_output": "smoke_log_sha256"
+        in mobile_device_smoke_validator_source,
         "no_phi_log_review": "device_logs_reviewed_no_phi"
         in mobile_device_smoke_validator_source,
         "raw_media_temp_cleanup_required": "raw_media_temp_files_absent"
@@ -1987,6 +1989,8 @@ def build_readiness_report(
     )
     mobile_device_smoke_validator_test_requirements = {
         "valid_template_test": "test_mobile_device_smoke_log_template_validates"
+        in mobile_device_smoke_validator_tests_source,
+        "smoke_log_sha256_test": "smoke_log_sha256"
         in mobile_device_smoke_validator_tests_source,
         "ios_android_matrix_test": "requires_ios_and_android"
         in mobile_device_smoke_validator_tests_source,
@@ -2050,6 +2054,12 @@ def build_readiness_report(
         ),
         "smoke_template_traceability": "mobile_device_smoke_template_summary_sha256"
         in mobile_store_rollout_template_source,
+        "device_smoke_evidence_handoff": "device_smoke_evidence"
+        in mobile_store_rollout_template_source,
+        "device_smoke_evidence_log_sha": "mobile_device_smoke_log_sha256"
+        in mobile_store_rollout_template_source,
+        "device_smoke_evidence_summary_sha": "mobile_device_smoke_summary_sha256"
+        in mobile_store_rollout_template_source,
     }
     _check(
         checks,
@@ -2080,6 +2090,14 @@ def build_readiness_report(
             "mobile_device_smoke_template_validation_archived"
             in mobile_store_rollout_validator_source
         ),
+        "device_smoke_evidence_validator": "_validate_device_smoke_evidence"
+        in mobile_store_rollout_validator_source,
+        "device_smoke_evidence_required_platforms": (
+            "REQUIRED_SMOKE_EVIDENCE_PLATFORMS"
+            in mobile_store_rollout_validator_source
+        ),
+        "device_smoke_evidence_summary": "device_smoke_evidence_status"
+        in mobile_store_rollout_validator_source,
         "blocked_external_support": "BLOCKED_STATUS" in mobile_store_rollout_validator_source,
     }
     _check(
@@ -2101,6 +2119,18 @@ def build_readiness_report(
         in mobile_store_rollout_validator_tests_source,
         "external_readiness_packet_sha_test": (
             "rejects_invalid_external_readiness_packet_sha"
+            in mobile_store_rollout_validator_tests_source
+        ),
+        "device_smoke_evidence_pass_test": (
+            "accepts_linked_device_smoke_evidence"
+            in mobile_store_rollout_validator_tests_source
+        ),
+        "device_smoke_evidence_required_test": (
+            "requires_device_smoke_evidence_for_distribution"
+            in mobile_store_rollout_validator_tests_source
+        ),
+        "device_smoke_evidence_sha_test": (
+            "rejects_invalid_device_smoke_evidence_sha"
             in mobile_store_rollout_validator_tests_source
         ),
         "smoke_template_sha_test": "rejects_invalid_smoke_template_sha"

--- a/scripts/validate_mobile_device_smoke_log.py
+++ b/scripts/validate_mobile_device_smoke_log.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import re
@@ -40,6 +41,10 @@ def _as_list(value: Any) -> list[Any]:
 
 def _read_text(value: Any) -> str:
     return value.strip() if isinstance(value, str) else ""
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def _is_iso_timestamp(value: str) -> bool:
@@ -284,6 +289,7 @@ def main() -> int:
         raise SystemExit("smoke log root must be a JSON object")
 
     summary = validate_smoke_log(payload)
+    summary["smoke_log_sha256"] = _sha256_file(args.smoke_log)
     encoded = json.dumps(summary, ensure_ascii=False, indent=2)
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/validate_mobile_store_rollout_handoff.py
+++ b/scripts/validate_mobile_store_rollout_handoff.py
@@ -23,6 +23,7 @@ REQUIRED_HANDOFF_CHECK_IDS = (
     "device_smoke_evidence_linked",
     "no_secrets_in_handoff",
 )
+REQUIRED_SMOKE_EVIDENCE_PLATFORMS = ("android", "ios")
 REQUIRED_CHANNELS: dict[tuple[str, str], tuple[str, ...]] = {
     (
         "ios",
@@ -81,6 +82,10 @@ def _is_sha256(value: str) -> bool:
 
 def _is_https_url(value: str) -> bool:
     return HTTPS_RE.fullmatch(value) is not None
+
+
+def _string_list(values: Any) -> list[str]:
+    return [_read_text(value) for value in _as_list(values) if _read_text(value)]
 
 
 def _check_map(checks: list[Any]) -> dict[str, dict[str, Any]]:
@@ -142,6 +147,83 @@ def _validate_handoff_checks(
             errors.append(f"handoff_checks[{check_id}].status must be 'pass'")
         if not _read_text(check.get("evidence")):
             errors.append(f"handoff_checks[{check_id}].evidence is required")
+
+
+def _validate_device_smoke_evidence(
+    evidence: dict[str, Any],
+    handoff_checks: list[Any],
+    rollout_status: str,
+    errors: list[str],
+) -> str:
+    status = _read_text(evidence.get("status")).lower()
+    if status not in ALLOWED_CHECK_STATUSES:
+        errors.append(
+            "device_smoke_evidence.status must be one of "
+            f"{sorted(ALLOWED_CHECK_STATUSES)!r}"
+        )
+
+    checks = _check_map(handoff_checks)
+    linked_check_status = _read_text(
+        _as_dict(checks.get("device_smoke_evidence_linked")).get("status")
+    ).lower()
+    if status and linked_check_status and status != linked_check_status:
+        errors.append(
+            "device_smoke_evidence.status must match "
+            "handoff_checks[device_smoke_evidence_linked].status"
+        )
+
+    if rollout_status != BLOCKED_STATUS and status != "pass":
+        errors.append("device_smoke_evidence.status must be 'pass' for distributable rollout")
+
+    for field in (
+        "mobile_device_smoke_log_sha256",
+        "mobile_device_smoke_summary_sha256",
+    ):
+        digest = _read_text(evidence.get(field))
+        if status == "pass" and not digest:
+            errors.append(f"device_smoke_evidence.{field} is required")
+        if digest and not _is_sha256(digest):
+            errors.append(
+                f"device_smoke_evidence.{field} must be a lowercase SHA-256 hex digest"
+            )
+
+    summary_url = _read_text(evidence.get("summary_url"))
+    if status == "pass" and not summary_url:
+        errors.append("device_smoke_evidence.summary_url is required")
+    if summary_url and not _is_https_url(summary_url):
+        errors.append("device_smoke_evidence.summary_url must be an https URL")
+
+    validated_at_utc = _read_text(evidence.get("validated_at_utc"))
+    if status == "pass" and not validated_at_utc:
+        errors.append("device_smoke_evidence.validated_at_utc is required")
+    if validated_at_utc and not _is_iso_timestamp(validated_at_utc):
+        errors.append("device_smoke_evidence.validated_at_utc must be ISO-8601")
+
+    platforms_seen = sorted(
+        {
+            platform.lower()
+            for platform in _string_list(evidence.get("platforms_seen"))
+        }
+    )
+    if status == "pass":
+        for platform in REQUIRED_SMOKE_EVIDENCE_PLATFORMS:
+            if platform not in platforms_seen:
+                errors.append(f"device_smoke_evidence.platforms_seen must include {platform}")
+
+    validator_summary_status = _read_text(evidence.get("validator_summary_status")).lower()
+    if status == "pass" and validator_summary_status != "pass":
+        errors.append("device_smoke_evidence.validator_summary_status must be 'pass'")
+    if validator_summary_status and validator_summary_status not in ALLOWED_CHECK_STATUSES:
+        errors.append(
+            "device_smoke_evidence.validator_summary_status must be one of "
+            f"{sorted(ALLOWED_CHECK_STATUSES)!r}"
+        )
+
+    blockers = _string_list(evidence.get("blockers"))
+    if status == BLOCKED_STATUS and not blockers:
+        errors.append("device_smoke_evidence.blockers must explain external blockers")
+
+    return status or "missing"
 
 
 def _validate_ready_channel_fields(
@@ -244,8 +326,15 @@ def validate_rollout_handoff(payload: dict[str, Any]) -> dict[str, Any]:
     if rollout_status not in ALLOWED_CHANNEL_STATUSES:
         errors.append(f"rollout_status must be one of {sorted(ALLOWED_CHANNEL_STATUSES)!r}")
 
+    handoff_checks = _as_list(payload.get("handoff_checks"))
     _validate_release(_as_dict(payload.get("release")), errors)
-    _validate_handoff_checks(_as_list(payload.get("handoff_checks")), rollout_status, errors)
+    _validate_handoff_checks(handoff_checks, rollout_status, errors)
+    device_smoke_evidence_status = _validate_device_smoke_evidence(
+        _as_dict(payload.get("device_smoke_evidence")),
+        handoff_checks,
+        rollout_status,
+        errors,
+    )
 
     channels = [_as_dict(channel) for channel in _as_list(payload.get("channels"))]
     if not channels:
@@ -275,6 +364,7 @@ def validate_rollout_handoff(payload: dict[str, Any]) -> dict[str, Any]:
         "rollout_status": rollout_status,
         "channels_seen": sorted(f"{platform}:{channel}" for platform, channel in channels_seen),
         "blocked_channels": sorted(blocked_channels),
+        "device_smoke_evidence_status": device_smoke_evidence_status,
         "required_channels": sorted(
             f"{platform}:{channel}" for platform, channel in REQUIRED_CHANNELS
         ),

--- a/tests/test_mobile_device_smoke_log.py
+++ b/tests/test_mobile_device_smoke_log.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import subprocess
 import sys
@@ -12,6 +13,10 @@ TEMPLATE = Path("docs/mobile-device-smoke-log-template-v0.1.json")
 
 def _valid_payload() -> dict:
     return json.loads(TEMPLATE.read_text(encoding="utf-8"))
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def _run_validator(
@@ -42,6 +47,7 @@ def test_mobile_device_smoke_log_template_validates(tmp_path: Path) -> None:
     summary = json.loads(result.stdout)
 
     assert summary["status"] == "pass"
+    assert summary["smoke_log_sha256"] == _sha256(tmp_path / "smoke-log.json")
     assert summary["device_count"] == 2
     assert summary["platforms_seen"] == ["android", "ios"]
     assert "connectivity_restore_sync" in summary["required_check_ids"]

--- a/tests/test_mobile_store_rollout_handoff.py
+++ b/tests/test_mobile_store_rollout_handoff.py
@@ -15,6 +15,28 @@ def _valid_payload() -> dict:
     return json.loads(TEMPLATE.read_text(encoding="utf-8"))
 
 
+def _set_handoff_check_status(payload: dict, check_id: str, status: str) -> None:
+    for check in payload["handoff_checks"]:
+        if check["id"] == check_id:
+            check["status"] = status
+            return
+    raise AssertionError(f"missing handoff check {check_id!r}")
+
+
+def _mark_device_smoke_evidence_pass(payload: dict) -> None:
+    _set_handoff_check_status(payload, "device_smoke_evidence_linked", "pass")
+    payload["device_smoke_evidence"] = {
+        "status": "pass",
+        "mobile_device_smoke_log_sha256": SHA256_ZERO,
+        "mobile_device_smoke_summary_sha256": "1" * 64,
+        "summary_url": "https://github.com/example/run/artifacts/mobile-device-smoke-summary",
+        "validated_at_utc": "2026-06-05T21:30:00Z",
+        "validator_summary_status": "pass",
+        "platforms_seen": ["android", "ios"],
+        "blockers": [],
+    }
+
+
 def _run_validator(
     tmp_path: Path,
     payload: dict,
@@ -52,6 +74,7 @@ def test_mobile_store_rollout_handoff_template_validates(tmp_path: Path) -> None
         "android:play_internal_testing",
         "ios:testflight_internal",
     ]
+    assert summary["device_smoke_evidence_status"] == "blocked_external"
     assert "mobile_release_manifest_archived" in summary["required_handoff_check_ids"]
     assert "mobile_dependency_review_archived" in summary["required_handoff_check_ids"]
     assert (
@@ -114,6 +137,43 @@ def test_mobile_store_rollout_handoff_requires_pass_checks_for_distribution(
     assert "channels[0].checks[apple_developer_access].status must be 'pass'" in summary[
         "errors"
     ]
+
+
+def test_mobile_store_rollout_handoff_accepts_linked_device_smoke_evidence(
+    tmp_path: Path,
+) -> None:
+    payload = _valid_payload()
+    _mark_device_smoke_evidence_pass(payload)
+
+    result = _run_validator(tmp_path, payload)
+    summary = json.loads(result.stdout)
+
+    assert summary["status"] == "pass"
+    assert summary["device_smoke_evidence_status"] == "pass"
+
+
+def test_mobile_store_rollout_handoff_requires_device_smoke_evidence_for_distribution(
+    tmp_path: Path,
+) -> None:
+    payload = copy.deepcopy(_valid_payload())
+    payload["rollout_status"] = "submitted"
+    payload["handoff_checks"] = [
+        {**check, "status": "pass"} for check in payload["handoff_checks"]
+    ]
+
+    result = _run_validator(tmp_path, payload, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert (
+        "device_smoke_evidence.status must match "
+        "handoff_checks[device_smoke_evidence_linked].status"
+    ) in summary["errors"]
+    assert (
+        "device_smoke_evidence.status must be 'pass' for distributable rollout"
+        in summary["errors"]
+    )
 
 
 def test_mobile_store_rollout_handoff_rejects_invalid_release_sha(
@@ -182,3 +242,40 @@ def test_mobile_store_rollout_handoff_rejects_invalid_external_readiness_packet_
         "release.mobile_external_readiness_packet_sha256 must be a lowercase "
         "SHA-256 hex digest"
     ) in summary["errors"]
+
+
+def test_mobile_store_rollout_handoff_rejects_invalid_device_smoke_evidence_sha(
+    tmp_path: Path,
+) -> None:
+    payload = _valid_payload()
+    _mark_device_smoke_evidence_pass(payload)
+    payload["device_smoke_evidence"]["mobile_device_smoke_log_sha256"] = "A" * 64
+
+    result = _run_validator(tmp_path, payload, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert (
+        "device_smoke_evidence.mobile_device_smoke_log_sha256 must be a lowercase "
+        "SHA-256 hex digest"
+    ) in summary["errors"]
+
+
+def test_mobile_store_rollout_handoff_rejects_incomplete_device_smoke_evidence(
+    tmp_path: Path,
+) -> None:
+    payload = _valid_payload()
+    _mark_device_smoke_evidence_pass(payload)
+    payload["device_smoke_evidence"]["platforms_seen"] = ["ios"]
+    payload["device_smoke_evidence"]["summary_url"] = "http://example.invalid/summary"
+
+    result = _run_validator(tmp_path, payload, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert "device_smoke_evidence.summary_url must be an https URL" in summary["errors"]
+    assert "device_smoke_evidence.platforms_seen must include android" in summary[
+        "errors"
+    ]


### PR DESCRIPTION
## Summary
- add `device_smoke_evidence` to the store rollout handoff template as an explicit `blocked_external` physical-device evidence slot
- validate filled physical-device evidence with smoke log SHA, validator summary SHA, HTTPS summary URL, validated timestamp, validator summary status, and iOS+Android platforms
- emit `smoke_log_sha256` from `validate_mobile_device_smoke_log.py` so release owners can copy a stable digest into handoff evidence
- update readiness self-checks, tests, and docs for the real-device smoke evidence handoff flow

## Local validation
- `.venv/bin/ruff check`
- `.venv/bin/pytest -q` (`164 passed`)
- `.venv/bin/python scripts/check_mobile_release_readiness.py ...` (`137` local checks, `0` failed)
- `python3 scripts/validate_mobile_device_smoke_log.py docs/mobile-device-smoke-log-template-v0.1.json ...` (`status=pass`, includes `smoke_log_sha256`)
- `python3 scripts/validate_mobile_store_rollout_handoff.py docs/mobile-store-rollout-handoff-template-v0.1.json ...` (`device_smoke_evidence_status=blocked_external`)
- `npm run validate:ci` from `apps/field-mobile` (typecheck, 115 unit tests, Expo Doctor 21/21, `npm audit` 0 vulnerabilities, iOS/Android export)
- `git diff --check`