### PR TITLE
Trace device smoke status in release bundle

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -167,7 +167,7 @@ CI:
   - `mobile-external-readiness-packet` (sanitized credential/account handoff checklist with placeholder commands, no secret values, and bundle SHA-256 traceability)
   - `mobile-release-notes` (operator-facing release notes and required evidence reminders)
   - `mobile-dependency-review` (direct mobile dependency lockfile review, production `npm audit` summary, native sensitive dependency surface, and SEC-003 remediation hints)
-  - `mobile-release-bundle-verification` (manifest/readiness/notes/external-readiness/store-handoff digest and traceability consistency summary)
+  - `mobile-release-bundle-verification` (manifest/readiness/notes/external-readiness/device-smoke/store-handoff digest and traceability consistency summary)
   - `mobile-store-rollout-handoff` (per-run TestFlight/Play Internal handoff template + validation summary with current external blockers and physical-device smoke evidence digest placeholders)
   - `mobile-eas-build-result-<run_id>` (raw EAS JSON response for build IDs/URLs)
   - `mobile-eas-submit-result-<run_id>` (raw EAS submit log + exit code when `submit_to_store=true`)

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -145,7 +145,8 @@ Workflow also generates artifact `mobile-release-bundle-verification` containing
 - git/run traceability shared by manifest, readiness, and store rollout handoff,
 - SHA-256 fingerprints for manifest, readiness, release notes, dependency review, external readiness packet, smoke-template validation summary, store rollout handoff, and store rollout summary,
 - consistency checks proving the manifest readiness summary matches raw readiness JSON,
-- digest checks proving the store rollout handoff references the exact manifest/readiness/notes/dependency-review/external-readiness-packet/smoke-template summary files from the same run.
+- digest checks proving the store rollout handoff references the exact manifest/readiness/notes/dependency-review/external-readiness-packet/smoke-template summary files from the same run,
+- `device_smoke_evidence_status` copied from the validated store rollout summary, proving the bundle records whether physical iPhone/Android smoke evidence is still externally blocked or linked.
 
 Manifest script:
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -2166,6 +2166,14 @@ def build_readiness_report(
         ),
         "smoke_template_summary_input": "smoke_template_summary_json"
         in mobile_release_bundle_verifier_source,
+        "device_smoke_evidence_summary_validation": (
+            "device_smoke_evidence_status"
+            in mobile_release_bundle_verifier_source
+        ),
+        "device_smoke_evidence_handoff_validation": (
+            "device_smoke_evidence.status is required"
+            in mobile_release_bundle_verifier_source
+        ),
         "expected_run_validation": "expect_run_id" in mobile_release_bundle_verifier_source,
     }
     _check(
@@ -2197,6 +2205,10 @@ def build_readiness_report(
         ),
         "external_readiness_packet_status_mismatch_test": (
             "rejects_external_readiness_packet_status_mismatch"
+            in mobile_release_bundle_verifier_tests_source
+        ),
+        "device_smoke_evidence_status_mismatch_test": (
+            "rejects_device_smoke_evidence_status_mismatch"
             in mobile_release_bundle_verifier_tests_source
         ),
         "failed_dependency_review_test": (

--- a/scripts/verify_mobile_release_bundle.py
+++ b/scripts/verify_mobile_release_bundle.py
@@ -490,6 +490,18 @@ def _validate_store_rollout_handoff(
     ]:
         errors.append("store_rollout_handoff.summary.required_channels mismatch")
 
+    device_smoke_evidence = _as_dict(handoff.get("device_smoke_evidence"))
+    device_smoke_evidence_status = device_smoke_evidence.get("status")
+    if not isinstance(device_smoke_evidence_status, str) or not device_smoke_evidence_status:
+        errors.append("store_rollout_handoff.device_smoke_evidence.status is required")
+    _compare_field(
+        errors,
+        "store_rollout_handoff.summary",
+        "device_smoke_evidence_status",
+        handoff_summary.get("device_smoke_evidence_status"),
+        device_smoke_evidence_status,
+    )
+
 
 def verify_release_bundle(
     *,
@@ -550,6 +562,9 @@ def verify_release_bundle(
         "external_readiness_status": readiness.get("external_readiness_status"),
         "store_rollout_status": handoff_summary.get("rollout_status"),
         "store_rollout_blocked_channels": handoff_summary.get("blocked_channels", []),
+        "device_smoke_evidence_status": handoff_summary.get(
+            "device_smoke_evidence_status"
+        ),
         "artifact_sha256": {
             "mobile_release_manifest": _sha256_file(manifest_json),
             "mobile_release_readiness": _sha256_file(readiness_json),

--- a/tests/test_mobile_release_bundle_verifier.py
+++ b/tests/test_mobile_release_bundle_verifier.py
@@ -229,7 +229,19 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
             "mobile_device_smoke_template_summary_sha256": _sha256(
                 smoke_template_summary_path
             ),
-        }
+        },
+        "device_smoke_evidence": {
+            "status": "blocked_external",
+            "mobile_device_smoke_log_sha256": "",
+            "mobile_device_smoke_summary_sha256": "",
+            "summary_url": "",
+            "validated_at_utc": "",
+            "validator_summary_status": "blocked_external",
+            "platforms_seen": [],
+            "blockers": [
+                "Validated iOS and Android physical-device smoke evidence is not available."
+            ],
+        },
     }
     handoff_path = tmp_path / "mobile-store-rollout-handoff.json"
     _write_json(handoff_path, handoff)
@@ -241,6 +253,7 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
             "android:play_internal_testing",
             "ios:testflight_internal",
         ],
+        "device_smoke_evidence_status": "blocked_external",
         "required_channels": [
             "android:play_internal_testing",
             "ios:testflight_internal",
@@ -311,6 +324,7 @@ def test_mobile_release_bundle_verifier_accepts_consistent_bundle(tmp_path: Path
         "android:play_internal_testing",
         "ios:testflight_internal",
     ]
+    assert summary["device_smoke_evidence_status"] == "blocked_external"
     assert "mobile_dependency_review" in summary["artifact_sha256"]
     assert "mobile_external_readiness_packet" in summary["artifact_sha256"]
     assert "mobile_device_smoke_template_summary" in summary["artifact_sha256"]
@@ -426,6 +440,25 @@ def test_mobile_release_bundle_verifier_rejects_external_readiness_packet_status
     assert summary["status"] == "fail"
     assert any(
         "mobile_external_readiness_packet.readiness_status mismatch" in error
+        for error in summary["errors"]
+    )
+
+
+def test_mobile_release_bundle_verifier_rejects_device_smoke_evidence_status_mismatch(
+    tmp_path: Path,
+) -> None:
+    paths = _valid_bundle(tmp_path)
+    handoff_summary = json.loads(paths["handoff_summary"].read_text(encoding="utf-8"))
+    handoff_summary["device_smoke_evidence_status"] = "pass"
+    _write_json(paths["handoff_summary"], handoff_summary)
+
+    result = _run_verifier(paths, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert any(
+        "store_rollout_handoff.summary.device_smoke_evidence_status mismatch" in error
         for error in summary["errors"]
     )
 


### PR DESCRIPTION
## Summary
- require `device_smoke_evidence.status` in the store rollout handoff bundle verifier
- compare that status against the validated handoff summary and expose it in `mobile-release-bundle-verification`
- extend readiness self-checks, verifier tests, and runbook/README wording for device-smoke traceability

## Local validation
- `npm run validate:ci` from `apps/field-mobile`
- `.venv/bin/ruff check && .venv/bin/pytest -q` (`165 passed`)
- `scripts/check_mobile_release_readiness.py` => `ready_except_external_credentials`, `137` local checks, failed `[]`
- `scripts/validate_mobile_store_rollout_handoff.py` => `pass`, `device_smoke_evidence_status=blocked_external`
- `scripts/validate_mobile_device_smoke_log.py` => `pass`, iOS + Android template platforms
