### PR TITLE
Trace device smoke evidence receipt in release bundle

### DIFF
--- a/apps/field-mobile/README.md
+++ b/apps/field-mobile/README.md
@@ -167,8 +167,8 @@ CI:
   - `mobile-external-readiness-packet` (sanitized credential/account handoff checklist with placeholder commands, no secret values, and bundle SHA-256 traceability)
   - `mobile-release-notes` (operator-facing release notes and required evidence reminders)
   - `mobile-dependency-review` (direct mobile dependency lockfile review, production `npm audit` summary, native sensitive dependency surface, and SEC-003 remediation hints)
-  - `mobile-release-bundle-verification` (manifest/readiness/notes/external-readiness/device-smoke/store-handoff digest and traceability consistency summary)
-  - `mobile-store-rollout-handoff` (per-run TestFlight/Play Internal handoff template + validation summary with current external blockers and physical-device smoke evidence digest placeholders)
+  - `mobile-release-bundle-verification` (manifest/readiness/notes/external-readiness/device-smoke/store-handoff digest, evidence receipt, and traceability consistency summary)
+  - `mobile-store-rollout-handoff` (per-run TestFlight/Play Internal handoff template + validation summary with current external blockers and physical-device smoke evidence status/platform/digest receipt)
   - `mobile-eas-build-result-<run_id>` (raw EAS JSON response for build IDs/URLs)
   - `mobile-eas-submit-result-<run_id>` (raw EAS submit log + exit code when `submit_to_store=true`)
 - Workflow summary includes release readiness status and direct EAS build links for operator/release use.

--- a/docs/mobile-release-runbook-v0.1.md
+++ b/docs/mobile-release-runbook-v0.1.md
@@ -146,7 +146,7 @@ Workflow also generates artifact `mobile-release-bundle-verification` containing
 - SHA-256 fingerprints for manifest, readiness, release notes, dependency review, external readiness packet, smoke-template validation summary, store rollout handoff, and store rollout summary,
 - consistency checks proving the manifest readiness summary matches raw readiness JSON,
 - digest checks proving the store rollout handoff references the exact manifest/readiness/notes/dependency-review/external-readiness-packet/smoke-template summary files from the same run,
-- `device_smoke_evidence_status` copied from the validated store rollout summary, proving the bundle records whether physical iPhone/Android smoke evidence is still externally blocked or linked.
+- device-smoke evidence receipt fields copied from the validated store rollout summary: status, validator-summary status, platforms seen, and smoke log/summary SHA-256 digests. These prove the bundle records whether physical iPhone/Android smoke evidence is still externally blocked or linked and catches stale summary files.
 
 Manifest script:
 

--- a/scripts/check_mobile_release_readiness.py
+++ b/scripts/check_mobile_release_readiness.py
@@ -2098,6 +2098,14 @@ def build_readiness_report(
         ),
         "device_smoke_evidence_summary": "device_smoke_evidence_status"
         in mobile_store_rollout_validator_source,
+        "device_smoke_evidence_summary_receipt": (
+            "device_smoke_evidence_validator_summary_status"
+            in mobile_store_rollout_validator_source
+            and "device_smoke_evidence_platforms_seen"
+            in mobile_store_rollout_validator_source
+            and "device_smoke_evidence_summary_sha256"
+            in mobile_store_rollout_validator_source
+        ),
         "blocked_external_support": "BLOCKED_STATUS" in mobile_store_rollout_validator_source,
     }
     _check(
@@ -2131,6 +2139,12 @@ def build_readiness_report(
         ),
         "device_smoke_evidence_sha_test": (
             "rejects_invalid_device_smoke_evidence_sha"
+            in mobile_store_rollout_validator_tests_source
+        ),
+        "device_smoke_evidence_summary_receipt_test": (
+            "device_smoke_evidence_platforms_seen"
+            in mobile_store_rollout_validator_tests_source
+            and "device_smoke_evidence_summary_sha256"
             in mobile_store_rollout_validator_tests_source
         ),
         "smoke_template_sha_test": "rejects_invalid_smoke_template_sha"
@@ -2168,6 +2182,14 @@ def build_readiness_report(
         in mobile_release_bundle_verifier_source,
         "device_smoke_evidence_summary_validation": (
             "device_smoke_evidence_status"
+            in mobile_release_bundle_verifier_source
+        ),
+        "device_smoke_evidence_receipt_validation": (
+            "device_smoke_evidence_validator_summary_status"
+            in mobile_release_bundle_verifier_source
+            and "device_smoke_evidence_platforms_seen"
+            in mobile_release_bundle_verifier_source
+            and "device_smoke_evidence_summary_sha256"
             in mobile_release_bundle_verifier_source
         ),
         "device_smoke_evidence_handoff_validation": (
@@ -2209,6 +2231,10 @@ def build_readiness_report(
         ),
         "device_smoke_evidence_status_mismatch_test": (
             "rejects_device_smoke_evidence_status_mismatch"
+            in mobile_release_bundle_verifier_tests_source
+        ),
+        "device_smoke_evidence_receipt_mismatch_test": (
+            "rejects_device_smoke_evidence_receipt_mismatch"
             in mobile_release_bundle_verifier_tests_source
         ),
         "failed_dependency_review_test": (

--- a/scripts/validate_mobile_store_rollout_handoff.py
+++ b/scripts/validate_mobile_store_rollout_handoff.py
@@ -327,13 +327,20 @@ def validate_rollout_handoff(payload: dict[str, Any]) -> dict[str, Any]:
         errors.append(f"rollout_status must be one of {sorted(ALLOWED_CHANNEL_STATUSES)!r}")
 
     handoff_checks = _as_list(payload.get("handoff_checks"))
+    device_smoke_evidence = _as_dict(payload.get("device_smoke_evidence"))
     _validate_release(_as_dict(payload.get("release")), errors)
     _validate_handoff_checks(handoff_checks, rollout_status, errors)
     device_smoke_evidence_status = _validate_device_smoke_evidence(
-        _as_dict(payload.get("device_smoke_evidence")),
+        device_smoke_evidence,
         handoff_checks,
         rollout_status,
         errors,
+    )
+    device_smoke_evidence_platforms_seen = sorted(
+        {
+            platform.lower()
+            for platform in _string_list(device_smoke_evidence.get("platforms_seen"))
+        }
     )
 
     channels = [_as_dict(channel) for channel in _as_list(payload.get("channels"))]
@@ -365,6 +372,16 @@ def validate_rollout_handoff(payload: dict[str, Any]) -> dict[str, Any]:
         "channels_seen": sorted(f"{platform}:{channel}" for platform, channel in channels_seen),
         "blocked_channels": sorted(blocked_channels),
         "device_smoke_evidence_status": device_smoke_evidence_status,
+        "device_smoke_evidence_validator_summary_status": _read_text(
+            device_smoke_evidence.get("validator_summary_status")
+        ).lower(),
+        "device_smoke_evidence_platforms_seen": device_smoke_evidence_platforms_seen,
+        "device_smoke_evidence_log_sha256": _read_text(
+            device_smoke_evidence.get("mobile_device_smoke_log_sha256")
+        ).lower(),
+        "device_smoke_evidence_summary_sha256": _read_text(
+            device_smoke_evidence.get("mobile_device_smoke_summary_sha256")
+        ).lower(),
         "required_channels": sorted(
             f"{platform}:{channel}" for platform, channel in REQUIRED_CHANNELS
         ),

--- a/scripts/verify_mobile_release_bundle.py
+++ b/scripts/verify_mobile_release_bundle.py
@@ -40,6 +40,10 @@ def _string_list(value: Any) -> list[str]:
     return [item for item in _as_list(value) if isinstance(item, str)]
 
 
+def _read_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
 def _sha256_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
@@ -501,6 +505,40 @@ def _validate_store_rollout_handoff(
         handoff_summary.get("device_smoke_evidence_status"),
         device_smoke_evidence_status,
     )
+    _compare_field(
+        errors,
+        "store_rollout_handoff.summary",
+        "device_smoke_evidence_validator_summary_status",
+        handoff_summary.get("device_smoke_evidence_validator_summary_status"),
+        _read_text(device_smoke_evidence.get("validator_summary_status")).lower(),
+    )
+    _compare_field(
+        errors,
+        "store_rollout_handoff.summary",
+        "device_smoke_evidence_platforms_seen",
+        handoff_summary.get("device_smoke_evidence_platforms_seen"),
+        sorted(
+            {
+                platform.strip().lower()
+                for platform in _string_list(device_smoke_evidence.get("platforms_seen"))
+                if platform.strip()
+            }
+        ),
+    )
+    _compare_field(
+        errors,
+        "store_rollout_handoff.summary",
+        "device_smoke_evidence_log_sha256",
+        handoff_summary.get("device_smoke_evidence_log_sha256"),
+        _read_text(device_smoke_evidence.get("mobile_device_smoke_log_sha256")).lower(),
+    )
+    _compare_field(
+        errors,
+        "store_rollout_handoff.summary",
+        "device_smoke_evidence_summary_sha256",
+        handoff_summary.get("device_smoke_evidence_summary_sha256"),
+        _read_text(device_smoke_evidence.get("mobile_device_smoke_summary_sha256")).lower(),
+    )
 
 
 def verify_release_bundle(
@@ -564,6 +602,18 @@ def verify_release_bundle(
         "store_rollout_blocked_channels": handoff_summary.get("blocked_channels", []),
         "device_smoke_evidence_status": handoff_summary.get(
             "device_smoke_evidence_status"
+        ),
+        "device_smoke_evidence_validator_summary_status": handoff_summary.get(
+            "device_smoke_evidence_validator_summary_status"
+        ),
+        "device_smoke_evidence_platforms_seen": handoff_summary.get(
+            "device_smoke_evidence_platforms_seen", []
+        ),
+        "device_smoke_evidence_log_sha256": handoff_summary.get(
+            "device_smoke_evidence_log_sha256"
+        ),
+        "device_smoke_evidence_summary_sha256": handoff_summary.get(
+            "device_smoke_evidence_summary_sha256"
         ),
         "artifact_sha256": {
             "mobile_release_manifest": _sha256_file(manifest_json),

--- a/tests/test_mobile_release_bundle_verifier.py
+++ b/tests/test_mobile_release_bundle_verifier.py
@@ -254,6 +254,10 @@ def _valid_bundle(tmp_path: Path) -> dict[str, Path]:
             "ios:testflight_internal",
         ],
         "device_smoke_evidence_status": "blocked_external",
+        "device_smoke_evidence_validator_summary_status": "blocked_external",
+        "device_smoke_evidence_platforms_seen": [],
+        "device_smoke_evidence_log_sha256": "",
+        "device_smoke_evidence_summary_sha256": "",
         "required_channels": [
             "android:play_internal_testing",
             "ios:testflight_internal",
@@ -325,6 +329,13 @@ def test_mobile_release_bundle_verifier_accepts_consistent_bundle(tmp_path: Path
         "ios:testflight_internal",
     ]
     assert summary["device_smoke_evidence_status"] == "blocked_external"
+    assert (
+        summary["device_smoke_evidence_validator_summary_status"]
+        == "blocked_external"
+    )
+    assert summary["device_smoke_evidence_platforms_seen"] == []
+    assert summary["device_smoke_evidence_log_sha256"] == ""
+    assert summary["device_smoke_evidence_summary_sha256"] == ""
     assert "mobile_dependency_review" in summary["artifact_sha256"]
     assert "mobile_external_readiness_packet" in summary["artifact_sha256"]
     assert "mobile_device_smoke_template_summary" in summary["artifact_sha256"]
@@ -459,6 +470,34 @@ def test_mobile_release_bundle_verifier_rejects_device_smoke_evidence_status_mis
     assert summary["status"] == "fail"
     assert any(
         "store_rollout_handoff.summary.device_smoke_evidence_status mismatch" in error
+        for error in summary["errors"]
+    )
+
+
+def test_mobile_release_bundle_verifier_rejects_device_smoke_evidence_receipt_mismatch(
+    tmp_path: Path,
+) -> None:
+    paths = _valid_bundle(tmp_path)
+    handoff_summary = json.loads(paths["handoff_summary"].read_text(encoding="utf-8"))
+    handoff_summary["device_smoke_evidence_validator_summary_status"] = "pass"
+    handoff_summary["device_smoke_evidence_platforms_seen"] = ["android", "ios"]
+    handoff_summary["device_smoke_evidence_log_sha256"] = "0" * 64
+    handoff_summary["device_smoke_evidence_summary_sha256"] = "1" * 64
+    _write_json(paths["handoff_summary"], handoff_summary)
+
+    result = _run_verifier(paths, check=False)
+    summary = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert summary["status"] == "fail"
+    assert any(
+        "store_rollout_handoff.summary.device_smoke_evidence_platforms_seen mismatch"
+        in error
+        for error in summary["errors"]
+    )
+    assert any(
+        "store_rollout_handoff.summary.device_smoke_evidence_summary_sha256 mismatch"
+        in error
         for error in summary["errors"]
     )
 

--- a/tests/test_mobile_store_rollout_handoff.py
+++ b/tests/test_mobile_store_rollout_handoff.py
@@ -75,6 +75,13 @@ def test_mobile_store_rollout_handoff_template_validates(tmp_path: Path) -> None
         "ios:testflight_internal",
     ]
     assert summary["device_smoke_evidence_status"] == "blocked_external"
+    assert (
+        summary["device_smoke_evidence_validator_summary_status"]
+        == "blocked_external"
+    )
+    assert summary["device_smoke_evidence_platforms_seen"] == []
+    assert summary["device_smoke_evidence_log_sha256"] == ""
+    assert summary["device_smoke_evidence_summary_sha256"] == ""
     assert "mobile_release_manifest_archived" in summary["required_handoff_check_ids"]
     assert "mobile_dependency_review_archived" in summary["required_handoff_check_ids"]
     assert (
@@ -150,6 +157,10 @@ def test_mobile_store_rollout_handoff_accepts_linked_device_smoke_evidence(
 
     assert summary["status"] == "pass"
     assert summary["device_smoke_evidence_status"] == "pass"
+    assert summary["device_smoke_evidence_validator_summary_status"] == "pass"
+    assert summary["device_smoke_evidence_platforms_seen"] == ["android", "ios"]
+    assert summary["device_smoke_evidence_log_sha256"] == SHA256_ZERO
+    assert summary["device_smoke_evidence_summary_sha256"] == "1" * 64
 
 
 def test_mobile_store_rollout_handoff_requires_device_smoke_evidence_for_distribution(


### PR DESCRIPTION
## Summary
- add device-smoke evidence receipt fields to the store rollout handoff validation summary
- make the release bundle verifier compare receipt fields against the handoff evidence block
- expose receipt fields in `mobile-release-bundle-verification` and document the contract
- extend readiness self-checks and unit tests for stale/mismatched receipt detection

## Local validation
- `npm run validate:ci` from `apps/field-mobile`
- `.venv/bin/ruff check && .venv/bin/pytest -q` (`166 passed`)
- targeted `ruff` + `pytest` for store handoff, bundle verifier, readiness tests (`37 passed`)
- `scripts/check_mobile_release_readiness.py` => `ready_except_external_credentials`, `137` local checks, failed `[]`
- `scripts/validate_mobile_store_rollout_handoff.py` => `pass`, receipt fields emitted with `blocked_external`
- `scripts/validate_mobile_device_smoke_log.py` => `pass`, iOS + Android template platforms
